### PR TITLE
Enhanced OpenAI api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ scripts/scalarlm
 *.swo
 *~
 
+# Claude Code per-session state (scheduled_tasks.lock, settings.local.json)
+.claude/
+
 # Python
 **/__pycache__/
 *.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -258,8 +258,11 @@ ARG VLLM_SOURCE=remote
 ARG VLLM_BRANCH=main
 ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
 
-# Handle vLLM source - support both local and remote modes
-COPY scripts/build-copy-vllm.sh ${INSTALL_ROOT}/build-copy-vllm.sh
+# Handle vLLM source - support both local and remote modes.
+# build-copy-vllm.sh and apply_patches.py are copied in a single COPY
+# step so the image stays under Docker's 127-layer overlay-fs stacking
+# cap. The script sources apply_patches.py from its own SCRIPT_DIR.
+COPY scripts/build-copy-vllm.sh scripts/vllm_patches/apply_patches.py ${INSTALL_ROOT}/
 
 # Handle vLLM source - single RUN command with conditional mount
 # For remote: clone from repository

--- a/bench/client/path_openai_completions_array.py
+++ b/bench/client/path_openai_completions_array.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Array-prompt /v1/completions — the OpenAI-path wire-batched bench.
+
+One HTTP call carries ``--prompt-count`` prompts in ``prompt=[...]``;
+vLLM continues-batches them internally. This is the apples-to-apples
+comparison point for the scalarlm-path's bulk ``POST /v1/generate`` call:
+equal N on this scenario and the OpenAI path should produce within 5 %
+wall-clock time per the parity target.
+
+Usage::
+
+    bench/client/path_openai_completions_array.py \\
+        --url http://localhost:8000 \\
+        --model Qwen/Qwen3-4B-Instruct-2507 \\
+        --prompt-count 1000
+
+One call per invocation — the script is called once per prompt-count
+level by the sweep driver.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+try:
+    import httpx
+except ImportError:
+    print("httpx not installed. `pip install 'httpx[http2]'` in your bench venv.", file=sys.stderr)
+    sys.exit(1)
+
+
+@dataclass
+class Result:
+    prompt_count: int
+    duration_seconds: float
+    status_code: int
+    prompts_per_second: float
+    total_tokens: Optional[int]
+    tokens_per_second: Optional[float]
+
+
+async def run(args) -> Result:
+    prompts = _build_prompts(args)
+    body = {
+        "model": args.model,
+        "prompt": prompts,
+        "max_tokens": args.max_tokens,
+        "temperature": 0.0,
+    }
+    url = args.url.rstrip("/") + "/v1/completions"
+    async with httpx.AsyncClient(
+        http2=not args.no_http2,
+        timeout=httpx.Timeout(args.timeout),
+    ) as client:
+        start = time.monotonic()
+        resp = await client.post(url, json=body)
+        elapsed = time.monotonic() - start
+
+    total_tokens: Optional[int] = None
+    if resp.status_code == 200:
+        try:
+            payload = resp.json()
+            total_tokens = payload.get("usage", {}).get("total_tokens")
+        except Exception:  # noqa: BLE001
+            pass
+
+    return Result(
+        prompt_count=args.prompt_count,
+        duration_seconds=elapsed,
+        status_code=resp.status_code,
+        prompts_per_second=args.prompt_count / elapsed if elapsed else 0.0,
+        total_tokens=total_tokens,
+        tokens_per_second=(total_tokens / elapsed) if total_tokens and elapsed else None,
+    )
+
+
+def _build_prompts(args) -> list[str]:
+    """Produce the prompt array. With ``--distinct-prompts`` each of the
+    N prompts is unique so vLLM's prefix cache can't collapse them to
+    one prefill — closer to a realistic multi-tenant workload. Without
+    the flag, N copies of the same prompt (prefix-cache-friendly, the
+    workload the parity sweep used up to this point).
+    """
+    if args.distinct_prompts:
+        # Pad the iteration counter so the prompts end up the same length
+        # and the benchmarker doesn't accidentally measure tokenization
+        # variance.
+        return [f"req {i:06d}: {args.prompt}" for i in range(args.prompt_count)]
+    return [args.prompt] * args.prompt_count
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--url", default="http://localhost:8000")
+    p.add_argument("--model", required=True)
+    p.add_argument("--prompt-count", type=int, required=True)
+    p.add_argument("--prompt", default="Hello. Say hi back in five words.")
+    p.add_argument("--distinct-prompts", action="store_true",
+                   help="Generate N unique prompts instead of N copies; "
+                        "defeats vLLM's prefix cache so the bench exercises "
+                        "actual prefill work per prompt.")
+    p.add_argument("--max-tokens", type=int, default=32)
+    p.add_argument("--no-http2", action="store_true")
+    p.add_argument("--timeout", type=float, default=600.0)
+    return p.parse_args(argv)
+
+
+def main() -> int:
+    args = parse_args()
+    result = asyncio.run(run(args))
+    json.dump(asdict(result), sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/client/path_scalarlm_generate_bulk.py
+++ b/bench/client/path_scalarlm_generate_bulk.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Wire-batched /v1/generate — the scalarlm-path throughput baseline.
+
+One call with ``prompts=[p1, ..., pN]`` to the scalarlm path. The /v1/generate
+surface is deprecated in favor of the OpenAI-compatible path; this bench
+exists to measure the baseline the OpenAI path needs to match.
+
+Usage::
+
+    bench/client/path_scalarlm_generate_bulk.py \\
+        --url http://localhost:8000 \\
+        --model Qwen/Qwen3-4B-Instruct-2507 \\
+        --prompt-count 1000
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+from dataclasses import dataclass, asdict
+from typing import Optional
+
+try:
+    import httpx
+except ImportError:
+    print("httpx not installed. `pip install 'httpx[http2]'` in your bench venv.", file=sys.stderr)
+    sys.exit(1)
+
+
+@dataclass
+class Result:
+    prompt_count: int
+    duration_seconds: float
+    status_code: int
+    prompts_per_second: float
+    results_returned: int
+
+
+async def run(args) -> Result:
+    if args.distinct_prompts:
+        prompts = [f"req {i:06d}: {args.prompt}" for i in range(args.prompt_count)]
+    else:
+        prompts = [args.prompt] * args.prompt_count
+    body = {
+        "model": args.model,
+        "prompts": prompts,
+        "max_tokens": args.max_tokens,
+    }
+    url = args.url.rstrip("/") + "/v1/generate"
+    async with httpx.AsyncClient(
+        http2=not args.no_http2,
+        timeout=httpx.Timeout(args.timeout),
+    ) as client:
+        start = time.monotonic()
+        resp = await client.post(url, json=body)
+        elapsed = time.monotonic() - start
+
+    results_returned = 0
+    if resp.status_code == 200:
+        try:
+            payload = resp.json()
+            results_returned = len(payload.get("results", []))
+        except Exception:  # noqa: BLE001
+            pass
+
+    return Result(
+        prompt_count=args.prompt_count,
+        duration_seconds=elapsed,
+        status_code=resp.status_code,
+        prompts_per_second=args.prompt_count / elapsed if elapsed else 0.0,
+        results_returned=results_returned,
+    )
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--url", default="http://localhost:8000")
+    p.add_argument("--model", required=True)
+    p.add_argument("--prompt-count", type=int, required=True)
+    p.add_argument("--prompt", default="Say hello in five words.")
+    p.add_argument("--distinct-prompts", action="store_true",
+                   help="Generate N unique prompts instead of N copies.")
+    p.add_argument("--max-tokens", type=int, default=32)
+    p.add_argument("--no-http2", action="store_true")
+    p.add_argument("--timeout", type=float, default=600.0)
+    return p.parse_args(argv)
+
+
+def main() -> int:
+    args = parse_args()
+    result = asyncio.run(run(args))
+    json.dump(asdict(result), sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enhance-openai-api.md
+++ b/enhance-openai-api.md
@@ -164,6 +164,31 @@ returns the entire batch in one `JSONResponse.content` load;
 re-reads the response file once per prompt. Not a property of the cache
 layer, a property of the scalarlm response-polling loop.
 
+## Phase 31b — conditional `--enable-lora`
+
+scalarlm has been passing `--enable-lora` to vLLM unconditionally. The flag
+makes vLLM wrap every layer in a LoRA-aware shim so adapters can be
+hot-loaded at runtime. For pods that never load adapters (the common
+inference case), that wrapping is pure overhead: an extra indirection on
+every forward pass, plus a larger attack surface for vLLM-fork bugs. In
+particular, on the current `scalarlm-on-v0.19.0` HEAD the LoRA wrapper
+for fused-MoE layers tries to call `TorchAllocator.set()` on an interface
+that now only exposes `get()`, and every MoE inference crashes at engine
+init. Dense models (e.g. Qwen3-32B) don't trigger it, MoE models
+(Qwen3-Next-80B-A3B) do.
+
+This commit makes `--enable-lora` conditional on `config["enable_lora"]`
+(default `True` for back-compat, opt out via `SCALARLM_ENABLE_LORA=false`).
+Benefit matrix:
+
+| deployment | `enable_lora` | effect |
+|---|---|---|
+| Training/eval pod (loads adapters) | `true` (default) | unchanged — adapters work |
+| Pure-inference pod (no adapters) | `false` | sidesteps the LoRA wrapper; fixes the MoE bug above; modest per-forward-pass perf win |
+
+Setting `enable_lora=false` **disables** `/v1/load_lora_adapter` at
+runtime. Pods that need dynamic adapter swap must leave the default on.
+
 ## Phase 31 — route bulk array `/v1/completions` through the queue worker
 
 At N ≥ 100 distinct prompts, the direct-proxy path lags `/v1/generate` by

--- a/enhance-openai-api.md
+++ b/enhance-openai-api.md
@@ -164,6 +164,71 @@ returns the entire batch in one `JSONResponse.content` load;
 re-reads the response file once per prompt. Not a property of the cache
 layer, a property of the scalarlm response-polling loop.
 
+## Phase 31 — route bulk array `/v1/completions` through the queue worker
+
+At N ≥ 100 distinct prompts, the direct-proxy path lags `/v1/generate` by
+~30 %. The gap wasn't vLLM — same kernels, same KV cache, same
+`max_num_seqs`. It was what the proxy did with the N requests:
+
+- **Direct proxy** forwarded the array through to vLLM's OpenAI server,
+  which created N `AsyncStream` futures. At N=1000 those futures all
+  live on the APIServer event loop simultaneously, eating CPU on
+  per-future output dispatch between engine iterations.
+- **`/v1/generate`** writes the batch to a queue, a dedicated worker
+  pulls `get_batch_size()` items at a time, submits them via
+  `asyncio.gather`, waits, pulls the next chunk. The engine sees the
+  same submissions either way, but the proxy event loop only ever
+  handles a bounded number of in-flight futures.
+
+The structural fix is to reuse the queue worker. This commit adds a fast
+path that, when array length ≥ `SCALARLM_QUEUE_ROUTE_THRESHOLD`, builds
+a `GenerateRequest` from the `CompletionRequest` and hands off to the
+same `generate()` handler `/v1/generate` uses. The `GenerateResponse`
+is translated back to the OpenAI `CompletionResponse` shape.
+
+### Design choices
+
+- **Opt-in via `SCALARLM_QUEUE_ROUTE_THRESHOLD` (int, default 0 / off).**
+  Recommended production value: **100**. Below that, the direct path is
+  the fast path for interactive latency; above that, the queue pacing
+  dominates.
+- **Streaming and non-string prompts are never routed.** The queue is
+  batch-oriented (no partial emission) and the current
+  `GenerateRequest` only handles strings and dict prompts.
+- **`request.prompt` is read directly (no `model_dump`).** At N=1000 the
+  full `model_dump(mode="json")` walk costs ~20-30 ms per call; the fast
+  path reads only the cache-relevant fields.
+- **Cache store is skipped on queue-routed responses.** The queue
+  worker's own disk cache at `{hash}_response.json` is authoritative;
+  duplicating in openai-cache is wasted I/O.
+
+### Known limitations (deliberate, to keep the change small)
+
+- **`usage.*_tokens` returns 0.** scalarlm's `Result` model doesn't carry
+  `token_count` today. The worker's `async_completion_task` already
+  parses `response_data["usage"]` — promoting those fields onto
+  `Result` is ~15 lines of follow-up and will land in a follow-up PR.
+  Not blocking for throughput benchmarks; blocking for usage-based
+  billing integrations.
+- **No streaming on queue-routed calls.** Callers that need streaming at
+  N ≥ threshold will get it — just through the direct path (above the
+  queue route, in the handler order) if they pass `stream=true`.
+- **No logprobs on queue-routed calls.**
+
+### Performance
+
+Blackwell 2-GPU PP=2, `max_num_seqs=256`, Qwen3-Next-80B-A3B-FP8,
+N=1000 distinct prompts, `max_tokens=16`, 3-run mean:
+
+| path | mean p/s | min | max |
+|---|---:|---:|---:|
+| openai /v1/completions (direct)  | ~62   | 60.1  | 63.5  |
+| openai /v1/completions (queue route) | **89.7** | 86.4  | 94.2  |
+| scalarlm /v1/generate            | 90.9  | 88.2  | 93.7  |
+
+Queue-routed openai hits **statistical parity** with `/v1/generate` on
+this workload (1.3 % mean gap, within run-to-run variance).
+
 ## Alternatives explored that didn't help
 
 Before the queue-route landed, five proxy-layer approaches were tried to

--- a/enhance-openai-api.md
+++ b/enhance-openai-api.md
@@ -1,0 +1,155 @@
+# OpenAI-compatible API: feature and performance parity with the ScalarLM path
+
+## Motivation
+
+ScalarLM exposes two inference surfaces today:
+
+- `POST /v1/generate` (the ScalarLM-native path) — queue-backed, batch-oriented,
+  with implicit content-hashed response caching.
+- `POST /v1/completions` and `POST /v1/chat/completions` (the OpenAI-compatible
+  path) — a direct proxy to vLLM's OpenAI server.
+
+Callers who need tool calling or OpenAI SDK compatibility end up on the openai
+path; `sql-gen` is the obvious one today. The long-term direction is **one
+inference surface**, namely the OpenAI-compatible one. This document lays out
+the changes that make the openai path a clean replacement for `/v1/generate`
+and records the design decisions along the way.
+
+Before this work, the openai path had three gaps vs. `/v1/generate`:
+
+| gap | consequence |
+|---|---|
+| no response cache | repeat calls re-ran inference; scalarlm returned the cached batch |
+| adapter-load check per request | ~10-20 ms of HTTP round-trip on every call, even with no LoRA loaded |
+| bulk array prompts are not paced | N=1000 array `/v1/completions` landed 1000 concurrent `AsyncStream` futures on the APIServer event loop, starving the engine of fresh work per iteration |
+
+After the work in this PR, the openai path has feature + performance parity
+with `/v1/generate` on the dimensions that matter for the workloads we run,
+and becomes the recommended surface for all new callers.
+
+## Scope of this PR
+
+Each commit adds one piece, plus an accompanying section in this document.
+Higher-level roadmap:
+
+1. **Phase 6.5** — move vLLM's output-handler metrics recording off the hot
+   path. Foundational; touches the vLLM fork via a build-time patcher.
+2. **Phase 7** — parallelise the OpenAI `/v1/batches` runner so it can
+   actually hit the ceiling at N=1000.
+3. **Phase 30** — batch response cache mirroring `/v1/generate`'s implicit
+   cache, keyed on the filtered params dict.
+4. **Phase 31b** — memoise adapter-load state so repeat calls skip the
+   `/v1/load_lora_adapter` round-trip, and short-circuit the base-model case.
+5. **Phase 31** — route bulk array `/v1/completions` through the existing
+   `/v1/generate` queue worker. Reuses the scalarlm worker's batched
+   `asyncio.gather` pacing so the proxy event loop isn't the bottleneck.
+6. **Docs (this commit + final)** — design rationale, performance summary,
+   deprecation plan, benchmark repro.
+
+Later commits expand each phase section below.
+
+## Design choices that are load-bearing for performance
+
+These are set once and not per-request — getting them wrong silently caps
+throughput by large factors.
+
+### `max_num_seqs` — let vLLM pick
+
+vLLM's default is 256. Overriding it down to 8 or 16 (a common "safety"
+choice that never got re-validated) caps concurrent sequences in the engine
+scheduler, which caps throughput at large N. On Blackwell 2-GPU with
+Qwen3-Next-80B-A3B-FP8 + `gpu_memory_utilization=0.85`, a sweep from 16 to
+1024 shows:
+
+| `max_num_seqs` | scalarlm p/s (N=1000 distinct, 16 tok) |
+|---:|---:|
+|   16 |  16.6 |
+|   32 |  22.4 |
+|   64 |  39.2 |
+|  128 |  68.2 |
+|  256 |  91.1 |
+|  512 | 130.5 |
+| 1024 | 154.0 |
+
+256 is a good default: ~9× the 16-case, diminishing returns past it. **Do
+not set `--max_num_seqs` in `SCALARLM_VLLM_ARGS` unless you have a specific
+reason**. Changing it requires a pod restart because the KV-cache block pool
+and CUDA graphs are allocated at engine boot.
+
+### Pipeline parallelism beats tensor parallelism on this MoE
+
+On 2×Blackwell with the 80B-A3B-FP8 MoE model, `--pipeline-parallel-size=2`
+outperforms `--tensor-parallel-size=2` by ~12 % on scalarlm at ms=256
+(101.8 vs 91.1 p/s). Each PP stage holds all experts for its layer range,
+so expert routing stays intra-GPU and there's no per-layer allreduce. TP
+splits each layer's experts across GPUs, which pays allreduce cost on every
+forward pass *and* leaves residual expert-routing imbalance across ranks.
+
+PP does have its own asymmetry — one stage typically ends up busier than the
+other because layer compute isn't perfectly uniform — but the aggregate
+throughput is higher. Split-point tuning to balance stages is an open lever
+not landed in this PR.
+
+### GPU-memory utilization: 0.85, not 0.5
+
+The KV-cache block pool is sized against `gpu_memory_utilization × free GPU
+memory`. Conservative values (0.5) leave most of the KV budget idle and
+directly limit concurrent sequences. 0.85 is the aggressive-but-safe
+default; drop it only if you're seeing OOMs. This interacts with
+`max_num_seqs` — the engine picks the smaller of the two limits.
+
+## Alternatives explored that didn't help
+
+Before the queue-route landed, five proxy-layer approaches were tried to
+close the openai-vs-scalarlm gap. All were null at N=1000 distinct and are
+not part of this PR. Keeping a concise record so the same experiments don't
+get re-run:
+
+- **Scatter-gather at the proxy.** Splitting an array `/v1/completions` into
+  N single-prompt `create_completion` calls via `asyncio.gather`. Does not
+  change what vLLM sees (vLLM scatters internally either way) and added no
+  throughput.
+- **Bounded scatter (Semaphore-limited fan-out).** Hypothesis: 1000 pending
+  requests were slowing the scheduler. Null — the vLLM scheduler is flat in
+  waiting-queue depth.
+- **Routing through `api_router.create_completion` (the decorated variant).**
+  Small win early on (part of the current direct path), but only because of
+  the `JSONResponse` wrapping, not the decorators themselves.
+- **Dedicated dispatcher coroutine.** A long-lived coroutine pulled items
+  off an `asyncio.Queue` and resolved `Future`s. Structurally mimics the
+  scalarlm worker without its file I/O; null result — the difference isn't
+  the worker architecture per se, it's the *pacing* (batched gather vs.
+  fanned-out futures).
+- **Yield injection at chunk boundaries.** `await asyncio.sleep(0)` every
+  K sub-requests. Null. Main-loop lag p99 was <15 ms already; openai's main
+  thread was *more* idle than scalarlm's.
+- **Side-loop thread for `create_completion`.** Null. AsyncStream isn't
+  cross-loop-safe cleanly, and the main loop wasn't CPU-saturated anyway.
+- **Expert parallelism (`--enable-expert-parallel`).** Actively harmful —
+  reshuffled placement so the *other* GPU became the hot one, and added
+  cross-GPU expert-dispatch cost. Throughput dropped 39 %.
+- **ZMQ message coalescing at the EngineCore boundary.** Planned
+  (Gemini's Phase 28) but not landed. Probably worth 3-6 % on top of
+  Phase 31, at the cost of a load-bearing vLLM-fork patch that rebasing
+  has to maintain. Deferred until there's a specific reason (p99 latency
+  at high concurrency) to pay that cost.
+
+The actual win ended up being **Phase 31** — push bulk requests into the
+existing scalarlm queue worker rather than fan-out at the proxy. The
+architectural difference was not scatter-vs-no-scatter, it was how many
+`AsyncStream` futures live on the APIServer event loop at once: 1000 at
+peak in the direct path, `max_num_seqs` at peak in the queue path.
+
+## Deprecation plan for `/v1/generate`
+
+See final commit in this PR. Short version: keep the handler, deprecate as
+a public surface, leave the internal queue worker in place because Phase 31
+relies on it.
+
+## Performance summary
+
+See final commit in this PR (populated once all phases are committed).
+
+## Benchmark repro
+
+See final commit in this PR.

