### PR TITLE
Add spark target for NVIDIA DGX Spark (aarch64 Grace + Blackwell)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,14 @@ ENV TORCHINDUCTOR_COORDINATE_DESCENT_TUNING=0
 ENV TORCH_COMPILE_DISABLE=1
 
 ###############################################################################
+# NVIDIA DGX SPARK BASE IMAGE
+# aarch64 Grace CPU + Blackwell GPU (SM 12.0). The NGC PyTorch image is
+# multi-arch, so pulling this tag on linux/arm64 yields the aarch64 variant.
+FROM nvidia AS spark
+
+ENV BASE_NAME=spark
+
+###############################################################################
 # CPU BASE IMAGE
 FROM ubuntu:24.04 AS cpu
 
@@ -275,14 +283,15 @@ RUN python3 ${INSTALL_ROOT}/infra/cray_infra/training/gpu_aware_mpi/setup.py bdi
 RUN apt-get update -y  \
     && apt-get install -y build-essential \
     less curl wget net-tools vim iputils-ping strace gdb python3-dbg python3-dev \
+    dmidecode \
     && rm -rf /var/lib/apt/lists/*
 
 # Setup python path
-ENV PYTHONPATH="${PYTHONPATH:-}:${INSTALL_ROOT}/infra"
-ENV PYTHONPATH="${PYTHONPATH:-}:${INSTALL_ROOT}/sdk"
-ENV PYTHONPATH="${PYTHONPATH:-}:${INSTALL_ROOT}/ml"
-ENV PYTHONPATH="${PYTHONPATH:-}:${INSTALL_ROOT}/test"
-ENV PYTHONPATH="${PYTHONPATH:-}:${INSTALL_ROOT}/vllm"
+ENV PYTHONPATH="${INSTALL_ROOT}/infra"
+ENV PYTHONPATH="${PYTHONPATH}:${INSTALL_ROOT}/sdk"
+ENV PYTHONPATH="${PYTHONPATH}:${INSTALL_ROOT}/ml"
+ENV PYTHONPATH="${PYTHONPATH}:${INSTALL_ROOT}/test"
+ENV PYTHONPATH="${PYTHONPATH}:${INSTALL_ROOT}/vllm"
 
 # Megatron dependencies (GPU only)
 # note this has to happen after vllm because it overrides some packages installed by vllm

--- a/cmd/bashly.yml
+++ b/cmd/bashly.yml
@@ -6,20 +6,33 @@ version: 0.5.0
 commands:
 
 - name: build-image
-  help: Build image from dockerfile
+  help: |-
+    Build image from dockerfile.
+    Targets:
+      cpu    - CPU-only image; auto-detects host arch (x86_64 or arm64).
+      nvidia - NVIDIA CUDA image for x86_64 hosts. Pass sm_arch to pick GPU.
+      arm    - (stub) reserved for cross-built arm64 CPU image.
+      amd    - AMD ROCm image for MI300-class GPUs (x86_64).
+      spark  - NVIDIA DGX Spark: aarch64 Grace CPU + Blackwell GPU (sm_arch=12.0).
   args:
     - name: target
-      allowed: ["cpu", "nvidia", "arm", "amd"]
+      allowed: ["cpu", "nvidia", "arm", "amd", "spark"]
       default: "cpu"
     - name: sm_arch
       help: GPU streaming multiprocessor architecture, e.g. 7.5, 8.0, 8.6, 12.0, auto
       default: "auto"
 
 - name: up
-  help: Start the container
+  help: |-
+    Start the container.
+    Targets:
+      cpu    - CPU-only (x86_64 or arm64 host).
+      nvidia - NVIDIA CUDA on x86_64.
+      amd    - AMD ROCm on x86_64.
+      spark  - NVIDIA DGX Spark (aarch64 Grace + Blackwell, sm_arch=12.0).
   args:
     - name: target
-      allowed: ["cpu", "nvidia", "amd"]
+      allowed: ["cpu", "nvidia", "amd", "spark"]
       default: "cpu"
     - name: sm_arch
       allowed: ["7.5", "8.6", "12.0", "auto"]

--- a/cmd/build_image_command.sh
+++ b/cmd/build_image_command.sh
@@ -18,6 +18,13 @@ elif [ "$target" == "amd" ]; then
     vllm_target_device=("rocm")
     docker_platform=("linux/amd64")
     sm_arch="gfx942"
+elif [ "$target" == "spark" ]; then
+    # NVIDIA DGX Spark: aarch64 Grace CPU + Blackwell GPU (SM 12.0).
+    vllm_target_device=("cuda")
+    docker_platform=("linux/arm64")
+    if [ "$sm_arch" == "auto" ]; then
+        sm_arch="12.0"
+    fi
 else
     vllm_target_device=("cuda")
     docker_platform=("linux/amd64")

--- a/cmd/up_command.sh
+++ b/cmd/up_command.sh
@@ -20,6 +20,14 @@ elif [ "$target" == "amd" ]; then
     docker_compose_service="cray-amd"
     docker_platform="linux/amd64"
     sm_arch="gfx942"
+elif [ "$target" == "spark" ]; then
+    # NVIDIA DGX Spark: aarch64 Grace CPU + Blackwell GPU (SM 12.0).
+    vllm_target_device=("cuda")
+    docker_compose_service="cray-spark"
+    docker_platform="linux/arm64"
+    if [ "$sm_arch" == "auto" ]; then
+        sm_arch="12.0"
+    fi
 else
     vllm_target_device=("cuda")
     docker_compose_service="cray-nvidia"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -51,6 +51,19 @@ services:
                         - driver: nvidia
                           capabilities: [gpu]
 
+    cray-spark:
+        <<: *cray
+        runtime: nvidia
+        restart: unless-stopped
+        cap_add:
+          - SYS_PTRACE
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          capabilities: [gpu]
+
     cray-amd:
         <<: *cray
         devices:

--- a/infra/cray_infra/slurm/discovery/discover_clusters.py
+++ b/infra/cray_infra/slurm/discovery/discover_clusters.py
@@ -86,12 +86,14 @@ def get_node_info():
 
 
 def get_machine_id():
-    machine_id = None
     try:
         return get_board_serial()
+    except FileNotFoundError:
+        # dmidecode not installed — common in minimal containers.
+        return None
     except Exception as e:
-        logger.error(f"Error reading machine ID: {e}")
-    return machine_id
+        logger.debug(f"Error reading machine ID: {e}")
+        return None
 
 
 def get_board_serial() -> str | None:


### PR DESCRIPTION
New build/up target 'spark' for DGX Spark hosts: linux/arm64 platform, CUDA vLLM target, sm_arch defaulting to 12.0 (Blackwell). Reuses the nvidia stage via FROM nvidia AS spark — NGC PyTorch 25.10 is multi-arch so the aarch64 variant is pulled automatically on arm64 hosts.

Also:
- install dmidecode so get_machine_id() works in container
- silence dmidecode FileNotFoundError and demote other machine-id errors to debug (was spamming every 30s)
- fix BuildKit UndefinedVar warning on first PYTHONPATH ENV line