### PR TITLE
fix remote build Docker flags, missing directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,11 +97,21 @@ ARG VLLM_SOURCE=remote
 ARG VLLM_BRANCH=main
 ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
 
-# Handle vLLM source - keep it simple with bind mount approach
+# Handle vLLM source - support both local and remote modes
 COPY scripts/build-copy-vllm.sh ${INSTALL_ROOT}/build-copy-vllm.sh
+
+# Remote mode (default): clone from repository without mounting
+RUN if [ "${VLLM_SOURCE}" = "remote" ]; then \
+        bash ${INSTALL_ROOT}/build-copy-vllm.sh ${VLLM_SOURCE} ${INSTALL_ROOT}/vllm \
+        /dev/null ${VLLM_REPO} ${VLLM_BRANCH}; \
+    fi
+
+# Local mode: mount ./vllm directory and copy
 RUN --mount=type=bind,source=./vllm,target=/workspace/vllm \
-    bash ${INSTALL_ROOT}/build-copy-vllm.sh ${VLLM_SOURCE} ${INSTALL_ROOT}/vllm \
-    /workspace/vllm ${VLLM_REPO} ${VLLM_BRANCH}
+    if [ "${VLLM_SOURCE}" = "local" ]; then \
+        bash ${INSTALL_ROOT}/build-copy-vllm.sh ${VLLM_SOURCE} ${INSTALL_ROOT}/vllm \
+        /workspace/vllm ${VLLM_REPO} ${VLLM_BRANCH}; \
+    fi
 
 WORKDIR ${INSTALL_ROOT}/vllm
 

--- a/scripts/build-copy-vllm.sh
+++ b/scripts/build-copy-vllm.sh
@@ -20,7 +20,7 @@ if [ "$VLLM_SOURCE" = "local" ]; then
         echo ""
         echo "   For local development, vLLM must be cloned into the ScalarLM directory:"
         echo "   cd /path/to/scalarlm"
-        echo "   git clone -b rschiavi/vllm-adapter https://github.com/funston/vllm.git vllm"
+        echo "   git clone -b main https://github.com/supermassive-intelligence/vllm-fork.git vllm"
         echo ""
         echo "   This will create: scalarlm/vllm/"
         exit 1


### PR DESCRIPTION
-for remote builds, if the .vllm directory didn't exist, the build would fail. this avoids that.