--- a/enhance-openai-api.md
+++ b/enhance-openai-api.md
@@ -119,6 +119,51 @@ diff) so upstream rebases don't silently drop it:
 Measured effect: on the N=100 distinct pilot A/B, throughput recovered
 +15 %. The patch is now part of every built image.
 
+## Phase 30 — response cache for `/v1/completions` and `/v1/chat/completions`
+
+`/v1/generate` hashes the batch contents and persists the response to
+`{upload_base_path}/{hash}_response.json`; repeat calls with the same payload
+skip inference and return the stored batch. The openai path had no
+equivalent, which (a) made identical-prompt workloads pay full inference
+cost every time and (b) left OpenAI-compatible clients without a benefit
+scalarlm was already giving `/v1/generate` callers.
+
+### Design
+
+- **Keyed on the filtered params dict:** `(model, prompt|messages,
+  max_tokens, temperature, top_p, stop, n, tools, tool_choice)`. Any field
+  that changes inference output is in the key; transport-only fields
+  (`stream`, `stream_options`, `seed` when non-deterministic, etc.) are
+  excluded.
+- **SHA-256 over sorted-key JSON:** deterministic across Python sessions;
+  collisions are not a concern for this key size.
+- **Disk-backed at `{upload_base_path}/openai_cache/{sha256}.json`:** same
+  directory root as `/v1/generate`'s cache, simplifying GC and quota
+  management.
+- **Streaming always bypassed:** the cache is batch-granular and a
+  streamed response would have to be buffered in memory before storage.
+  Acceptable trade-off — streaming is for interactive UX, not batch
+  replay.
+- **Opt-in via `SCALARLM_OPENAI_CACHE=1`** so existing deployments don't
+  see behavior change unless they choose to. Recommended on for any
+  deployment that serves batch/eval/dataset-labeling workloads.
+
+### Performance effect
+
+On a repeat-batch workload (1000 prompts, second call with identical
+params), Blackwell 2-GPU:
+
+| path | cold p/s | warm (cache hit) p/s |
+|---|---:|---:|
+| openai /v1/completions | 63 (ms=256) | ~35 000 |
+| scalarlm /v1/generate  | 91 (ms=256) | ~690 |
+
+The warm-hit openai throughput dominates scalarlm's because openai
+returns the entire batch in one `JSONResponse.content` load;
+`/v1/generate`'s `poll_for_responses` iterates all N `request_id`s and
+re-reads the response file once per prompt. Not a property of the cache
+layer, a property of the scalarlm response-polling loop.
+
 ## Alternatives explored that didn't help
 
 Before the queue-route landed, five proxy-layer approaches were tried to

--- a/enhance-openai-api.md
+++ b/enhance-openai-api.md
@@ -98,6 +98,27 @@ directly limit concurrent sequences. 0.85 is the aggressive-but-safe
 default; drop it only if you're seeing OOMs. This interacts with
 `max_num_seqs` — the engine picks the smaller of the two limits.
 
+## Phase 6.5 — move vLLM's output-handler metrics off the hot path
+
+vLLM's `AsyncLLM.output_handler_loop` calls `loggers.record(...)` synchronously
+every iteration, computing Prometheus stats (scheduler, per-engine iteration,
+mm-cache) before yielding back to outputs. At N=100 distinct prompts the
+record call was **20.3 % of main-thread time** in a py-spy profile. vLLM
+already has a `TODO(rob)` on that exact line acknowledging the problem.
+
+The fix applies at vLLM-fork build time (via a patcher script, not a vendored
+diff) so upstream rebases don't silently drop it:
+
+- `scripts/vllm_patches/apply_patches.py` — asserts the exact anchor text it
+  expects and fails loudly on rebase drift rather than mis-patching silently.
+- Metrics move to a background consumer coroutine fed by a bounded
+  `asyncio.Queue`. The hot path only pushes; the consumer does the record.
+- Bounded queue means bursty metrics can't blow memory and backpressure
+  is applied by dropping the oldest entry (metrics are summaries anyway).
+
+Measured effect: on the N=100 distinct pilot A/B, throughput recovered
++15 %. The patch is now part of every built image.
+
 ## Alternatives explored that didn't help
 
 Before the queue-route landed, five proxy-layer approaches were tried to

--- a/enhance-openai-api.md
+++ b/enhance-openai-api.md
@@ -271,16 +271,185 @@ architectural difference was not scatter-vs-no-scatter, it was how many
 `AsyncStream` futures live on the APIServer event loop at once: 1000 at
 peak in the direct path, `max_num_seqs` at peak in the queue path.
 
-## Deprecation plan for `/v1/generate`
-
-See final commit in this PR. Short version: keep the handler, deprecate as
-a public surface, leave the internal queue worker in place because Phase 31
-relies on it.
-
 ## Performance summary
 
-See final commit in this PR (populated once all phases are committed).
+### Blackwell (2× RTX PRO 6000 Max-Q, TP=2 vs PP=2)
+
+Qwen3-Next-80B-A3B-FP8, `gpu_memory_utilization=0.85`, `max_num_seqs=256`,
+`--kv-cache-dtype=fp8`. N=1000 distinct prompts, `max_tokens=16`, cold
+cache. **All numbers below are 3-run means.** Single-run variance on
+this workload is ±8 % due to prefix-cache warmth and engine state;
+mixing single samples with multi-run means produces misleading "gaps."
+
+| config | path | mean p/s | 3-run range | GPU 0 util | GPU 1 util |
+|---|---|---:|---:|---:|---:|
+| TP=2 | scalarlm /v1/generate       | 91.1 | — | ~58 % | ~94 % |
+| TP=2 | openai direct               | 63.6 | — | ~58 % | ~94 % |
+| PP=2 | scalarlm /v1/generate       | 90.9 | 88.2 – 93.7 | ~97 % | ~59 % |
+| PP=2 | openai direct               | 62.3 | — | ~88 % | ~22 % |
+| **PP=2** | **openai via queue route** | **89.7** | 86.4 – 94.2 | ~93 % | ~57 % |
+
+Throughput was similar between TP=2 and PP=2 on the 3-run mean. An
+earlier single-run had scalarlm at 101.8 p/s under PP=2, but subsequent
+cold runs landed in the 88-94 range — within the ±8 % variance band.
+GPU utilization patterns differ materially though: TP=2 leaves GPU 0
+underused; PP=2 leaves GPU 1 underused. Split-point tuning would
+rebalance PP.
+
+Key takeaways:
+- `max_num_seqs=256` is a ~9× throughput win over the previous override of 16.
+- **Queue route closes the openai-vs-scalarlm gap to statistical parity.**
+  Without it, openai runs at ~62 p/s on PP=2; with it, openai runs at ~90
+  p/s — same as scalarlm (1.3 % mean gap, inside run-to-run variance).
+- With cache hits on repeat batches, openai crosses into the 35 000 p/s
+  regime that scalarlm's polling-heavy cache layer can't reach.
+
+### Spark (single NVIDIA GB10, TP=1)
+
+Qwen3-32B-NVFP4, vLLM defaults (`max_num_seqs=256`),
+`max_model_length=4096`, `gpu_memory_utilization=0.85`. N=1000 distinct
+prompts, `max_tokens=16`. **3-run means, measured against a clean PR
+image deployed as `kapu/scalarlm-spark:enhanced-openai-api`, with
+`SCALARLM_OPENAI_CACHE=1` and `SCALARLM_QUEUE_ROUTE_THRESHOLD=100`.**
+Cache-busted with a unique prefix on each run so scalarlm doesn't
+cache-hit.
+
+| path | mean p/s | 3-run |
+|---|---:|---:|
+| openai /v1/completions (queue-routed) | **41.2** | 40.6, 41.6, 41.3 |
+| scalarlm /v1/generate                 | **41.1** | 40.4, 41.9, 41.1 |
+
+**0.2 % gap — statistical parity.** Same story as Blackwell: the
+queue-routed openai path matches scalarlm because they share the same
+underlying code path.
+
+Both paths on the PR image measure **~2× the previous production
+Spark pod** (which had been running `max_num_seqs=12,
+gpu_memory_utilization=0.55` in its pinned `cray-config.yaml` and
+measured ~18-22 p/s). That doubling is the same lesson as Blackwell —
+**don't override vLLM's defaults**. The PR image honors the defaults
+and picks them up automatically.
+
+On single-GPU there's no TP/PP asymmetry to fight, so GPU utilization
+is consistently ~96 % on both paths and the queue-route closure is
+small in absolute terms (both paths are already near the compute
+ceiling). The win is that the openai path no longer pays the proxy
+fanout cost it would have paid otherwise.
+
+## Best ways to use the openai path
+
+- **Interactive / single request:** just call `/v1/completions` or
+  `/v1/chat/completions` with OpenAI SDK conventions. This takes the direct
+  path — fastest per-request latency (no queue, no extra hop).
+- **Bulk batch of prompts:** pass `prompt=[...]` with the full array and
+  enable `SCALARLM_QUEUE_ROUTE_THRESHOLD=100` in the pod env. Requests
+  with ≥ 100 prompts transparently go through the queue worker and land
+  at `/v1/generate` throughput.
+- **Repeated identical batches (eval / sweep loops):** enable
+  `SCALARLM_OPENAI_CACHE=1` in the pod env. First call pays full
+  inference; subsequent calls with the same params return from disk in
+  tens of ms.
+- **Tool calling:** use `/v1/chat/completions` — this is the only path
+  that supports tools. `/v1/generate` has never exposed them.
+- **Streaming:** use `/v1/completions` / `/v1/chat/completions` with
+  `stream=true`. The queue route is bypassed for streaming (it's
+  batch-oriented); responses land directly from vLLM's streaming proxy.
+- **Don't set `--max_num_seqs` in `SCALARLM_VLLM_ARGS`.** The vLLM default
+  of 256 is usually the right choice for this hardware class; lower
+  values cap throughput and higher values hit diminishing returns.
+
+## Deprecation plan for `/v1/generate`
+
+`/v1/generate` is **kept** internally — Phase 31 reuses its worker
+loop — but **deprecated as a public surface**. New external callers
+should use `/v1/completions` with the queue-route threshold set.
+
+**Phase 1 — this PR:**
+- Document `/v1/generate` as deprecated. Add a `Deprecation: true` HTTP
+  response header (follow-up PR, trivial) and a logged warning on
+  external use distinguished by request origin.
+- OpenAI path reaches feature + performance parity for bulk workloads.
+- SDKs that wrap `/v1/generate` (`masint`, etc.) keep working unchanged;
+  they call internally and `generate()` still works.
+
+**Phase 2 — after the `usage.token_count` plumb-through:**
+- Flip `SCALARLM_QUEUE_ROUTE_THRESHOLD` default to 100 in the base pod
+  templates so new deployments inherit the optimised behavior.
+- Update internal docs pointing callers at `/v1/completions`.
+
+**Phase 3 — after at least one release with Phase 2 in effect:**
+- Remove the `/v1/generate` external route registration from
+  `main.py`; keep `generate()` as an internal function called by the
+  queue-route path.
+- `masint` SDK is updated to call `/v1/completions` directly. The
+  `SupermassiveIntelligence` API stays the same shape externally; only
+  the wire call changes.
+
+Estimated cadence: Phase 2 follows within a release of Phase 1; Phase 3
+follows after one full release cycle of Phase 2 to catch long-running
+clients.
 
 ## Benchmark repro
 
-See final commit in this PR.
+All measurements in this doc use two clients:
+
+- `bench/client/path_openai_completions_array.py` — posts a single array
+  `/v1/completions` with N prompts, reports p/s + total tokens.
+- `bench/client/path_scalarlm_generate_bulk.py` — posts a single array
+  `/v1/generate` with N prompts, reports p/s.
+
+To repeat the headline benchmark (N=1000 distinct cold):
+
+```bash
+# Inside the pod, clear caches to force cold inference:
+rm -rf /app/cray/inference_requests/openai_cache
+rm -f /app/cray/inference_requests/*.json
+
+# openai path (direct or queue-routed depending on
+# SCALARLM_QUEUE_ROUTE_THRESHOLD env):
+python3 bench/client/path_openai_completions_array.py \
+  --url http://localhost:8000 \
+  --model "$SCALARLM_MODEL" \
+  --prompt-count 1000 --max-tokens 16 --distinct-prompts
+
+# scalarlm path:
+python3 bench/client/path_scalarlm_generate_bulk.py \
+  --url http://localhost:8000 \
+  --model "$SCALARLM_MODEL" \
+  --prompt-count 1000 --max-tokens 16 --distinct-prompts
+```
+
+Both clients default to 1000 identical prompts if `--distinct-prompts`
+is omitted; the identical case hits cache on the second call and is
+useful for validating cache behavior but not for measuring inference.
+
+To measure cache-hit throughput:
+```bash
+# Set SCALARLM_OPENAI_CACHE=1 in the pod env first.
+# First call populates cache; second call should return in <50 ms.
+python3 bench/client/path_openai_completions_array.py \
+  --url http://localhost:8000 \
+  --model "$SCALARLM_MODEL" \
+  --prompt-count 1000 --max-tokens 16 --distinct-prompts  # cold
+python3 bench/client/path_openai_completions_array.py \
+  --url http://localhost:8000 \
+  --model "$SCALARLM_MODEL" \
+  --prompt-count 1000 --max-tokens 16 --distinct-prompts  # warm
+```
+
+To sample GPU utilization alongside the bench:
+```bash
+nvidia-smi --query-gpu=timestamp,index,utilization.gpu,utilization.memory,memory.used,power.draw \
+  --format=csv,nounits -l 1 > /tmp/gpu.csv &
+SMI=$!
+# ... run the bench client ...
+kill $SMI
+```
+
+For the PP-vs-TP A/B on Blackwell: change `SCALARLM_VLLM_ARGS` between
+`--tensor-parallel-size=2 --max_num_seqs=256 --max-cudagraph-capture-size=8 --kv-cache-dtype=fp8`
+and
+`--pipeline-parallel-size=2 --max_num_seqs=256 --max-cudagraph-capture-size=8 --kv-cache-dtype=fp8`,
+with `SCALARLM_TENSOR_PARALLEL_SIZE=1` for the PP variant. Each config
+change requires a pod restart (KV-cache pool + CUDA graphs allocate at
+engine boot).

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -69,6 +69,17 @@ def _cache_lookup(params: dict, config: dict) -> Optional[dict]:
         return None
 
 
+def _cache_lookup_by_key(key: str, config: dict) -> Optional[dict]:
+    path = os.path.join(_cache_dir(config), key + ".json")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
 def _cache_store(params: dict, body: dict, config: dict) -> None:
     if not _OPENAI_CACHE_ENABLED or params.get("stream"):
         return
@@ -84,17 +95,6 @@ def _cache_store(params: dict, body: dict, config: dict) -> None:
         logger.exception("openai cache store failed at %s", path)
 
 
-def _cache_lookup_by_key(key: str, config: dict) -> Optional[dict]:
-    path = os.path.join(_cache_dir(config), key + ".json")
-    if not os.path.exists(path):
-        return None
-    try:
-        with open(path) as fh:
-            return json.load(fh)
-    except (OSError, json.JSONDecodeError):
-        return None
-
-
 def _should_route_via_queue_fast(request) -> bool:
     if _QUEUE_ROUTE_THRESHOLD <= 0:
         return False
@@ -104,3 +104,119 @@ def _should_route_via_queue_fast(request) -> bool:
     if not isinstance(prompt, list) or len(prompt) < _QUEUE_ROUTE_THRESHOLD:
         return False
     return all(isinstance(p, str) for p in prompt)
+
+
+# --- Router-level pure helpers (kept here for unit-testability) -----------
+
+# Tail-window for sniffing the upstream SSE payload for `usage`. The
+# terminal usage event is on the order of a few hundred bytes and always
+# sits at the very end; 64 KB is more than enough headroom while bounding
+# memory for very long completions.
+_USAGE_SCAN_TAIL_BYTES = 64 * 1024
+
+_COMPLETION_ALLOWED_KEYS = (
+    "model",
+    "temperature",
+    "prompt",
+    "max_tokens",
+    "stream",
+    "stream_options",
+    "tools",
+    "tool_choice",
+    "response_format",
+    "top_p",
+    "stop",
+    "seed",
+    "presence_penalty",
+    "frequency_penalty",
+)
+
+_CHAT_ALLOWED_KEYS = (
+    "model",
+    "temperature",
+    "messages",
+    "max_tokens",
+    "stream",
+    "stream_options",
+    "tools",
+    "tool_choice",
+    "response_format",
+    "top_p",
+    "stop",
+    "seed",
+    "presence_penalty",
+    "frequency_penalty",
+)
+
+
+def _filter_params(raw: dict, allowed: tuple) -> dict:
+    return {k: v for k, v in raw.items() if v is not None and k in allowed}
+
+
+def _ensure_usage_reported(params: dict) -> None:
+    """For streaming requests, force vLLM to emit a final ``usage`` event so we
+    can count tokens. OpenAI-compatible clients tolerate the extra field; the
+    ScalarLM chat UI specifically reads it and surfaces tokens-per-message.
+    Non-streaming responses always include usage in the final JSON body, so
+    no opt-in is needed there.
+    """
+    if not params.get("stream"):
+        return
+    opts = dict(params.get("stream_options") or {})
+    opts.setdefault("include_usage", True)
+    params["stream_options"] = opts
+
+
+def _read_total_tokens(json_text: str) -> Optional[int]:
+    try:
+        obj = json.loads(json_text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(obj, dict):
+        return None
+    usage = obj.get("usage")
+    if not isinstance(usage, dict):
+        return None
+    total = usage.get("total_tokens")
+    return int(total) if isinstance(total, (int, float)) else None
+
+
+def _extract_token_count(payload: bytes) -> Optional[int]:
+    """Best-effort scan for ``usage.total_tokens`` in either an SSE stream tail
+    or a single JSON response body. Returns None if not found."""
+    if not payload:
+        return None
+    try:
+        text = payload.decode("utf-8", errors="replace")
+    except Exception:
+        return None
+
+    # SSE path — look for the last event that contains a `usage` field.
+    # Per the SSE spec:
+    #   - events are separated by an empty line (\n\n, \r\n\r\n, or \r\r)
+    #   - a single event can contain multiple `data:` lines whose values
+    #     are concatenated with "\n" to form one decoded value
+    # Normalize line endings to LF up-front so split("\n\n") handles all
+    # separator forms; parse per-event (not per-line) so multi-line JSON
+    # still resolves to a single object.
+    if "data:" in text:
+        normalized = text.replace("\r\n", "\n").replace("\r", "\n")
+        last: Optional[int] = None
+        for event in normalized.split("\n\n"):
+            data_lines = [
+                line[5:].lstrip() for line in event.splitlines()
+                if line.startswith("data:")
+            ]
+            if not data_lines:
+                continue
+            body = "\n".join(data_lines)
+            if not body or body == "[DONE]":
+                continue
+            tokens = _read_total_tokens(body)
+            if tokens is not None:
+                last = tokens
+        if last is not None:
+            return last
+
+    # Non-streaming path — try parsing the whole tail as JSON.
+    return _read_total_tokens(text)

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -12,13 +12,28 @@ import hashlib
 import json
 import logging
 import os
+import tempfile
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+
+def _parse_env_bool(name: str, default: bool = False) -> bool:
+    """Robust boolean parse for scalarlm env flags. Accepts common forms
+    (``1`` / ``true`` / ``yes`` / ``on`` — case-insensitive). Anything
+    else, or unset, returns ``default``. Prevents the ``bool(int(...))``
+    pattern from crashing module import when a user sets
+    ``SCALARLM_OPENAI_CACHE=true``.
+    """
+    v = os.environ.get(name)
+    if v is None:
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+
 # --- Phase 30: response cache ---------------------------------------------
 
-_OPENAI_CACHE_ENABLED = bool(int(os.environ.get("SCALARLM_OPENAI_CACHE", "0") or 0))
+_OPENAI_CACHE_ENABLED = _parse_env_bool("SCALARLM_OPENAI_CACHE")
 _OPENAI_CACHE_KEYS = (
     "model", "prompt", "messages", "max_tokens", "temperature",
     "top_p", "stop", "n", "tools", "tool_choice",
@@ -27,6 +42,24 @@ _OPENAI_CACHE_KEYS = (
 # --- Phase 31: bulk queue-route fast-path ---------------------------------
 
 _QUEUE_ROUTE_THRESHOLD = int(os.environ.get("SCALARLM_QUEUE_ROUTE_THRESHOLD", "0") or 0)
+
+# Fields that the queue-route translation does NOT forward to the worker.
+# If any of these is set to a non-default value on a bulk request, keep
+# the request on the direct proxy path instead of silently dropping them.
+# Map of field name → default value that we treat as "unset".
+_QUEUE_ROUTE_UNSUPPORTED = {
+    "top_p": None,
+    "stop": None,
+    "seed": None,
+    "presence_penalty": 0.0,
+    "frequency_penalty": 0.0,
+    "response_format": None,
+    "logprobs": None,
+    "logit_bias": None,
+    "suffix": None,
+    "echo": False,
+    "best_of": None,
+}
 
 
 def _cache_dir(config: dict) -> str:
@@ -85,14 +118,30 @@ def _cache_store(params: dict, body: dict, config: dict) -> None:
         return
     if not isinstance(body, dict) or "choices" not in body:
         return
-    path = os.path.join(_cache_dir(config), _cache_key(params) + ".json")
-    tmp = path + ".tmp"
+    key = _cache_key(params)
+    cache_dir = _cache_dir(config)
+    path = os.path.join(cache_dir, key + ".json")
+    # Unique tmp path so two concurrent writers of the same key don't
+    # clobber each other's tmp file and leave a half-written .json on
+    # the rename. mkstemp creates the file atomically with a unique
+    # suffix; we os.fdopen its fd so we never open() a path twice.
     try:
-        with open(tmp, "w") as fh:
+        fd, tmp = tempfile.mkstemp(
+            prefix=key + ".", suffix=".json.tmp", dir=cache_dir,
+        )
+    except OSError:
+        logger.exception("openai cache store mkstemp failed under %s", cache_dir)
+        return
+    try:
+        with os.fdopen(fd, "w") as fh:
             json.dump(body, fh)
         os.replace(tmp, path)
     except OSError:
         logger.exception("openai cache store failed at %s", path)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def _should_route_via_queue_fast(request) -> bool:
@@ -103,7 +152,21 @@ def _should_route_via_queue_fast(request) -> bool:
     prompt = getattr(request, "prompt", None)
     if not isinstance(prompt, list) or len(prompt) < _QUEUE_ROUTE_THRESHOLD:
         return False
-    return all(isinstance(p, str) for p in prompt)
+    if not all(isinstance(p, str) for p in prompt):
+        return False
+    # The queue-route translation only forwards model / prompts /
+    # max_tokens / temperature / tools / tool_choice to the worker.
+    # If the caller set any other OpenAI completion param, keep the
+    # request on the direct proxy so the param actually takes effect.
+    for field, default in _QUEUE_ROUTE_UNSUPPORTED.items():
+        if getattr(request, field, default) != default:
+            return False
+    # n defaults to 1 for /v1/completions; reject n > 1 because the
+    # queue worker only returns one completion per prompt.
+    n = getattr(request, "n", 1)
+    if n is not None and n != 1:
+        return False
+    return True
 
 
 # --- Router-level pure helpers (kept here for unit-testability) -----------

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -1,4 +1,5 @@
-"""Pure-logic helpers for the Phase 30 response cache.
+"""Pure-logic helpers for the Phase 30 cache and Phase 31 queue-route
+fast-path.
 
 Kept free of vllm / fastapi / aiohttp imports so the logic stays unit-
 testable without the full inference stack. ``openai_v1_router``
@@ -23,6 +24,10 @@ _OPENAI_CACHE_KEYS = (
     "top_p", "stop", "n", "tools", "tool_choice",
 )
 
+# --- Phase 31: bulk queue-route fast-path ---------------------------------
+
+_QUEUE_ROUTE_THRESHOLD = int(os.environ.get("SCALARLM_QUEUE_ROUTE_THRESHOLD", "0") or 0)
+
 
 def _cache_dir(config: dict) -> str:
     base = config.get("upload_base_path") or "/app/cray/inference_requests"
@@ -34,6 +39,20 @@ def _cache_dir(config: dict) -> str:
 def _cache_key(params: dict) -> str:
     payload = {k: params.get(k) for k in _OPENAI_CACHE_KEYS if k in params}
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _cache_key_from_request(request) -> str:
+    """Build the cache key without walking the full pydantic object via
+    ``model_dump``. On the queue-route fast-path this saves ~20-30 ms at
+    N=1000 (pydantic re-encodes every element of the prompt list)."""
+    payload = {}
+    for k in _OPENAI_CACHE_KEYS:
+        v = getattr(request, k, None)
+        if v is None:
+            continue
+        payload[k] = v
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
     return hashlib.sha256(blob).hexdigest()
 
 
@@ -63,3 +82,25 @@ def _cache_store(params: dict, body: dict, config: dict) -> None:
         os.replace(tmp, path)
     except OSError:
         logger.exception("openai cache store failed at %s", path)
+
+
+def _cache_lookup_by_key(key: str, config: dict) -> Optional[dict]:
+    path = os.path.join(_cache_dir(config), key + ".json")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _should_route_via_queue_fast(request) -> bool:
+    if _QUEUE_ROUTE_THRESHOLD <= 0:
+        return False
+    if getattr(request, "stream", False):
+        return False
+    prompt = getattr(request, "prompt", None)
+    if not isinstance(prompt, list) or len(prompt) < _QUEUE_ROUTE_THRESHOLD:
+        return False
+    return all(isinstance(p, str) for p in prompt)

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -1,0 +1,65 @@
+"""Pure-logic helpers for the Phase 30 response cache.
+
+Kept free of vllm / fastapi / aiohttp imports so the logic stays unit-
+testable without the full inference stack. ``openai_v1_router``
+re-exports these names.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Phase 30: response cache ---------------------------------------------
+
+_OPENAI_CACHE_ENABLED = bool(int(os.environ.get("SCALARLM_OPENAI_CACHE", "0") or 0))
+_OPENAI_CACHE_KEYS = (
+    "model", "prompt", "messages", "max_tokens", "temperature",
+    "top_p", "stop", "n", "tools", "tool_choice",
+)
+
+
+def _cache_dir(config: dict) -> str:
+    base = config.get("upload_base_path") or "/app/cray/inference_requests"
+    path = os.path.join(base, "openai_cache")
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def _cache_key(params: dict) -> str:
+    payload = {k: params.get(k) for k in _OPENAI_CACHE_KEYS if k in params}
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
+
+
+def _cache_lookup(params: dict, config: dict) -> Optional[dict]:
+    if not _OPENAI_CACHE_ENABLED or params.get("stream"):
+        return None
+    path = os.path.join(_cache_dir(config), _cache_key(params) + ".json")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _cache_store(params: dict, body: dict, config: dict) -> None:
+    if not _OPENAI_CACHE_ENABLED or params.get("stream"):
+        return
+    if not isinstance(body, dict) or "choices" not in body:
+        return
+    path = os.path.join(_cache_dir(config), _cache_key(params) + ".json")
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as fh:
+            json.dump(body, fh)
+        os.replace(tmp, path)
+    except OSError:
+        logger.exception("openai cache store failed at %s", path)

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -17,6 +17,11 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 )
 
 from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
+from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _OPENAI_CACHE_ENABLED,
+    _cache_lookup,
+    _cache_store,
+)
 from cray_infra.generate.metrics import get_metrics
 from cray_infra.util.get_config import get_config
 
@@ -96,7 +101,17 @@ async def create_completions(request: CompletionRequest, raw_request: Request):
     config = get_config()
     params = _filter_params(request.model_dump(mode="json", exclude_none=True), _COMPLETION_ALLOWED_KEYS)
     _ensure_usage_reported(params)
+    cached = _cache_lookup(params, config)
+    if cached is not None:
+        return JSONResponse(content=cached)
     logger.info("Received completions request: %s", params)
+    if _OPENAI_CACHE_ENABLED and not params.get("stream"):
+        return await _proxy_nonstreaming_cached(
+            upstream_url=config["vllm_api_url"] + "/v1/completions",
+            params=params,
+            endpoint_label="completions",
+            config=config,
+        )
     return _proxy_streaming(
         upstream_url=config["vllm_api_url"] + "/v1/completions",
         params=params,
@@ -110,7 +125,17 @@ async def create_chat_completions(request: ChatCompletionRequest, raw_request: R
     config = get_config()
     params = _filter_params(request.model_dump(mode="json", exclude_none=True), _CHAT_ALLOWED_KEYS)
     _ensure_usage_reported(params)
+    cached = _cache_lookup(params, config)
+    if cached is not None:
+        return JSONResponse(content=cached)
     logger.info("Received chat completions request: %s", params)
+    if _OPENAI_CACHE_ENABLED and not params.get("stream"):
+        return await _proxy_nonstreaming_cached(
+            upstream_url=config["vllm_api_url"] + "/v1/chat/completions",
+            params=params,
+            endpoint_label="chat completions",
+            config=config,
+        )
     return _proxy_streaming(
         upstream_url=config["vllm_api_url"] + "/v1/chat/completions",
         params=params,
@@ -139,6 +164,56 @@ def _ensure_usage_reported(params: dict) -> None:
     opts = dict(params.get("stream_options") or {})
     opts.setdefault("include_usage", True)
     params["stream_options"] = opts
+
+
+async def _proxy_nonstreaming_cached(
+    *,
+    upstream_url: str,
+    params: dict,
+    endpoint_label: str,
+    config: dict,
+) -> JSONResponse:
+    """Collect the upstream body in full, store it in the openai-cache,
+    then return it to the caller. Used for non-streaming requests when
+    `SCALARLM_OPENAI_CACHE=1`; streaming requests still go through
+    `_proxy_streaming` since the cache is batch-granular.
+    """
+    session = get_global_session()
+    metrics = get_metrics()
+    metrics.record_new_request()
+    try:
+        async with session.post(upstream_url, json=params) as resp:
+            text = await resp.text()
+            if resp.status != 200:
+                logger.error(
+                    "vLLM %s error (%s): %s", endpoint_label, resp.status, text,
+                )
+                metrics.record_completed_request(token_count=0, flop_count=None)
+                return JSONResponse(
+                    content={"error": f"Failed to create {endpoint_label}: {text}"},
+                    status_code=resp.status,
+                )
+            try:
+                body = json.loads(text)
+            except json.JSONDecodeError:
+                metrics.record_completed_request(token_count=0, flop_count=None)
+                return JSONResponse(
+                    content={"error": f"vLLM returned non-JSON body for {endpoint_label}"},
+                    status_code=502,
+                )
+    except Exception:  # noqa: BLE001
+        metrics.record_completed_request(token_count=0, flop_count=None)
+        raise
+
+    token_count = 0
+    usage = body.get("usage") if isinstance(body, dict) else None
+    if isinstance(usage, dict):
+        total = usage.get("total_tokens")
+        if isinstance(total, (int, float)):
+            token_count = int(total)
+    metrics.record_completed_request(token_count=token_count, flop_count=None)
+    _cache_store(params, body, config)
+    return JSONResponse(content=body)
 
 
 def _proxy_streaming(

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -19,8 +19,11 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
 from cray_infra.api.fastapi.routers.openai_v1_helpers import (
     _OPENAI_CACHE_ENABLED,
+    _cache_key_from_request,
     _cache_lookup,
+    _cache_lookup_by_key,
     _cache_store,
+    _should_route_via_queue_fast,
 )
 from cray_infra.generate.metrics import get_metrics
 from cray_infra.util.get_config import get_config
@@ -99,6 +102,20 @@ async def list_models():
 async def create_completions(request: CompletionRequest, raw_request: Request):
     """Create completions - proxy to vLLM server."""
     config = get_config()
+
+    # Bulk-route fast path (Phase 31). Fires BEFORE model_dump so bulk
+    # requests don't pay the O(N) pydantic walk.
+    if _should_route_via_queue_fast(request):
+        if _OPENAI_CACHE_ENABLED:
+            hit = _cache_lookup_by_key(_cache_key_from_request(request), config)
+            if hit is not None:
+                return JSONResponse(content=hit)
+        logger.info(
+            "completions via queue: model=%s prompts=%d",
+            request.model, len(request.prompt),
+        )
+        return await _route_via_scalarlm_queue(request, config)
+
     params = _filter_params(request.model_dump(mode="json", exclude_none=True), _COMPLETION_ALLOWED_KEYS)
     _ensure_usage_reported(params)
     cached = _cache_lookup(params, config)
@@ -117,6 +134,73 @@ async def create_completions(request: CompletionRequest, raw_request: Request):
         params=params,
         endpoint_label="completions",
     )
+
+
+async def _route_via_scalarlm_queue(request, config: dict) -> JSONResponse:
+    """Dispatch a bulk array /v1/completions request through the existing
+    /v1/generate queue worker. The worker calls create_completion on a
+    controlled `get_batch_size()`-sized slice, `asyncio.gather`s the
+    sub-calls, and posts results back — keeping the engine saturated
+    without fanning N AsyncStream futures onto the APIServer event loop.
+
+    The worker's queue layer caches by content hash too, so repeat calls
+    short-circuit at that layer as well (in addition to openai's own
+    cache above). We deliberately do not double-store in the openai
+    cache here — the queue's `{hash}_response.json` already holds it.
+
+    Limitations (deliberate, documented in enhance-openai-api.md):
+    - no streaming (queue is batch-oriented)
+    - `usage.*_tokens` returns 0 (GenerateResponse.Result doesn't carry
+      token_count today — follow-up item to plumb through)
+    - no logprobs
+    """
+    # Imported lazily so modules that import this router at startup don't
+    # force-import the /v1/generate pipeline.
+    from cray_infra.api.fastapi.generate.generate import generate as _scalarlm_generate
+    from cray_infra.api.fastapi.routers.request_types.generate_request import (
+        GenerateRequest,
+    )
+
+    metrics = get_metrics()
+    metrics.record_new_request()
+
+    gen_req = GenerateRequest(
+        model=request.model,
+        prompts=list(request.prompt),
+        max_tokens=request.max_tokens or 16,
+        temperature=request.temperature or 0.0,
+        tools=getattr(request, "tools", None),
+        tool_choice=getattr(request, "tool_choice", None),
+    )
+    gen_resp = await _scalarlm_generate(gen_req)
+
+    import time as _t
+    choices = []
+    for i, r in enumerate(gen_resp.results):
+        choices.append({
+            "index": i,
+            "text": r.response or "",
+            "finish_reason": "stop" if r.error is None else "error",
+            "logprobs": None,
+        })
+    group_id = (
+        gen_resp.results[0].request_id.split("_")[0][:12]
+        if gen_resp.results else "queue"
+    )
+    body = {
+        "id": f"cmpl-queue-{group_id}",
+        "object": "text_completion",
+        "created": int(_t.time()),
+        "model": request.model,
+        "choices": choices,
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+        },
+    }
+    metrics.record_completed_request(token_count=0, flop_count=None)
+    return JSONResponse(content=body)
 
 
 @openai_v1_router.post("/chat/completions")

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -18,11 +18,22 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 
 from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
 from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _CHAT_ALLOWED_KEYS,
+    _COMPLETION_ALLOWED_KEYS,
     _OPENAI_CACHE_ENABLED,
+    _OPENAI_CACHE_KEYS,
+    _QUEUE_ROUTE_THRESHOLD,
+    _USAGE_SCAN_TAIL_BYTES,
+    _cache_dir,
+    _cache_key,
     _cache_key_from_request,
     _cache_lookup,
     _cache_lookup_by_key,
     _cache_store,
+    _ensure_usage_reported,
+    _extract_token_count,
+    _filter_params,
+    _read_total_tokens,
     _should_route_via_queue_fast,
 )
 from cray_infra.generate.metrics import get_metrics
@@ -36,104 +47,6 @@ import logging
 from typing import Optional
 
 logger = logging.getLogger(__name__)
-
-openai_v1_router = APIRouter()
-
-# Tail-window for sniffing the upstream payload for `usage`. The terminal
-# usage event in an OpenAI SSE stream is on the order of a few hundred bytes
-# and always sits at the very end; 64 KB is more than enough headroom while
-# bounding memory for very long completions.
-_USAGE_SCAN_TAIL_BYTES = 64 * 1024
-
-# Allowed keys on requests forwarded to vLLM. `stream_options` is included so
-# that callers can opt into usage reporting; we also force it on for streaming
-# requests below so we can count tokens server-side.
-_COMPLETION_ALLOWED_KEYS = (
-    "model",
-    "temperature",
-    "prompt",
-    "max_tokens",
-    "stream",
-    "stream_options",
-    "tools",
-    "tool_choice",
-    "response_format",
-    "top_p",
-    "stop",
-    "seed",
-    "presence_penalty",
-    "frequency_penalty",
-)
-
-_CHAT_ALLOWED_KEYS = (
-    "model",
-    "temperature",
-    "messages",
-    "max_tokens",
-    "stream",
-    "stream_options",
-    "tools",
-    "tool_choice",
-    "response_format",
-    "top_p",
-    "stop",
-    "seed",
-    "presence_penalty",
-    "frequency_penalty",
-)
-
-
-@openai_v1_router.get("/models")
-async def list_models():
-    """List available models - proxy to vLLM server."""
-    session = get_global_session()
-    config = get_config()
-    async with session.get(config["vllm_api_url"] + "/v1/models") as resp:
-        if resp.status == 200:
-            return await resp.json()
-        else:
-            return JSONResponse(
-                content={"error": f"Failed to fetch models: {resp.status}"},
-                status_code=resp.status,
-            )
-
-
-@openai_v1_router.post("/completions")
-async def create_completions(request: CompletionRequest, raw_request: Request):
-    """Create completions - proxy to vLLM server."""
-    config = get_config()
-
-    # Bulk-route fast path (Phase 31). Fires BEFORE model_dump so bulk
-    # requests don't pay the O(N) pydantic walk.
-    if _should_route_via_queue_fast(request):
-        if _OPENAI_CACHE_ENABLED:
-            hit = _cache_lookup_by_key(_cache_key_from_request(request), config)
-            if hit is not None:
-                return JSONResponse(content=hit)
-        logger.info(
-            "completions via queue: model=%s prompts=%d",
-            request.model, len(request.prompt),
-        )
-        return await _route_via_scalarlm_queue(request, config)
-
-    params = _filter_params(request.model_dump(mode="json", exclude_none=True), _COMPLETION_ALLOWED_KEYS)
-    _ensure_usage_reported(params)
-    cached = _cache_lookup(params, config)
-    if cached is not None:
-        return JSONResponse(content=cached)
-    logger.info("Received completions request: %s", params)
-    if _OPENAI_CACHE_ENABLED and not params.get("stream"):
-        return await _proxy_nonstreaming_cached(
-            upstream_url=config["vllm_api_url"] + "/v1/completions",
-            params=params,
-            endpoint_label="completions",
-            config=config,
-        )
-    return _proxy_streaming(
-        upstream_url=config["vllm_api_url"] + "/v1/completions",
-        params=params,
-        endpoint_label="completions",
-    )
 
 
 async def _route_via_scalarlm_queue(request, config: dict) -> JSONResponse:
@@ -202,6 +115,61 @@ async def _route_via_scalarlm_queue(request, config: dict) -> JSONResponse:
     metrics.record_completed_request(token_count=0, flop_count=None)
     return JSONResponse(content=body)
 
+openai_v1_router = APIRouter()
+
+
+@openai_v1_router.get("/models")
+async def list_models():
+    """List available models - proxy to vLLM server."""
+    session = get_global_session()
+    config = get_config()
+    async with session.get(config["vllm_api_url"] + "/v1/models") as resp:
+        if resp.status == 200:
+            return await resp.json()
+        else:
+            return JSONResponse(
+                content={"error": f"Failed to fetch models: {resp.status}"},
+                status_code=resp.status,
+            )
+
+
+@openai_v1_router.post("/completions")
+async def create_completions(request: CompletionRequest, raw_request: Request):
+    """Create completions - proxy to vLLM server."""
+    config = get_config()
+
+    # Bulk-route fast path (Phase 31). Fires BEFORE model_dump so bulk
+    # requests don't pay the O(N) pydantic walk.
+    if _should_route_via_queue_fast(request):
+        if _OPENAI_CACHE_ENABLED:
+            hit = _cache_lookup_by_key(_cache_key_from_request(request), config)
+            if hit is not None:
+                return JSONResponse(content=hit)
+        logger.info(
+            "completions via queue: model=%s prompts=%d",
+            request.model, len(request.prompt),
+        )
+        return await _route_via_scalarlm_queue(request, config)
+
+    params = _filter_params(request.model_dump(mode="json", exclude_none=True), _COMPLETION_ALLOWED_KEYS)
+    _ensure_usage_reported(params)
+    cached = _cache_lookup(params, config)
+    if cached is not None:
+        return JSONResponse(content=cached)
+    logger.info("Received completions request: %s", params)
+    if _OPENAI_CACHE_ENABLED and not params.get("stream"):
+        return await _proxy_nonstreaming_cached(
+            upstream_url=config["vllm_api_url"] + "/v1/completions",
+            params=params,
+            endpoint_label="completions",
+            config=config,
+        )
+    return _proxy_streaming(
+        upstream_url=config["vllm_api_url"] + "/v1/completions",
+        params=params,
+        endpoint_label="completions",
+    )
+
 
 @openai_v1_router.post("/chat/completions")
 async def create_chat_completions(request: ChatCompletionRequest, raw_request: Request):
@@ -230,24 +198,6 @@ async def create_chat_completions(request: ChatCompletionRequest, raw_request: R
 # ---------------------------------------------------------------------------
 # Internals
 # ---------------------------------------------------------------------------
-
-
-def _filter_params(raw: dict, allowed: tuple) -> dict:
-    return {k: v for k, v in raw.items() if v is not None and k in allowed}
-
-
-def _ensure_usage_reported(params: dict) -> None:
-    """For streaming requests, force vLLM to emit a final `usage` event so we
-    can count tokens. OpenAI-compatible clients tolerate the extra field; the
-    ScalarLM chat UI specifically reads it and surfaces tokens-per-message.
-    Non-streaming responses always include usage in the final JSON body, so
-    no opt-in is needed there.
-    """
-    if not params.get("stream"):
-        return
-    opts = dict(params.get("stream_options") or {})
-    opts.setdefault("include_usage", True)
-    params["stream_options"] = opts
 
 
 async def _proxy_nonstreaming_cached(
@@ -363,45 +313,5 @@ async def _wrap_with_metrics(source):
         )
 
 
-def _extract_token_count(payload: bytes) -> Optional[int]:
-    """Best-effort scan for `usage.total_tokens` in either an SSE stream tail
-    or a single JSON response body. Returns None if not found."""
-    if not payload:
-        return None
-    try:
-        text = payload.decode("utf-8", errors="replace")
-    except Exception:
-        return None
-
-    # SSE path — look for the last `data: {...}` event with a usage field.
-    if "data:" in text:
-        last: Optional[int] = None
-        for event in text.split("\n\n"):
-            for line in event.splitlines():
-                if not line.startswith("data:"):
-                    continue
-                body = line[5:].lstrip()
-                if not body or body == "[DONE]":
-                    continue
-                tokens = _read_total_tokens(body)
-                if tokens is not None:
-                    last = tokens
-        if last is not None:
-            return last
-
-    # Non-streaming path — try parsing the whole tail as JSON.
-    return _read_total_tokens(text)
-
-
-def _read_total_tokens(json_text: str) -> Optional[int]:
-    try:
-        obj = json.loads(json_text)
-    except (json.JSONDecodeError, ValueError):
-        return None
-    if not isinstance(obj, dict):
-        return None
-    usage = obj.get("usage")
-    if not isinstance(usage, dict):
-        return None
-    total = usage.get("total_tokens")
-    return int(total) if isinstance(total, (int, float)) else None
+# _extract_token_count, _read_total_tokens, _filter_params,
+# _ensure_usage_reported are re-imported from openai_v1_helpers above.

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -87,15 +87,43 @@ async def _route_via_scalarlm_queue(request, config: dict) -> JSONResponse:
     )
     gen_resp = await _scalarlm_generate(gen_req)
 
+    # Per-item errors bubble up as a 500 with an OpenAI-shaped body.
+    # scalarlm's /v1/generate supports partial success; /v1/completions
+    # does not (the OpenAI `finish_reason` enum has no "error" value,
+    # so clients would fail validation on a mixed-success batch).
+    # Fail the whole request instead.
+    failed = [(i, r.error) for i, r in enumerate(gen_resp.results) if r.error]
+    if failed:
+        first_i, first_err = failed[0]
+        metrics.record_completed_request(token_count=0, flop_count=None)
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": {
+                    "message": (
+                        f"inference failed for prompt index {first_i}: "
+                        f"{first_err}" + (
+                            f" (and {len(failed) - 1} other prompt(s))"
+                            if len(failed) > 1 else ""
+                        )
+                    ),
+                    "type": "server_error",
+                    "param": None,
+                    "code": None,
+                }
+            },
+        )
+
     import time as _t
-    choices = []
-    for i, r in enumerate(gen_resp.results):
-        choices.append({
+    choices = [
+        {
             "index": i,
             "text": r.response or "",
-            "finish_reason": "stop" if r.error is None else "error",
+            "finish_reason": "stop",
             "logprobs": None,
-        })
+        }
+        for i, r in enumerate(gen_resp.results)
+    ]
     group_id = (
         gen_resp.results[0].request_id.split("_")[0][:12]
         if gen_resp.results else "queue"

--- a/infra/cray_infra/one_server/create_vllm.py
+++ b/infra/cray_infra/one_server/create_vllm.py
@@ -23,6 +23,11 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Re-export so the arg-builder is reachable from its historical location
+# for any downstream importers, while the torch-free implementation lives
+# in vllm_cli_args for unit tests.
+from cray_infra.one_server.vllm_cli_args import build_vllm_cli_args  # noqa: E402
+
 async def create_vllm(server_status, port):
 
     print(f"DEBUG: BEFORE CONFIG - Environment variables:")
@@ -54,24 +59,7 @@ async def create_vllm(server_status, port):
         description="vLLM OpenAI-Compatible RESTful API server."
     )
     parser = make_arg_parser(parser)
-    args = [
-        f"--dtype={config['dtype']}",
-        f"--max-model-len=auto",
-        #f"--max-num-batched-tokens={config['max_model_length']}",
-        #f"--max-seq-len-to-capture={config['max_model_length']}",
-        f"--gpu-memory-utilization={config['gpu_memory_utilization']}",
-        f"--max-log-len={config['max_log_length']}",
-        f"--tensor-parallel-size={config['tensor_parallel_size']}",
-        #f"--model_impl transformers",
-        "--enable-lora",
-        "--enable-auto-tool-choice",
-        "--tool-call-parser=hermes",
-        "--trust-remote-code",
-    ]
-
-
-    if config['limit_mm_per_prompt'] is not None:
-        args.append(f"--limit-mm-per-prompt={config['limit_mm_per_prompt']}")
+    args = build_vllm_cli_args(config)
 
     # Extra SCALARLM_VLLM_ARGS are passed via environment variable, and should override config values
     extra_args = os.environ.get("SCALARLM_VLLM_ARGS", "")

--- a/infra/cray_infra/one_server/vllm_cli_args.py
+++ b/infra/cray_infra/one_server/vllm_cli_args.py
@@ -1,0 +1,35 @@
+"""Pure-Python vLLM CLI-arg builder.
+
+Kept free of heavy imports (``torch``, ``vllm``) so it can be exercised
+from unit tests without pulling in the full training/inference stack.
+"""
+
+from __future__ import annotations
+
+
+def build_vllm_cli_args(config: dict) -> list[str]:
+    """Build the base vLLM CLI arg list from a scalarlm config dict.
+
+    Callers then extend this with model name, port, and any
+    ``SCALARLM_VLLM_ARGS`` overrides (dedupped).
+
+    The only non-obvious behavior is the ``enable_lora`` gate: when the
+    config flag is False, ``--enable-lora`` is omitted, which avoids
+    wrapping every layer in a LoRA-aware shim. See Phase 31b in
+    ``enhance-openai-api.md``.
+    """
+    args = [
+        f"--dtype={config['dtype']}",
+        "--max-model-len=auto",
+        f"--gpu-memory-utilization={config['gpu_memory_utilization']}",
+        f"--max-log-len={config['max_log_length']}",
+        f"--tensor-parallel-size={config['tensor_parallel_size']}",
+        "--enable-auto-tool-choice",
+        "--tool-call-parser=hermes",
+        "--trust-remote-code",
+    ]
+    if config.get("enable_lora", True):
+        args.append("--enable-lora")
+    if config.get("limit_mm_per_prompt") is not None:
+        args.append(f"--limit-mm-per-prompt={config['limit_mm_per_prompt']}")
+    return args

--- a/infra/cray_infra/util/default_config.py
+++ b/infra/cray_infra/util/default_config.py
@@ -52,6 +52,18 @@ class Config(BaseModel):
     dtype: str = "auto"
     limit_mm_per_prompt:str = '{"image":2}'
 
+    # Whether to pass --enable-lora to vLLM on startup. When true (default),
+    # every layer in the model is wrapped in a LoRA-aware shim so adapters
+    # can be hot-loaded. That wrapping has cost on every forward pass even
+    # with no adapter loaded, and on some vLLM-fork builds the MoE LoRA
+    # wrapper has outright bugs (e.g. the TorchAllocator.set interface drift
+    # on scalarlm-on-v0.19.0 HEAD). Deployments that know they won't use
+    # LoRA/tokenformer adapters should set SCALARLM_ENABLE_LORA=false to
+    # skip the wrapping entirely. Dynamic adapter loading via
+    # /v1/load_lora_adapter won't be available in that mode — fine for
+    # pure-inference pods, not fine for training-eval pods.
+    enable_lora: bool = True
+
     max_log_length: int = 100
 
     server_list: str = "all"

--- a/scripts/build-copy-vllm.sh
+++ b/scripts/build-copy-vllm.sh
@@ -57,3 +57,17 @@ fi
 
 echo "📍 vLLM is ready at: $DEST_DIR"
 ls -la "$DEST_DIR" | head -5
+
+# ScalarLM fork patches (see scripts/vllm_patches/apply_patches.py for why
+# each one exists and what anchors it's guarding). Runs after the vLLM
+# tree is staged, before the pip install compiles anything. In-container
+# the patcher lives next to this script (single COPY; see Dockerfile),
+# so source it from SCRIPT_DIR directly rather than a vllm_patches/ subdir.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATCHER="${SCRIPT_DIR}/apply_patches.py"
+if [ -x "${PATCHER}" ]; then
+    echo "🩹 Applying ScalarLM vLLM-fork patches"
+    python3 "${PATCHER}" "${DEST_DIR}"
+else
+    echo "⚠️  Patcher not found at ${PATCHER}; skipping"
+fi

--- a/scripts/build-copy-vllm.sh
+++ b/scripts/build-copy-vllm.sh
@@ -65,7 +65,11 @@ ls -la "$DEST_DIR" | head -5
 # so source it from SCRIPT_DIR directly rather than a vllm_patches/ subdir.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PATCHER="${SCRIPT_DIR}/apply_patches.py"
-if [ -x "${PATCHER}" ]; then
+# We invoke the patcher via `python3 ${PATCHER}`, so it doesn't need the
+# exec bit — check for readability instead so a file missing +x (e.g.
+# after some cp/rsync that didn't preserve mode) doesn't silently skip
+# patch application.
+if [ -f "${PATCHER}" ] && [ -r "${PATCHER}" ]; then
     echo "🩹 Applying ScalarLM vLLM-fork patches"
     python3 "${PATCHER}" "${DEST_DIR}"
 else

--- a/scripts/vllm_patches/apply_patches.py
+++ b/scripts/vllm_patches/apply_patches.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Apply ScalarLM's vLLM-fork patches in-place.
+
+Invoked from both:
+  - scripts/build-copy-vllm.sh at Docker build time (production path)
+  - Kubernetes pod `command:` at startup (dev/bench iteration)
+
+Adds new patches here. Each patch is a function that takes the vLLM tree
+root, reads the target file, asserts the exact anchor it expects, and
+writes the transformed file back. The assertions are load-bearing — they
+fail loudly when a fork rebase drifts the source rather than silently
+producing a mis-patched image.
+
+Usage: apply_patches.py <path/to/vllm/root>
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def patch_output_handler_metrics_offload(vllm_root: Path) -> None:
+    """Phase 6.5: move `logger_ref[0].record(...)` out of async_llm's output
+    loop onto a background consumer coroutine fed by a bounded asyncio.Queue.
+
+    Follows the TODO vLLM itself left on `vllm/v1/engine/async_llm.py:700`.
+    Profile: the synchronous record call was 20.3 %% of main-thread time at
+    N=100 and the consumer-offload pattern recovered +15 %% throughput in
+    the pilot A/B. See enhance-openai-api.md § "Phase 6.5".
+    """
+    target = vllm_root / "vllm" / "v1" / "engine" / "async_llm.py"
+    src = target.read_text()
+
+    # --- Anchor 1: the inline record call we're replacing. ---
+    anchor_record = (
+        "                    # 4) Logging.\n"
+        "                    # TODO(rob): make into a coroutine and launch it in\n"
+        "                    # background thread once Prometheus overhead is non-trivial.\n"
+        "                    if logger_ref[0]:\n"
+        "                        logger_ref[0].record(\n"
+        "                            engine_idx=outputs.engine_index,\n"
+        "                            scheduler_stats=outputs.scheduler_stats,\n"
+        "                            iteration_stats=iteration_stats,\n"
+        "                            mm_cache_stats=renderer.stat_mm_cache(),\n"
+        "                        )\n"
+    )
+    assert anchor_record in src, (
+        "async_llm.py anchor missing: the inline `logger_ref[0].record(...)` "
+        "block expected at the end of output_handler has drifted. Rebase of "
+        "the vLLM fork requires re-reading scripts/vllm_patches/apply_patches.py "
+        "to re-anchor this patch."
+    )
+
+    replacement_record = (
+        "                    # 4) Logging — offloaded to background consumer.\n"
+        "                    #    ScalarLM patch (Phase 6.5). vLLM's own TODO\n"
+        "                    #    on this spot suggested a background thread;\n"
+        "                    #    an asyncio task + bounded queue yields the\n"
+        "                    #    same shape with less machinery.\n"
+        "                    if logger_ref[0] is not None:\n"
+        "                        try:\n"
+        "                            metrics_queue_ref[0].put_nowait((\n"
+        "                                outputs.engine_index,\n"
+        "                                outputs.scheduler_stats,\n"
+        "                                iteration_stats,\n"
+        "                                renderer.stat_mm_cache(),\n"
+        "                            ))\n"
+        "                        except asyncio.QueueFull:\n"
+        "                            # Metrics are statistical — drop the\n"
+        "                            # oldest rather than block the output\n"
+        "                            # loop. The engine must keep pulling.\n"
+        "                            try:\n"
+        "                                metrics_queue_ref[0].get_nowait()\n"
+        "                                metrics_queue_ref[0].put_nowait((\n"
+        "                                    outputs.engine_index,\n"
+        "                                    outputs.scheduler_stats,\n"
+        "                                    iteration_stats,\n"
+        "                                    renderer.stat_mm_cache(),\n"
+        "                                ))\n"
+        "                            except (asyncio.QueueEmpty, asyncio.QueueFull):\n"
+        "                                pass\n"
+    )
+
+    # --- Anchor 2: the ``async def output_handler()`` signature — we hang
+    #     the metrics queue + consumer task off this spot, one level up
+    #     from the handler body, so they share closure state. ---
+    anchor_handler_def = "        async def output_handler():\n"
+    assert src.count(anchor_handler_def) == 1, (
+        "async_llm.py anchor missing: expected exactly one "
+        "`async def output_handler():` inside `_run_output_handler`. "
+        "Fork has drifted."
+    )
+
+    consumer_preamble = (
+        "        # ScalarLM Phase 6.5: bounded queue + consumer task that\n"
+        "        # drains the record() calls off the output_handler hot\n"
+        "        # path. 1024 items is ~seconds of engine iterations at our\n"
+        "        # scale; metric samples that overflow are dropped (see\n"
+        "        # output_handler for the drop-oldest path).\n"
+        "        metrics_queue_ref: list = [asyncio.Queue(maxsize=1024)]\n"
+        "\n"
+        "        async def _metrics_consumer():\n"
+        "            q = metrics_queue_ref[0]\n"
+        "            while True:\n"
+        "                try:\n"
+        "                    engine_idx, scheduler_stats, iteration_stats, mm_cache_stats = (\n"
+        "                        await q.get()\n"
+        "                    )\n"
+        "                except asyncio.CancelledError:\n"
+        "                    return\n"
+        "                try:\n"
+        "                    if logger_ref[0] is not None:\n"
+        "                        logger_ref[0].record(\n"
+        "                            engine_idx=engine_idx,\n"
+        "                            scheduler_stats=scheduler_stats,\n"
+        "                            iteration_stats=iteration_stats,\n"
+        "                            mm_cache_stats=mm_cache_stats,\n"
+        "                        )\n"
+        "                except Exception:\n"
+        "                    logger.exception(\"Background metrics record failed.\")\n"
+        "\n"
+        "        async def output_handler():\n"
+    )
+
+    # --- Anchor 3: the ``self.output_handler = asyncio.create_task(...)``
+    #     line where the handler task is actually scheduled. We schedule
+    #     the consumer next to it so the two have matching lifecycles. ---
+    anchor_schedule = (
+        "        self.output_handler = asyncio.create_task(output_handler())\n"
+    )
+    assert anchor_schedule in src, (
+        "async_llm.py anchor missing: expected the "
+        "`self.output_handler = asyncio.create_task(output_handler())` line."
+    )
+    replacement_schedule = (
+        "        self.output_handler = asyncio.create_task(output_handler())\n"
+        "        self._metrics_consumer_task = asyncio.create_task(_metrics_consumer())\n"
+    )
+
+    # Apply in order; each assertion above already guaranteed uniqueness.
+    patched = (
+        src
+        .replace(anchor_record, replacement_record)
+        .replace(anchor_handler_def, consumer_preamble)
+        .replace(anchor_schedule, replacement_schedule)
+    )
+
+    # Sanity: the patch should change the file.
+    assert patched != src, "patch produced identical output — something's wrong"
+    # And it should still parse.
+    compile(patched, str(target), "exec")
+
+    target.write_text(patched)
+    print(f"[vllm_patches] Applied output_handler metrics offload to {target}")
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <vllm-root>", file=sys.stderr)
+        return 2
+    vllm_root = Path(sys.argv[1]).resolve()
+    if not (vllm_root / "vllm" / "v1" / "engine" / "async_llm.py").exists():
+        print(f"[vllm_patches] async_llm.py not found under {vllm_root}", file=sys.stderr)
+        return 3
+
+    patch_output_handler_metrics_offload(vllm_root)
+    print("[vllm_patches] All patches applied.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/test_enable_lora_arg.py
+++ b/test/unit/test_enable_lora_arg.py
@@ -1,0 +1,63 @@
+"""Unit tests for the Phase 31b conditional --enable-lora arg.
+
+Pure-inference pods can opt out via SCALARLM_ENABLE_LORA=false, which
+drops the --enable-lora vLLM CLI arg. This avoids wrapping every layer
+in a LoRA shim (perf win, plus sidesteps the fused_moe wrapper bug on
+some vllm-fork builds).
+"""
+
+from __future__ import annotations
+
+from cray_infra.one_server.vllm_cli_args import build_vllm_cli_args
+
+
+def _base_config(**overrides):
+    cfg = {
+        "dtype": "auto",
+        "gpu_memory_utilization": 0.85,
+        "max_log_length": 100,
+        "tensor_parallel_size": 1,
+        "limit_mm_per_prompt": None,
+        "enable_lora": True,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_enable_lora_true_includes_flag():
+    args = build_vllm_cli_args(_base_config(enable_lora=True))
+    assert "--enable-lora" in args
+
+
+def test_enable_lora_false_omits_flag():
+    args = build_vllm_cli_args(_base_config(enable_lora=False))
+    assert "--enable-lora" not in args
+
+
+def test_enable_lora_default_true():
+    """Missing key in config defaults to True (back-compat with pods
+    that haven't re-synced their config yaml)."""
+    cfg = _base_config()
+    del cfg["enable_lora"]
+    args = build_vllm_cli_args(cfg)
+    assert "--enable-lora" in args
+
+
+def test_other_required_flags_always_present():
+    """The LoRA toggle must not accidentally drop other required args."""
+    args = build_vllm_cli_args(_base_config(enable_lora=False))
+    assert "--trust-remote-code" in args
+    assert "--enable-auto-tool-choice" in args
+    assert "--tool-call-parser=hermes" in args
+    assert any(a.startswith("--tensor-parallel-size=") for a in args)
+    assert any(a.startswith("--gpu-memory-utilization=") for a in args)
+
+
+def test_limit_mm_per_prompt_included_when_set():
+    args = build_vllm_cli_args(_base_config(limit_mm_per_prompt='{"image":2}'))
+    assert "--limit-mm-per-prompt={\"image\":2}" in args
+
+
+def test_limit_mm_per_prompt_omitted_when_none():
+    args = build_vllm_cli_args(_base_config(limit_mm_per_prompt=None))
+    assert not any(a.startswith("--limit-mm-per-prompt=") for a in args)

--- a/test/unit/test_openai_cache.py
+++ b/test/unit/test_openai_cache.py
@@ -1,0 +1,205 @@
+"""Unit tests for the Phase 30 response cache on /v1/completions and
+/v1/chat/completions.
+
+The cache hashes the filtered params dict and persists the response JSON
+to {upload_base_path}/openai_cache/{sha256}.json. These tests exercise
+the helpers directly rather than standing up the FastAPI app.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def router_cache_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("SCALARLM_OPENAI_CACHE", "1")
+    from cray_infra.api.fastapi.routers import openai_v1_helpers as r
+    importlib.reload(r)
+    return r, {"upload_base_path": str(tmp_path)}
+
+
+@pytest.fixture
+def router_cache_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("SCALARLM_OPENAI_CACHE", raising=False)
+    from cray_infra.api.fastapi.routers import openai_v1_helpers as r
+    importlib.reload(r)
+    return r, {"upload_base_path": str(tmp_path)}
+
+
+# ---- _cache_key deterministic + key-sensitive -----------------------------
+
+
+def test_cache_key_deterministic_across_dict_order(router_cache_enabled):
+    r, _ = router_cache_enabled
+    a = {"model": "m", "prompt": ["p1", "p2"], "max_tokens": 16, "temperature": 0.0}
+    b = {"temperature": 0.0, "max_tokens": 16, "prompt": ["p1", "p2"], "model": "m"}
+    assert r._cache_key(a) == r._cache_key(b)
+
+
+def test_cache_key_changes_when_any_keyed_field_changes(router_cache_enabled):
+    r, _ = router_cache_enabled
+    base = {"model": "m", "prompt": ["p"], "max_tokens": 16, "temperature": 0.0}
+    for field, new in [
+        ("model", "m2"),
+        ("prompt", ["p2"]),
+        ("max_tokens", 17),
+        ("temperature", 0.1),
+    ]:
+        mutated = dict(base)
+        mutated[field] = new
+        assert r._cache_key(base) != r._cache_key(mutated), (
+            f"hash did not change when {field} changed"
+        )
+
+
+def test_cache_key_ignores_non_cache_fields(router_cache_enabled):
+    """Fields outside _OPENAI_CACHE_KEYS (e.g. stream, seed) must not
+    influence the hash — otherwise a stream-off/stream-on pair would
+    mint different keys for the same inference."""
+    r, _ = router_cache_enabled
+    a = {"model": "m", "prompt": ["p"], "max_tokens": 16}
+    b = {"model": "m", "prompt": ["p"], "max_tokens": 16, "stream": True}
+    assert r._cache_key(a) == r._cache_key(b)
+
+
+# ---- _cache_lookup gating --------------------------------------------------
+
+
+def test_cache_lookup_returns_none_when_disabled(router_cache_disabled, tmp_path):
+    """Even if a matching file is on disk, lookup should return None when
+    SCALARLM_OPENAI_CACHE is unset."""
+    r, config = router_cache_disabled
+    cache_dir = tmp_path / "openai_cache"
+    cache_dir.mkdir()
+    params = {"model": "m", "prompt": ["p"]}
+    key = r._cache_key(params)
+    (cache_dir / f"{key}.json").write_text('{"choices": []}')
+    assert r._cache_lookup(params, config) is None
+
+
+def test_cache_lookup_returns_none_for_streaming(router_cache_enabled):
+    """Streaming requests bypass the cache entirely."""
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["p"], "stream": True}
+    nonstream = dict(params)
+    nonstream.pop("stream")
+    r._cache_store(nonstream, {"choices": [{"index": 0}]}, config)
+    assert r._cache_lookup(params, config) is None
+
+
+def test_cache_lookup_miss_returns_none(router_cache_enabled):
+    r, config = router_cache_enabled
+    assert r._cache_lookup({"model": "m", "prompt": ["nope"]}, config) is None
+
+
+# ---- _cache_lookup error-path handling ------------------------------------
+
+
+def test_cache_lookup_handles_corrupted_json(router_cache_enabled, tmp_path):
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["p"]}
+    key = r._cache_key(params)
+    cache_file = Path(config["upload_base_path"]) / "openai_cache" / f"{key}.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text("{ not json }")
+    assert r._cache_lookup(params, config) is None
+
+
+def test_cache_lookup_handles_file_io_errors(router_cache_enabled, tmp_path):
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["p"]}
+    key = r._cache_key(params)
+    cache_file = Path(config["upload_base_path"]) / "openai_cache" / f"{key}.json"
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text('{"choices": []}')
+    with patch("builtins.open", side_effect=PermissionError("no read")):
+        assert r._cache_lookup(params, config) is None
+
+
+# ---- _cache_store roundtrip + refusal cases -------------------------------
+
+
+def test_cache_store_then_lookup_roundtrip(router_cache_enabled):
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["hi"], "max_tokens": 16}
+    body = {
+        "id": "cmpl-abc",
+        "object": "text_completion",
+        "choices": [{"index": 0, "text": "hello", "finish_reason": "stop"}],
+        "usage": {"total_tokens": 3},
+    }
+    r._cache_store(params, body, config)
+    hit = r._cache_lookup(params, config)
+    assert hit == body
+
+
+def test_cache_store_is_atomic(router_cache_enabled):
+    """The store must use os.replace for atomicity so a crash mid-write
+    can't leave a partial file that a concurrent reader would see."""
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["p"]}
+    body = {"choices": [{"text": "ok"}]}
+    with patch("os.replace") as mock_replace:
+        r._cache_store(params, body, config)
+        assert mock_replace.called
+        src, dst = mock_replace.call_args[0]
+        assert src.endswith(".tmp")
+        assert dst.endswith(".json")
+
+
+def test_cache_store_refuses_non_dict_bodies(router_cache_enabled):
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["p"]}
+    r._cache_store(params, "not a dict", config)
+    assert r._cache_lookup(params, config) is None
+
+
+def test_cache_store_refuses_bodies_without_choices(router_cache_enabled):
+    """Error-shaped responses (no ``choices``) must not be cached."""
+    r, config = router_cache_enabled
+    params = {"model": "m", "prompt": ["hi"]}
+    r._cache_store(params, {"error": {"message": "boom"}}, config)
+    assert r._cache_lookup(params, config) is None
+
+
+def test_cache_store_no_op_when_disabled(router_cache_disabled, tmp_path):
+    r, config = router_cache_disabled
+    params = {"model": "m", "prompt": ["hi"]}
+    r._cache_store(params, {"choices": [{"index": 0}]}, config)
+    cache_dir = tmp_path / "openai_cache"
+    assert not cache_dir.exists() or not any(cache_dir.iterdir())
+
+
+# ---- _cache_key_from_request consistency ---------------------------------
+
+
+def test_cache_key_from_request_consistency(router_cache_enabled):
+    """The fast-path `_cache_key_from_request` must agree with the
+    model-dump-based `_cache_key` — otherwise a cold direct-path call
+    and a warm queue-routed call on the same params would mint
+    different keys and silently miss the cache."""
+    r, _ = router_cache_enabled
+    req = SimpleNamespace(
+        model="gpt-4",
+        prompt=["hello"],
+        temperature=0.7,
+        max_tokens=100,
+        tools=[{"type": "function"}],
+        ignored_field="secret",
+    )
+    params = {
+        "model": req.model,
+        "prompt": req.prompt,
+        "temperature": req.temperature,
+        "max_tokens": req.max_tokens,
+        "tools": req.tools,
+    }
+    assert r._cache_key_from_request(req) == r._cache_key(params)

--- a/test/unit/test_openai_cache.py
+++ b/test/unit/test_openai_cache.py
@@ -178,6 +178,34 @@ def test_cache_store_no_op_when_disabled(router_cache_disabled, tmp_path):
     assert not cache_dir.exists() or not any(cache_dir.iterdir())
 
 
+# ---- _parse_env_bool robust env parsing ----------------------------------
+
+
+@pytest.mark.parametrize("val,expected", [
+    ("1", True), ("true", True), ("True", True), ("TRUE", True),
+    ("yes", True), ("YES", True), ("on", True), ("ON", True),
+    ("  true  ", True),  # surrounding whitespace tolerated
+    ("0", False), ("false", False), ("no", False), ("off", False),
+    ("", False), ("garbage", False), ("2", False),
+])
+def test_parse_env_bool_accepts_common_forms(val, expected, monkeypatch):
+    """The old ``bool(int(os.environ.get(...)))`` pattern crashed on
+    SCALARLM_OPENAI_CACHE=true (ValueError from int("true")). The
+    robust parser accepts any common boolean form and falls back to
+    default on anything else, matching how most config libraries handle
+    env-var booleans."""
+    monkeypatch.setenv("_TEST_ENV_BOOL", val)
+    from cray_infra.api.fastapi.routers import openai_v1_helpers as r
+    assert r._parse_env_bool("_TEST_ENV_BOOL") is expected
+
+
+def test_parse_env_bool_unset_uses_default(monkeypatch):
+    monkeypatch.delenv("_TEST_ENV_BOOL", raising=False)
+    from cray_infra.api.fastapi.routers import openai_v1_helpers as r
+    assert r._parse_env_bool("_TEST_ENV_BOOL") is False
+    assert r._parse_env_bool("_TEST_ENV_BOOL", default=True) is True
+
+
 # ---- _cache_key_from_request consistency ---------------------------------
 
 

--- a/test/unit/test_openai_queue_route.py
+++ b/test/unit/test_openai_queue_route.py
@@ -1,0 +1,169 @@
+"""Unit tests for the Phase 31 bulk queue-route fast-path.
+
+Array /v1/completions requests with >= SCALARLM_QUEUE_ROUTE_THRESHOLD
+string prompts are routed through the /v1/generate queue worker. These
+tests verify the routing logic and cache key consistency for complex
+request shapes.
+"""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def router_threshold_100(monkeypatch):
+    monkeypatch.setenv("SCALARLM_QUEUE_ROUTE_THRESHOLD", "100")
+    from cray_infra.api.fastapi.routers import openai_v1_helpers as r
+    importlib.reload(r)
+    return r
+
+
+@pytest.fixture
+def router_threshold_off(monkeypatch):
+    monkeypatch.delenv("SCALARLM_QUEUE_ROUTE_THRESHOLD", raising=False)
+    from cray_infra.api.fastapi.routers import openai_v1_helpers as r
+    importlib.reload(r)
+    return r
+
+
+def _req(**kwargs):
+    """Minimal stand-in for CompletionRequest. The fast-path only reads
+    attributes, so a plain namespace suffices."""
+    defaults = {
+        "prompt": ["hi"] * 100,
+        "stream": False,
+        "model": "m",
+        "max_tokens": 16,
+        "temperature": 0.0,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+# ---- _should_route_via_queue_fast: accept ---------------------------------
+
+
+def test_accept_string_list_at_threshold(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt=["p"] * 100)
+    assert r._should_route_via_queue_fast(req) is True
+
+
+def test_accept_large_string_list(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt=["p"] * 1000)
+    assert r._should_route_via_queue_fast(req) is True
+
+
+# ---- _should_route_via_queue_fast: reject ---------------------------------
+
+
+def test_reject_when_threshold_unset(router_threshold_off):
+    r = router_threshold_off
+    req = _req(prompt=["p"] * 1000)
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_when_streaming(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt=["p"] * 1000, stream=True)
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_scalar_string_prompt(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt="one prompt")
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_empty_list(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt=[])
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_shorter_than_threshold(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt=["p"] * 99)
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_token_id_list(router_threshold_100):
+    """list[int] is the OpenAI token-id prompt form — the queue worker
+    can't handle it."""
+    r = router_threshold_100
+    req = _req(prompt=list(range(1000)))
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_list_of_token_lists(router_threshold_100):
+    """list[list[int]] is the multi-prompt token-id form."""
+    r = router_threshold_100
+    req = _req(prompt=[[1, 2, 3]] * 200)
+    assert r._should_route_via_queue_fast(req) is False
+
+
+def test_reject_mixed_list(router_threshold_100):
+    r = router_threshold_100
+    req = _req(prompt=["valid"] * 500 + [[1, 2, 3]])
+    assert r._should_route_via_queue_fast(req) is False
+
+
+# ---- Cache Key Consistency: _cache_key_from_request vs _cache_key(params) --
+
+
+def test_cache_key_consistency_simple(router_threshold_100):
+    """Ensure fast-path key matches direct-path key for simple params."""
+    r = router_threshold_100
+    req = _req(prompt=["p1", "p2"], max_tokens=32, temperature=0.7)
+    
+    # Simulate what _filter_params(request.model_dump()) would produce
+    params = {
+        "model": req.model,
+        "prompt": req.prompt,
+        "max_tokens": req.max_tokens,
+        "temperature": req.temperature,
+    }
+    
+    assert r._cache_key_from_request(req) == r._cache_key(params)
+
+
+def test_cache_key_consistency_complex_fields(router_threshold_100):
+    """Verify consistency when complex fields like tools are present."""
+    r = router_threshold_100
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {"location": {"type": "string"}}
+            }
+        }
+    ]
+    req = _req(tools=tools, tool_choice="auto")
+    
+    params = {
+        "model": req.model,
+        "prompt": req.prompt,
+        "max_tokens": req.max_tokens,
+        "temperature": req.temperature,
+        "tools": tools,
+        "tool_choice": "auto"
+    }
+    
+    assert r._cache_key_from_request(req) == r._cache_key(params)
+
+
+def test_cache_key_ignores_untracked_request_attributes(router_threshold_100):
+    """Attributes on the request object that aren't in _OPENAI_CACHE_KEYS
+    should not affect the cache key produced by the fast-path."""
+    r = router_threshold_100
+    req_a = _req(prompt=["p"])
+    req_b = _req(prompt=["p"])
+    req_b.internal_debug_flag = True
+    
+    assert r._cache_key_from_request(req_a) == r._cache_key_from_request(req_b)

--- a/test/unit/test_openai_queue_route.py
+++ b/test/unit/test_openai_queue_route.py
@@ -113,6 +113,64 @@ def test_reject_mixed_list(router_threshold_100):
     assert r._should_route_via_queue_fast(req) is False
 
 
+# ---- reject on params the queue-route translation drops ------------------
+
+
+def test_reject_when_top_p_set(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(top_p=0.9)) is False
+
+
+def test_reject_when_stop_set(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(stop=["<|end|>"])) is False
+
+
+def test_reject_when_seed_set(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(seed=42)) is False
+
+
+def test_reject_when_presence_penalty_nonzero(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(presence_penalty=0.5)) is False
+
+
+def test_reject_when_frequency_penalty_nonzero(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(frequency_penalty=0.5)) is False
+
+
+def test_accept_when_penalties_at_default(router_threshold_100):
+    """Default 0.0 penalties must not trigger a rejection — that's the
+    pydantic default, not a user-set value."""
+    r = router_threshold_100
+    assert (
+        r._should_route_via_queue_fast(
+            _req(presence_penalty=0.0, frequency_penalty=0.0)
+        ) is True
+    )
+
+
+def test_reject_when_response_format_set(router_threshold_100):
+    r = router_threshold_100
+    assert (
+        r._should_route_via_queue_fast(
+            _req(response_format={"type": "json_object"})
+        ) is False
+    )
+
+
+def test_reject_when_n_greater_than_1(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(n=3)) is False
+
+
+def test_accept_when_n_is_1(router_threshold_100):
+    r = router_threshold_100
+    assert r._should_route_via_queue_fast(_req(n=1)) is True
+
+
 # ---- Cache Key Consistency: _cache_key_from_request vs _cache_key(params) --
 
 

--- a/test/unit/test_openai_router_logic.py
+++ b/test/unit/test_openai_router_logic.py
@@ -1,0 +1,109 @@
+"""Unit tests for the pure-logic helpers behind the openai proxy router.
+
+These tests exercise the private helper functions (_extract_token_count,
+_filter_params, _ensure_usage_reported) to pin robust metrics extraction
+and request sanitization. They live in `openai_v1_helpers` so the test
+suite can run without standing up vllm / fastapi / aiohttp.
+"""
+
+from __future__ import annotations
+
+import json
+import pytest
+from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _extract_token_count,
+    _filter_params,
+    _ensure_usage_reported,
+)
+
+# ---- _extract_token_count --------------------------------------------------
+
+def test_extract_token_count_from_json_body():
+    payload = json.dumps({
+        "usage": {"total_tokens": 42}
+    }).encode("utf-8")
+    assert _extract_token_count(payload) == 42
+
+def test_extract_token_count_from_sse_stream():
+    # Multi-event stream, usage in the last event
+    sse_data = (
+        'data: {"choices": [{"text": "hello"}]}\n\n'
+        'data: {"choices": [], "usage": {"total_tokens": 10}}\n\n'
+        'data: [DONE]\n\n'
+    ).encode("utf-8")
+    assert _extract_token_count(sse_data) == 10
+
+def test_extract_token_count_handles_varying_whitespace_and_newlines():
+    # OpenAI spec allows single \n or \r\n and varying space after data:
+    sse_data = (
+        'data:{"usage":{"total_tokens":1}}\n\n'
+        'data:   {"usage":{"total_tokens":2}}\r\n\r\n'
+        'data: {"usage": {"total_tokens": 3}}\n\n'
+    ).encode("utf-8")
+    assert _extract_token_count(sse_data) == 3
+
+def test_extract_token_count_handles_multiline_data_events():
+    # Per the SSE spec, a single event can have multiple `data:` lines;
+    # their contents are concatenated with "\n" to form one decoded
+    # value. In practice vLLM's OpenAI SSE emitter keeps each JSON on
+    # one line, but we want the parser to handle spec-compliant input
+    # correctly so a future emitter change doesn't silently break
+    # token counting.
+    sse_data = (
+        'data: {"usage":\n'
+        'data: {"total_tokens": 7}}\n\n'
+    ).encode("utf-8")
+    assert _extract_token_count(sse_data) == 7
+
+def test_extract_token_count_handles_partial_trailing_data():
+    # If the buffer has extra garbage at the end but valid SSE events before it
+    sse_data = (
+        'data: {"usage": {"total_tokens": 5}}\n\n'
+        'data: [DONE]\n\n'
+        'extra garbage'
+    ).encode("utf-8")
+    assert _extract_token_count(sse_data) == 5
+
+def test_extract_token_count_handles_malformed_json_gracefully():
+    assert _extract_token_count(b"{ invalid }") is None
+    assert _extract_token_count(b"data: { malformed }\n\n") is None
+
+def test_extract_token_count_returns_none_on_empty():
+    assert _extract_token_count(b"") is None
+
+def test_extract_token_count_handles_unicode_errors():
+    # Payload with invalid utf-8 sequences
+    payload = b'{"usage": {"total_tokens": 5}, "extra": "' + b'\xff' + b'"}'
+    # Decoder should use "replace" and still find the usage field if possible
+    assert _extract_token_count(payload) == 5
+
+# ---- _filter_params --------------------------------------------------------
+
+def test_filter_params_strips_unknown_keys():
+    raw = {"model": "m1", "unknown": "u1", "temperature": 0.5}
+    allowed = ("model", "temperature")
+    filtered = _filter_params(raw, allowed)
+    assert filtered == {"model": "m1", "temperature": 0.5}
+
+def test_filter_params_strips_none_values():
+    raw = {"model": "m1", "temperature": None}
+    allowed = ("model", "temperature")
+    filtered = _filter_params(raw, allowed)
+    assert filtered == {"model": "m1"}
+
+# ---- _ensure_usage_reported ------------------------------------------------
+
+def test_ensure_usage_reported_injects_field_on_stream():
+    params = {"stream": True}
+    _ensure_usage_reported(params)
+    assert params["stream_options"] == {"include_usage": True}
+
+def test_ensure_usage_reported_respects_existing_options():
+    params = {"stream": True, "stream_options": {"existing": 1}}
+    _ensure_usage_reported(params)
+    assert params["stream_options"] == {"existing": 1, "include_usage": True}
+
+def test_ensure_usage_reported_no_op_on_non_stream():
+    params = {"stream": False}
+    _ensure_usage_reported(params)
+    assert "stream_options" not in params


### PR DESCRIPTION
## Summary                                                                                
                                                                               
  Brings `/v1/completions` and `/v1/chat/completions` to feature + performance                                                         
  parity with `/v1/generate`, so the OpenAI-compatible path becomes the single
  recommended inference surface. Sets up deprecating `/v1/generate` as a                                                               
  public surface.                                                                           
                                                                                                                                       
  Four user-facing changes behind env flags; one foundational vLLM-fork                     
  patch; one SSE parser fix:                                                 
                                                                               
  1. **Phase 6.5** — move vLLM's output-handler metrics off the hot path                                                               
     (build-time patch). +15 % throughput. Layer-count fix so the image        
     stays under Docker's 127-layer overlay-fs cap.                                                                                    
  2. **Phase 30** — response cache for `/v1/completions` and                                                                           
     `/v1/chat/completions`. Opt-in via `SCALARLM_OPENAI_CACHE=1`.                                                                     
  3. **Phase 31** — route bulk array `/v1/completions` through the                                                                     
     existing `/v1/generate` queue worker. Opt-in via                                                                                  
     `SCALARLM_QUEUE_ROUTE_THRESHOLD=100`. Closes the ~30 % structural                                                                 
     gap to parity.                                                                                                                    
  4. **Phase 31b** — conditional `--enable-lora`. Opt-out via                                                                          
     `SCALARLM_ENABLE_LORA=false` for pure-inference pods. Sidesteps the                                                               
     vllm-fork MoE+LoRA crash until that fork PR                                                                                       
     ([fix-lora-fused-moe-torch-allocator](https://github.com/supermassive-intelligence/vllm-fork/compare/scalarlm-on-v0.19.0...fix-lor
  a-fused-moe-torch-allocator))                                                                                                        
     lands.                                                                                 
  5. **SSE fix** — `_extract_token_count` now handles multi-line `data:`                                                               
     events and CRLF separators per the SSE spec. Router-logic helpers                                                                 
     extracted for unit-testability.                                                                                                   
                                                                                                                                       
  ## Performance (validated against clean-built images on both hosts)                                                                  
                                                                                                                                       
  **Blackwell 2-GPU PP=2, ms=256, Qwen3-Next-80B-A3B-FP8, N=1000 distinct:**                                                           
                                                                                                                                       
  | path | warm p/s | cold/warm 3-run mean |                                                                                           
  |---|---:|---:|                                                                                                                      
  | openai direct  | —    | 62 |                                                                                                       
  | **openai queue** | **97.6** | **85.1** |                                                                                           
  | scalarlm `/v1/generate` | 96.7 | 94.7 |                                                                                            
                                                                                                                                       
  Warm-run parity: 0.9 % gap. 3-run mean parity: within single-run variance.                                                           
                                                                                            
  **Spark GB10, Qwen3-32B-NVFP4, N=1000 distinct, cache-busted 3-run:**                                                                
                                                                                            
  | path | mean p/s |                                                                                                                  
  |---|---:|                                                                                                                           
  | openai (queue-routed) | 41.2 |                                                                                                     
  | scalarlm `/v1/generate` | 41.1 |                                                                                                   
                                                                                                                                       
  0.2 % gap.                                                                                                                           
                                                                                                                                       
  ## Test plan                                                                              
                                                                                                                                       
  - [x] Unit tests: `test_openai_cache.py` (14), `test_openai_queue_route.py`               
        (13), `test_enable_lora_arg.py` (6), `test_openai_router_logic.py`     
        (13) — 46 tests, all passing (`PYTHONPATH=infra pytest test/unit/                                                              
        test_openai_*.py test_enable_lora_arg.py -q`).                       
  - [x] End-to-end bench on Blackwell against `kapu/scalarlm-nvidia-12.0:                                                              
        enhanced-openai-api` (3-run paired, openai queue-route vs scalarlm                  
        `/v1/generate`).                                                                                                               
  - [x] End-to-end bench on Spark against `kapu/scalarlm-spark:                             
        enhanced-openai-api` (3-run paired).                                                                                           
  - [x] Phase 31b (`SCALARLM_ENABLE_LORA=false`) verified on Blackwell —       
        engine init succeeds on MoE + pure-inference pod.                                                                              
                                                                                                                                       
  ## Follow-ups (not in this PR)                                                                                                       
                                                                                                                                       
  - Promote `token_count` onto `Result` in `create_generate_worker`'s                                                                  
    `async_completion_task` — 15-line change that unlocks accurate                                                                     
    `usage.*_tokens` on queue-routed responses.                                                                                        
  - vllm-fork PR (`fix-lora-fused-moe-torch-allocator`) — lets                                                                         
    training-eval pods re-enable LoRA on MoE without the                                                                               
    `TorchAllocator.set` crash.                                                                                                        
  - Pin vllm-fork to a specific commit in the Dockerfile for build                                                                     
    determinism.                                                                                                                       
  - PP layer-partition tuning beyond `23,25`.               