### PR TITLE
OpenAI chat completions queue: heartbeat transport + shared chat template

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/admission.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/admission.py
@@ -1,0 +1,79 @@
+"""
+Admission control for /v1/chat/completions.
+
+Two responsibilities:
+
+  - is_over_high_water(...) — pure threshold check used by the
+    handler to decide whether to admit or reject with 429.
+  - WaitEstimator             — moving average of recent batch
+    completion times, exposed as a `Retry-After` hint when rejecting.
+
+Both pieces are intentionally tiny and stateless-or-bounded-state so
+the handler can call them on the hot path without contention.
+
+See docs/openai-chat-completions-queue.md §5.
+"""
+
+from collections import deque
+from typing import Deque
+
+
+def is_over_high_water(
+    *,
+    queue_depth: int,
+    in_flight_count: int,
+    max_num_seqs: int,
+    admit_factor: int,
+) -> bool:
+    """
+    True if `queue_depth + in_flight_count` exceeds `admit_factor *
+    max_num_seqs`. Equality is *not* over — the threshold is the last
+    value we'll admit.
+    """
+    return (queue_depth + in_flight_count) > admit_factor * max_num_seqs
+
+
+class WaitEstimator:
+    """
+    Bounded ring buffer of recent batch completion times. The
+    `estimate_wait_seconds` method returns the `Retry-After` hint to
+    send with a 429: the moving-average batch latency, scaled by the
+    current overload ratio, padded by a constant factor to prevent
+    retry storms when many clients receive identical hints and
+    synchronize their next attempts.
+
+    The estimate is non-negative and zero whenever queue depth is at
+    or below `max_num_seqs` — callers shouldn't get a Retry-After
+    when they're about to be admitted.
+    """
+
+    def __init__(
+        self,
+        *,
+        default_batch_latency_seconds: float = 5.0,
+        padding: float = 1.5,
+        sample_size: int = 32,
+    ) -> None:
+        self._default = default_batch_latency_seconds
+        self._padding = padding
+        self._samples: Deque[float] = deque(maxlen=sample_size)
+
+    def record_batch_latency_seconds(self, seconds: float) -> None:
+        self._samples.append(seconds)
+
+    def estimate_wait_seconds(
+        self, *, queue_depth: int, max_num_seqs: int
+    ) -> float:
+        if max_num_seqs <= 0:
+            return 0.0
+        overload_ratio = (queue_depth - max_num_seqs) / max_num_seqs
+        if overload_ratio <= 0:
+            return 0.0
+
+        avg_latency = (
+            sum(self._samples) / len(self._samples)
+            if self._samples
+            else self._default
+        )
+
+        return max(0.0, avg_latency * overload_ratio * self._padding)

--- a/infra/cray_infra/api/fastapi/chat_completions/coalescer.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/coalescer.py
@@ -1,0 +1,108 @@
+"""
+Per-process request coalescer for /v1/chat/completions.
+
+Reduces SQLite write amplification by packing up to `packing_factor`
+admitted requests into a single queue row. Under light load (queue
+depth below `bypass_threshold`) every submit flushes immediately so
+small bursts pay no batching tax. Under sustained load, batches form
+naturally and one row holds N requests, giving the queue N× capacity.
+
+See docs/openai-chat-completions-queue.md §6 for the full spec
+including the sizing guidance for `packing_factor`.
+
+Three flush triggers — only one fires for any given batch:
+
+  1. SIZE   — `len(batch) >= packing_factor`
+  2. TIME   — `window_seconds` elapsed since the *first* submit in the
+              current batch. The timer is started on the transition
+              empty → non-empty and is *not* reset by subsequent
+              submits, so the first arrival's worst-case wait is
+              bounded by `window_seconds`.
+  3. BYPASS — queue depth was below `bypass_threshold` at submit time;
+              flush immediately, no timer.
+
+The flush callback is awaited inline. It is the callback's
+responsibility to be fast (e.g. spawn a task for slow I/O and return
+quickly) — submits during a flush queue up on the lock, so a slow
+callback creates head-of-line blocking on the producer side.
+"""
+
+import asyncio
+from typing import Any, Awaitable, Callable, List, Tuple
+
+
+BatchEntry = Tuple[Any, str]
+FlushCallback = Callable[[List[BatchEntry]], Awaitable[None]]
+QueueDepthProvider = Callable[[], int]
+
+
+class Coalescer:
+    def __init__(
+        self,
+        *,
+        packing_factor: int,
+        window_seconds: float,
+        bypass_threshold: int,
+        flush_callback: FlushCallback,
+        queue_depth_provider: QueueDepthProvider,
+    ) -> None:
+        if packing_factor < 1:
+            raise ValueError("packing_factor must be >= 1")
+        if window_seconds < 0:
+            raise ValueError("window_seconds must be >= 0")
+        if bypass_threshold < 0:
+            raise ValueError("bypass_threshold must be >= 0")
+
+        self.packing_factor = packing_factor
+        self.window_seconds = window_seconds
+        self.bypass_threshold = bypass_threshold
+        self._flush_callback = flush_callback
+        self._queue_depth_provider = queue_depth_provider
+
+        self._lock = asyncio.Lock()
+        self._batch: List[BatchEntry] = []
+        self._flush_timer: asyncio.Task | None = None
+
+    async def submit(self, request: Any, correlation_id: str) -> None:
+        async with self._lock:
+            self._batch.append((request, correlation_id))
+
+            if self._queue_depth_provider() < self.bypass_threshold:
+                await self._flush_locked()
+            elif len(self._batch) >= self.packing_factor:
+                await self._flush_locked()
+            elif self._flush_timer is None:
+                self._flush_timer = asyncio.create_task(
+                    self._flush_after(self.window_seconds)
+                )
+
+    async def _flush_after(self, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            return
+        async with self._lock:
+            await self._flush_locked()
+
+    async def _flush_locked(self) -> None:
+        """
+        Drain the accumulator and run the callback. Must be called
+        with `self._lock` held. Cancels any pending flush timer so a
+        size-triggered or bypass-triggered flush doesn't leave a
+        timer about to fire on an empty batch.
+        """
+        if not self._batch:
+            self._cancel_flush_timer()
+            return
+
+        outgoing, self._batch = self._batch, []
+        self._cancel_flush_timer()
+
+        await self._flush_callback(outgoing)
+
+    def _cancel_flush_timer(self) -> None:
+        if self._flush_timer is None:
+            return
+        if not self._flush_timer.done():
+            self._flush_timer.cancel()
+        self._flush_timer = None

--- a/infra/cray_infra/api/fastapi/chat_completions/enqueue_coalesced_batch.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/enqueue_coalesced_batch.py
@@ -40,3 +40,10 @@ async def enqueue_coalesced_batch(batch: List[Tuple[Any, str]]) -> None:
         handle.write(contents)
 
     await push_into_queue(len(requests), path)
+
+    # Record the realized batch size for the chat_batch_size_p50/p99
+    # histogram (docs §13). Imported lazily so this module remains
+    # importable in unit tests that don't pull in metrics state.
+    from cray_infra.generate.metrics import get_metrics
+
+    get_metrics().record_chat_batch_size(len(requests))

--- a/infra/cray_infra/api/fastapi/chat_completions/enqueue_coalesced_batch.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/enqueue_coalesced_batch.py
@@ -1,0 +1,42 @@
+"""
+Coalescer flush callback: turn one in-memory batch into one queue row.
+
+The coalescer hands us a list of `(request_dict, correlation_id)`
+tuples. We serialize the request dicts to a JSON file under
+`upload_base_path`, name the file by the SHA-256 of its contents
+(matching the existing `/v1/generate` upload path's dedup property),
+and call `push_into_queue` to register a single SQLite row pointing
+at that file.
+
+The correlation id for each request is already inside the request
+dict (the handler put it there before submitting to the coalescer)
+so the worker can preserve it across the queue boundary; we don't
+re-store it separately here.
+
+See docs/openai-chat-completions-queue.md §6.3.
+"""
+
+import hashlib
+import json
+import os
+from typing import Any, List, Tuple
+
+from cray_infra.api.work_queue.push_into_queue import push_into_queue
+from cray_infra.util.get_config import get_config
+
+
+async def enqueue_coalesced_batch(batch: List[Tuple[Any, str]]) -> None:
+    if not batch:
+        raise ValueError("enqueue_coalesced_batch received an empty batch")
+
+    requests = [request for request, _cid in batch]
+    contents = json.dumps(requests).encode("utf-8")
+    contents_hash = hashlib.sha256(contents).hexdigest()
+
+    config = get_config()
+    path = os.path.join(config["upload_base_path"], f"{contents_hash}.json")
+
+    with open(path, "wb") as handle:
+        handle.write(contents)
+
+    await push_into_queue(len(requests), path)

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -43,6 +43,7 @@ from cray_infra.api.fastapi.chat_completions.result_router import (
     ResultRouter,
     get_result_router,
 )
+from cray_infra.generate.metrics import get_metrics
 from cray_infra.util.get_config import get_config
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,7 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
             queue_depth=queue_depth,
             max_num_seqs=config["max_num_seqs"],
         )
+        get_metrics().record_chat_rejected_429()
         raise HTTPException(
             status_code=429,
             detail="Server is over capacity; retry after the indicated interval.",
@@ -91,6 +93,7 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
 
     correlation_id = str(uuid4())
     future = router.register(correlation_id)
+    get_metrics().record_chat_admitted(correlation_id)
 
     backend_request = {
         "prompt": rendered_prompt,
@@ -123,6 +126,11 @@ async def _stream_and_unregister(
             yield chunk
     finally:
         router.unregister(correlation_id)
+        # If the worker resolved already, this is a no-op (the cid's
+        # start_time was popped during record_chat_resolved). If the
+        # client disconnected before the worker resolved, this is the
+        # only place that decrements chat_in_flight.
+        get_metrics().record_chat_unregistered(correlation_id)
 
 
 # ---------------------------------------------------------------------------

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -1,0 +1,190 @@
+"""
+FastAPI handler for /v1/chat/completions (non-streaming, queue-backed).
+
+Stream=True requests are delegated to the existing direct-to-vLLM
+proxy (see openai_v1_router.py); only stream=False flows through the
+queue. See docs/openai-chat-completions-queue.md §3.1.
+
+The handler is a thin orchestrator over four foundation pieces:
+
+  1. render_chat_template — turns `messages: [...]` into a prompt str
+  2. is_over_high_water + WaitEstimator — admission decision and 429
+     Retry-After hint
+  3. ResultRouter — registers a correlation_id before submission so
+     the worker has somewhere to deliver the result
+  4. Coalescer — accumulates admitted requests; the configured flush
+     callback (`enqueue_coalesced_batch`) writes one batch as one
+     SQLite row.
+
+The HTTP response is the heartbeat-padded chunked-JSON streamer from
+`heartbeat.py`; the body generator wraps it in a try/finally that
+unregisters the correlation id on completion or client disconnect.
+"""
+
+import logging
+from typing import Any, AsyncIterator
+from uuid import uuid4
+
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from cray_infra.api.fastapi.chat_completions.admission import (
+    WaitEstimator,
+    is_over_high_water,
+)
+from cray_infra.api.fastapi.chat_completions.coalescer import Coalescer
+from cray_infra.api.fastapi.chat_completions.heartbeat import (
+    stream_with_heartbeat,
+)
+from cray_infra.api.fastapi.chat_completions.render_chat_template import (
+    render_chat_template,
+)
+from cray_infra.api.fastapi.chat_completions.result_router import (
+    ResultRouter,
+    get_result_router,
+)
+from cray_infra.util.get_config import get_config
+
+logger = logging.getLogger(__name__)
+
+
+async def chat_completions_via_queue(request: Any) -> StreamingResponse:
+    """
+    Top-level handler. `request` is an OpenAI-compatible
+    ChatCompletionRequest (vllm.entrypoints.openai.protocol or
+    equivalent). The shape is duck-typed: we read `model`, `messages`,
+    `max_tokens`, `temperature`, and `stream`.
+    """
+    if getattr(request, "stream", False):
+        return await proxy_streaming_to_vllm(request)
+
+    # Admission check first: rejecting an overload request before
+    # rendering the chat template avoids paying the (possibly first-
+    # use, multi-second) tokenizer load on requests we're going to
+    # 429 anyway.
+    config = get_config()
+    queue_depth = get_queue_depth()
+    router = get_result_router()
+
+    if is_over_high_water(
+        queue_depth=queue_depth,
+        in_flight_count=router.in_flight_count,
+        max_num_seqs=config["max_num_seqs"],
+        admit_factor=config["chat_admit_factor"],
+    ):
+        wait = get_wait_estimator().estimate_wait_seconds(
+            queue_depth=queue_depth,
+            max_num_seqs=config["max_num_seqs"],
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="Server is over capacity; retry after the indicated interval.",
+            headers={"Retry-After": str(max(1, int(wait)))},
+        )
+
+    rendered_prompt = render_chat_template(
+        model=request.model,
+        messages=request.messages,
+        prompt=None,
+    )
+
+    correlation_id = str(uuid4())
+    future = router.register(correlation_id)
+
+    backend_request = {
+        "prompt": rendered_prompt,
+        "model": request.model,
+        "max_tokens": getattr(request, "max_tokens", None),
+        "temperature": getattr(request, "temperature", None),
+        "request_type": "chat_completion",
+        "correlation_id": correlation_id,
+    }
+
+    await get_coalescer().submit(backend_request, correlation_id)
+
+    return StreamingResponse(
+        _stream_and_unregister(future, correlation_id, router),
+        media_type="application/json",
+    )
+
+
+async def _stream_and_unregister(
+    future,
+    correlation_id: str,
+    router: ResultRouter,
+) -> AsyncIterator[bytes]:
+    """
+    Wrap the heartbeat stream so the cid is always unregistered on
+    completion or generator close (the client-disconnect path).
+    """
+    try:
+        async for chunk in stream_with_heartbeat(future):
+            yield chunk
+    finally:
+        router.unregister(correlation_id)
+
+
+# ---------------------------------------------------------------------------
+# Singletons / wiring. Tests patch these accessors; production wires once.
+# ---------------------------------------------------------------------------
+
+
+_coalescer: Coalescer | None = None
+_wait_estimator: WaitEstimator | None = None
+
+
+def get_coalescer() -> Coalescer:
+    global _coalescer
+    if _coalescer is None:
+        from cray_infra.api.fastapi.chat_completions.enqueue_coalesced_batch import (
+            enqueue_coalesced_batch,
+        )
+
+        config = get_config()
+        _coalescer = Coalescer(
+            packing_factor=config.get("chat_coalescer_packing_factor", 10),
+            window_seconds=config.get("chat_coalescer_window_ms", 50) / 1000.0,
+            bypass_threshold=config.get("chat_coalescer_bypass_threshold", 10),
+            flush_callback=enqueue_coalesced_batch,
+            queue_depth_provider=get_queue_depth,
+        )
+    return _coalescer
+
+
+def get_wait_estimator() -> WaitEstimator:
+    global _wait_estimator
+    if _wait_estimator is None:
+        config = get_config()
+        _wait_estimator = WaitEstimator(
+            default_batch_latency_seconds=config.get(
+                "chat_wait_estimator_default_seconds", 5.0
+            ),
+            padding=config.get("chat_wait_estimator_padding", 1.5),
+            sample_size=config.get("chat_wait_estimator_sample_size", 32),
+        )
+    return _wait_estimator
+
+
+def get_queue_depth() -> int:
+    """
+    Current in-flight inference work (queue + processing). Read from
+    the existing Metrics singleton, which already tracks this counter
+    for /v1/generate.
+    """
+    from cray_infra.generate.metrics import get_metrics
+
+    return get_metrics().queue_depth
+
+
+async def proxy_streaming_to_vllm(request: Any) -> StreamingResponse:
+    """
+    For stream=True clients, hand off to the existing direct-to-vLLM
+    proxy in openai_v1_router. Imported lazily to avoid the router's
+    import-time dependency on vllm-only modules during unit tests of
+    this module.
+    """
+    from cray_infra.api.fastapi.routers.openai_v1_router import (
+        create_chat_completions as _existing_proxy,
+    )
+
+    return await _existing_proxy(request, raw_request=None)

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -50,14 +50,15 @@ logger = logging.getLogger(__name__)
 
 async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     """
-    Top-level handler. `request` is an OpenAI-compatible
-    ChatCompletionRequest (vllm.entrypoints.openai.protocol or
-    equivalent). The shape is duck-typed: we read `model`, `messages`,
-    `max_tokens`, `temperature`, and `stream`.
-    """
-    if getattr(request, "stream", False):
-        return await proxy_streaming_to_vllm(request)
+    Non-streaming chat completions handler. The router (see
+    openai_v1_router.py) is responsible for branching on
+    `request.stream`; this function never sees a streaming request.
 
+    `request` is an OpenAI-compatible ChatCompletionRequest
+    (vllm.entrypoints.openai.protocol or equivalent). The shape is
+    duck-typed: we read `model`, `messages`, `max_tokens`, and
+    `temperature`.
+    """
     # Admission check first: rejecting an overload request before
     # rendering the chat template avoids paying the (possibly first-
     # use, multi-second) tokenizer load on requests we're going to
@@ -176,15 +177,3 @@ def get_queue_depth() -> int:
     return get_metrics().queue_depth
 
 
-async def proxy_streaming_to_vllm(request: Any) -> StreamingResponse:
-    """
-    For stream=True clients, hand off to the existing direct-to-vLLM
-    proxy in openai_v1_router. Imported lazily to avoid the router's
-    import-time dependency on vllm-only modules during unit tests of
-    this module.
-    """
-    from cray_infra.api.fastapi.routers.openai_v1_router import (
-        create_chat_completions as _existing_proxy,
-    )
-
-    return await _existing_proxy(request, raw_request=None)

--- a/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
@@ -1,0 +1,76 @@
+"""
+Shared chat template rendering for /v1/chat/completions and /v1/generate.
+
+A request entry carries either `prompt: str` (raw passthrough) or
+`messages: list[ChatMessage]` (conversation turns of one request).
+This module is the single point that renders the latter into a model
+input string via the model's tokenizer chat template, so both
+endpoints produce byte-identical inputs to vLLM for equivalent
+requests.
+
+See docs/openai-chat-completions-queue.md §4.
+"""
+
+from typing import Any, Dict, List, Optional
+
+ChatMessage = Dict[str, Any]
+
+
+_tokenizer_cache: Dict[str, Any] = {}
+
+
+def render_chat_template(
+    *,
+    model: str,
+    messages: Optional[List[ChatMessage]],
+    prompt: Optional[str],
+) -> str:
+    """
+    Render one request entry into a prompt string.
+
+    Exactly one of `messages` or `prompt` must be a non-empty value.
+    Empty list / empty string are rejected so silent
+    misconfigurations on the caller's side surface as a clear
+    ValueError rather than an opaque tokenizer or vLLM error
+    downstream.
+    """
+    has_messages = bool(messages)
+    has_prompt = bool(prompt)
+
+    if has_messages == has_prompt:
+        raise ValueError(
+            "render_chat_template requires exactly one of `messages` or "
+            "`prompt` to be set; got "
+            f"messages={'present' if has_messages else 'absent'}, "
+            f"prompt={'present' if has_prompt else 'absent'}"
+        )
+
+    if has_prompt:
+        return prompt  # type: ignore[return-value]
+
+    tokenizer = _load_tokenizer(model)
+    return tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
+def _load_tokenizer(model: str) -> Any:
+    """Return a cached tokenizer for `model`, loading on first use."""
+    cached = _tokenizer_cache.get(model)
+    if cached is not None:
+        return cached
+    tokenizer = _load_tokenizer_from_pretrained(model)
+    _tokenizer_cache[model] = tokenizer
+    return tokenizer
+
+
+def _load_tokenizer_from_pretrained(model: str) -> Any:
+    """
+    Indirection point so tests can patch the network/disk-touching call
+    without monkeypatching `transformers.AutoTokenizer` globally.
+    """
+    from transformers import AutoTokenizer
+
+    return AutoTokenizer.from_pretrained(model)

--- a/infra/cray_infra/api/fastapi/chat_completions/render_generate_entry.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/render_generate_entry.py
@@ -1,0 +1,53 @@
+"""
+Render one /v1/generate prompts-array entry into a prompt string.
+
+The /v1/generate endpoint accepts a batch of independent inference
+requests in `prompts: [...]`. Each entry can be one of three shapes:
+
+  - a bare string (legacy raw passthrough),
+  - a dict shaped `{"prompt": str, ...}` (raw passthrough, same
+    semantics as the bare string),
+  - a dict shaped `{"messages": [...], ...}` (chat turns of one
+    request, rendered via the model's tokenizer chat template).
+
+This module is the single dispatch point between those forms. The
+chat-completions handler renders its own (different-shaped) input
+directly via `render_chat_template`; only `/v1/generate` needs the
+per-entry shape disambiguation done here.
+
+See docs/openai-chat-completions-queue.md §10 for the wire contract.
+"""
+
+from typing import Any
+
+from fastapi import HTTPException
+
+from cray_infra.api.fastapi.chat_completions.render_chat_template import (
+    render_chat_template,
+)
+
+
+def render_generate_entry(entry: Any, *, model: str) -> str:
+    if isinstance(entry, str):
+        return entry
+
+    if not isinstance(entry, dict):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "prompts entries must be either a string or a dict with "
+                f"`prompt` or `messages`; got {type(entry).__name__}"
+            ),
+        )
+
+    try:
+        return render_chat_template(
+            model=model,
+            messages=entry.get("messages"),
+            prompt=entry.get("prompt"),
+        )
+    except ValueError as e:
+        # render_chat_template raises ValueError on shape errors
+        # (both/neither set, empty values). Surface as 400 so the
+        # caller learns about the bad request, not a 500.
+        raise HTTPException(status_code=400, detail=str(e))

--- a/infra/cray_infra/api/fastapi/chat_completions/result_router.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/result_router.py
@@ -1,0 +1,70 @@
+"""
+Per-prompt fan-out from the worker back to waiting handlers.
+
+The coalescer assigns each chat request a correlation id (UUID) and
+registers a Future under that id with the router; the FastAPI handler
+awaits that Future. When the worker reports completion via
+`update_and_ack` (`infra/cray_infra/api/fastapi/generate/update_and_ack.py`),
+that path calls `router.resolve(cid, result)` and the handler's
+`asyncio.wait_for` unblocks.
+
+Designed to tolerate the post-disconnect race: a handler that closed
+its connection has already called `unregister(cid)`, so a late
+`resolve(cid, ...)` from the worker silently no-ops instead of raising.
+
+Contract:
+- register(cid)   → Future. Raises KeyError if cid already exists.
+- resolve(cid, x) → set the Future and drop the mapping. Silent if cid
+                    isn't registered (client disconnect raced the
+                    worker).
+- unregister(cid) → drop the mapping without resolving. For the
+                    client-disconnect path; the future is left pending
+                    and falls out of scope with the cancelled task.
+- in_flight_count → current registration count. Used by the admission
+                    controller for backpressure decisions and surfaced
+                    as the `chat_in_flight` gauge (§13).
+
+Single per-process singleton expected; no locking is needed because
+all callers are FastAPI/asyncio coroutines on a single event loop.
+"""
+
+import asyncio
+from typing import Any, Dict
+
+
+class ResultRouter:
+    def __init__(self) -> None:
+        self._futures: Dict[str, asyncio.Future] = {}
+
+    def register(self, correlation_id: str) -> asyncio.Future:
+        if correlation_id in self._futures:
+            raise KeyError(
+                f"correlation_id {correlation_id!r} is already registered"
+            )
+        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._futures[correlation_id] = future
+        return future
+
+    def resolve(self, correlation_id: str, result: Any) -> None:
+        future = self._futures.pop(correlation_id, None)
+        if future is None:
+            return
+        if not future.done():
+            future.set_result(result)
+
+    def unregister(self, correlation_id: str) -> None:
+        self._futures.pop(correlation_id, None)
+
+    @property
+    def in_flight_count(self) -> int:
+        return len(self._futures)
+
+
+_singleton: ResultRouter | None = None
+
+
+def get_result_router() -> ResultRouter:
+    global _singleton
+    if _singleton is None:
+        _singleton = ResultRouter()
+    return _singleton

--- a/infra/cray_infra/api/fastapi/chat_completions/result_router.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/result_router.py
@@ -41,7 +41,11 @@ class ResultRouter:
             raise KeyError(
                 f"correlation_id {correlation_id!r} is already registered"
             )
-        future: asyncio.Future = asyncio.get_event_loop().create_future()
+        # Use the running loop. Production callers (FastAPI handlers,
+        # update_and_ack) are always inside one; if a caller isn't,
+        # surfacing the failure here is more useful than the silent
+        # cross-loop bugs the deprecated `get_event_loop()` produced.
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._futures[correlation_id] = future
         return future
 

--- a/infra/cray_infra/api/fastapi/generate/generate.py
+++ b/infra/cray_infra/api/fastapi/generate/generate.py
@@ -1,3 +1,6 @@
+from cray_infra.api.fastapi.chat_completions.render_generate_entry import (
+    render_generate_entry,
+)
 from cray_infra.api.fastapi.routers.request_types.generate_request import (
     GenerateRequest,
 )
@@ -64,9 +67,14 @@ async def generate(request: GenerateRequest):
     try:
         request_count = 0
 
-        for prompt in prompts:
+        for entry in prompts:
+            # Each entry is independently a bare string, a {"prompt":
+            # str} dict, or a {"messages": [...]} dict; the renderer
+            # produces a model-input string in all three cases. See
+            # docs/openai-chat-completions-queue.md §10.
+            rendered_prompt = render_generate_entry(entry, model=model)
             request = {
-                "prompt": prompt,
+                "prompt": rendered_prompt,
                 "model": model,
                 "max_tokens": max_tokens,
                 "temperature": temperature,

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -106,16 +106,34 @@ async def create_completions(request: CompletionRequest, raw_request: Request):
 
 @openai_v1_router.post("/chat/completions")
 async def create_chat_completions(request: ChatCompletionRequest, raw_request: Request):
-    """Create chat completions - proxy to vLLM server."""
-    config = get_config()
-    params = _filter_params(request.model_dump(mode="json", exclude_none=True), _CHAT_ALLOWED_KEYS)
-    _ensure_usage_reported(params)
-    logger.info("Received chat completions request: %s", params)
-    return _proxy_streaming(
-        upstream_url=config["vllm_api_url"] + "/v1/chat/completions",
-        params=params,
-        endpoint_label="chat completions",
+    """
+    Create chat completions.
+
+    Streaming requests (stream=True) keep the existing direct-to-vLLM
+    SSE proxy — SSE keeps the connection alive natively, so it doesn't
+    need the queue-and-heartbeat machinery. Non-streaming requests go
+    through the new queue path: admission control → coalescer →
+    SQLite InferenceWorkQueue → worker → result router → chunked-JSON
+    heartbeat response. See docs/openai-chat-completions-queue.md §3.1.
+    """
+    if getattr(request, "stream", False):
+        config = get_config()
+        params = _filter_params(request.model_dump(mode="json", exclude_none=True), _CHAT_ALLOWED_KEYS)
+        _ensure_usage_reported(params)
+        logger.info("Received streaming chat completions request: %s", params)
+        return _proxy_streaming(
+            upstream_url=config["vllm_api_url"] + "/v1/chat/completions",
+            params=params,
+            endpoint_label="chat completions",
+        )
+
+    # Non-streaming path: queue-backed with admission control and
+    # whitespace-heartbeat transport.
+    from cray_infra.api.fastapi.chat_completions.handler import (
+        chat_completions_via_queue,
     )
+
+    return await chat_completions_via_queue(request)
 
 
 # ---------------------------------------------------------------------------

--- a/infra/cray_infra/api/fastapi/routers/request_types/generate_request.py
+++ b/infra/cray_infra/api/fastapi/routers/request_types/generate_request.py
@@ -1,11 +1,26 @@
 from pydantic import BaseModel
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 
 class GenerateRequest(BaseModel):
     model: Optional[str] = None
-    prompts: list[Union[str, dict[str, Union[str, list[str]]]]]
+    # A batch of independent inference requests. Each entry is one of:
+    #   - a bare string                              (legacy raw prompt)
+    #   - {"prompt": "..."}                          (raw, dict form)
+    #   - {"messages": [{"role": ..., "content": ...}, ...]}
+    #                                                (chat turns;
+    #                                                 rendered via
+    #                                                 the model's
+    #                                                 chat template
+    #                                                 at enqueue time
+    #                                                 — see docs/
+    #                                                 openai-chat-
+    #                                                 completions-
+    #                                                 queue.md §10)
+    # The dict variant carries the per-entry shape; render_generate_entry
+    # is the single point that validates and renders.
+    prompts: list[Union[str, dict[str, Any]]]
     max_tokens: Optional[int] = 16
     temperature: Optional[float] = 0.0
     tools: Optional[list] = None

--- a/infra/cray_infra/api/work_queue/correlation_id_map.py
+++ b/infra/cray_infra/api/work_queue/correlation_id_map.py
@@ -1,0 +1,40 @@
+"""
+Per-process map from per-prompt request_id to chat-completions
+correlation_id.
+
+The chat-completions handler attaches a `correlation_id` to each
+queued request before serializing it to disk. When the worker pulls
+the batch and begins dispatching prompts, `fill_work_queue` calls
+`stash_correlation_id(request_id, cid)` for each one that carries a
+cid. When `update_and_ack` records a result, it calls
+`pop_correlation_id(request_id)` and, if non-None, resolves the
+ResultRouter future for that cid.
+
+The map is process-local and ephemeral; it is not durable across
+restarts. That is fine — on restart the result router is also empty
+(clients have all retried or disconnected), so the cid lookup
+correctly returns None and no resolve happens. The eventual response
+file on disk handles client reconnection via the existing
+`/v1/generate/get_results` polling path.
+
+`/v1/generate` requests don't carry a correlation_id; for those,
+`pop_correlation_id` always returns None and `update_and_ack`'s hook
+becomes a no-op. The two endpoint paths share update_and_ack without
+behavioral interference.
+"""
+
+import asyncio
+from typing import Dict, Optional
+
+_lock = asyncio.Lock()
+_map: Dict[str, str] = {}
+
+
+async def stash_correlation_id(request_id: str, correlation_id: str) -> None:
+    async with _lock:
+        _map[request_id] = correlation_id
+
+
+async def pop_correlation_id(request_id: str) -> Optional[str]:
+    async with _lock:
+        return _map.pop(request_id, None)

--- a/infra/cray_infra/api/work_queue/get_work_item.py
+++ b/infra/cray_infra/api/work_queue/get_work_item.py
@@ -1,4 +1,5 @@
 from cray_infra.api.work_queue.acquire_file_lock import acquire_file_lock
+from cray_infra.api.work_queue.correlation_id_map import stash_correlation_id
 
 from cray_infra.api.work_queue.group_request_id_to_status_path import (
     group_request_id_to_status_path,
@@ -95,6 +96,20 @@ async def fill_work_queue(work_queue):
                 (request, make_id(group_request_id, index))
                 for index, request in enumerate(requests)
             ]
+
+            # Stash chat-completions correlation_ids from this batch
+            # so update_and_ack can later resolve the per-prompt
+            # ResultRouter future. Generate-path entries (no cid) are
+            # skipped — pop_correlation_id will return None for them
+            # and the resolve hook becomes a no-op.
+            for index, batch_request in enumerate(requests):
+                if not isinstance(batch_request, dict):
+                    continue
+                cid = batch_request.get("correlation_id")
+                if cid:
+                    await stash_correlation_id(
+                        make_id(group_request_id, index), cid
+                    )
 
             break
 

--- a/infra/cray_infra/api/work_queue/update_and_ack.py
+++ b/infra/cray_infra/api/work_queue/update_and_ack.py
@@ -1,4 +1,8 @@
+from cray_infra.api.fastapi.chat_completions.result_router import (
+    get_result_router,
+)
 from cray_infra.api.work_queue.acquire_file_lock import acquire_file_lock
+from cray_infra.api.work_queue.correlation_id_map import pop_correlation_id
 from cray_infra.api.work_queue.group_request_id_to_response_path import (
     group_request_id_to_response_path,
 )
@@ -43,6 +47,16 @@ async def update_and_ack(inference_work_queue, request_id, item):
 
     in_memory_results["results"][request_id] = item
     in_memory_results["results"][request_id]["is_acked"] = True
+
+    # Resolve the chat-completions ResultRouter future if this
+    # request_id was tagged with a correlation_id at fill_work_queue
+    # time. /v1/generate requests carry no cid; pop returns None and
+    # this becomes a no-op for them. A late completion whose handler
+    # already disconnected also pops fine — router.resolve is silent
+    # for unregistered cids.
+    correlation_id = await pop_correlation_id(request_id)
+    if correlation_id is not None:
+        get_result_router().resolve(correlation_id, item)
 
     if in_memory_results["current_index"] >= in_memory_results["total_requests"]:
         await finish_work_queue_item(request_id, inference_work_queue, in_memory_results)

--- a/infra/cray_infra/api/work_queue/update_and_ack.py
+++ b/infra/cray_infra/api/work_queue/update_and_ack.py
@@ -57,6 +57,12 @@ async def update_and_ack(inference_work_queue, request_id, item):
     correlation_id = await pop_correlation_id(request_id)
     if correlation_id is not None:
         get_result_router().resolve(correlation_id, item)
+        # Recording the duration here happens at the same instant the
+        # router future resolves — close enough to "user-perceived
+        # delivery" without instrumenting the chunked-JSON byte writer.
+        from cray_infra.generate.metrics import get_metrics
+
+        get_metrics().record_chat_resolved(correlation_id)
 
     if in_memory_results["current_index"] >= in_memory_results["total_requests"]:
         await finish_work_queue_item(request_id, inference_work_queue, in_memory_results)

--- a/infra/cray_infra/generate/metrics.py
+++ b/infra/cray_infra/generate/metrics.py
@@ -1,6 +1,7 @@
 
 import time
 from collections import deque
+from typing import Dict
 
 generate_metrics = None
 
@@ -11,9 +12,19 @@ generate_metrics = None
 # between polls and rendered a flat sparkline.
 RATE_WINDOW_SECONDS = 60.0
 
+# Bounded sample window for chat batch-size and request-duration
+# histograms. Big enough for stable p50/p99 under realistic QPS, small
+# enough that an O(n log n) sort at read time is trivial.
+CHAT_HISTOGRAM_SAMPLE_SIZE = 1024
+
 
 class Metrics:
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        buffering_check_proxy_timeout_seconds: float = 60.0,
+        buffering_match_threshold_seconds: float = 0.5,
+    ):
         self.queue_depth = 0
         # Concurrent OpenAI-streaming requests in flight. Driven by
         # _wrap_with_metrics in openai_v1_router.py; that path doesn't
@@ -32,6 +43,21 @@ class Metrics:
         # Per-completion window: (timestamp, tokens, flops). Pruned
         # to the last RATE_WINDOW_SECONDS in get_all_metrics.
         self._rate_window: deque = deque()
+
+        # ----- chat-completions metrics (docs §13) -----
+        # Six metrics surfaced through get_all_metrics. The chat path
+        # is independent of the SDK path's queue_depth bookkeeping;
+        # nothing here mutates the existing /v1/generate counters.
+        self.chat_in_flight: int = 0
+        self.chat_admitted_429_count: int = 0
+        self.chat_total_count: int = 0
+        self.chat_apparent_buffering_count: int = 0
+        self._chat_batch_sizes: deque = deque(maxlen=CHAT_HISTOGRAM_SAMPLE_SIZE)
+        self._chat_request_durations: deque = deque(maxlen=CHAT_HISTOGRAM_SAMPLE_SIZE)
+        self._chat_start_times: Dict[str, float] = {}
+
+        self._buffering_proxy_timeout = buffering_check_proxy_timeout_seconds
+        self._buffering_match_threshold = buffering_match_threshold_seconds
 
     def record_completed_request(self, token_count: int, flop_count: int):
         """
@@ -82,6 +108,64 @@ class Metrics:
         if self.streaming_inflight > 0:
             self.streaming_inflight -= 1
 
+    # ------------------------------------------------------------------
+    # Chat-completions metrics (docs §13)
+    # ------------------------------------------------------------------
+
+    def record_chat_admitted(self, correlation_id: str) -> None:
+        """Handler admitted a request: in_flight++, total++, log start time."""
+        self.record_chat_admitted_with_clock(correlation_id, start_time=time.time())
+
+    def record_chat_admitted_with_clock(
+        self, correlation_id: str, *, start_time: float
+    ) -> None:
+        """Test seam — same as record_chat_admitted but takes the clock value."""
+        self.chat_in_flight += 1
+        self.chat_total_count += 1
+        self._chat_start_times[correlation_id] = start_time
+
+    def record_chat_rejected_429(self) -> None:
+        """Admission denied a request with 429."""
+        self.chat_admitted_429_count += 1
+        self.chat_total_count += 1
+
+    def record_chat_resolved(self, correlation_id: str) -> None:
+        """Worker delivered a result for an admitted request."""
+        self.record_chat_resolved_with_clock(correlation_id, end_time=time.time())
+
+    def record_chat_resolved_with_clock(
+        self, correlation_id: str, *, end_time: float
+    ) -> None:
+        start = self._chat_start_times.pop(correlation_id, None)
+        if start is None:
+            # Unknown cid — admitted before this Metrics instance
+            # existed, or already cleaned up. Don't underflow in_flight.
+            return
+
+        if self.chat_in_flight > 0:
+            self.chat_in_flight -= 1
+
+        duration = max(0.0, end_time - start)
+        self._chat_request_durations.append(duration)
+
+        # Apparent-buffering heuristic: if the request landed within
+        # `match_threshold` of a known proxy idle timeout, flag it.
+        # See docs §13.2 — this is a signal, not a strict measurement.
+        if abs(duration - self._buffering_proxy_timeout) <= self._buffering_match_threshold:
+            self.chat_apparent_buffering_count += 1
+
+    def record_chat_unregistered(self, correlation_id: str) -> None:
+        """Client disconnected before resolution — drop the in_flight slot."""
+        if self._chat_start_times.pop(correlation_id, None) is None:
+            return
+        if self.chat_in_flight > 0:
+            self.chat_in_flight -= 1
+
+    def record_chat_batch_size(self, size: int) -> None:
+        """Coalescer flushed a batch of `size` requests as one queue row."""
+        if size > 0:
+            self._chat_batch_sizes.append(size)
+
     def get_all_metrics(self, sdk_queue_depth=None):
         """
         Get the current metrics.
@@ -109,6 +193,20 @@ class Metrics:
             "token/s": token_rate,
             "request/s": request_rate,
             "flop/s": flop_rate,
+            # Chat-completions metrics (docs §13).
+            "chat_in_flight": self.chat_in_flight,
+            "chat_admitted_429_count": self.chat_admitted_429_count,
+            "chat_total_count": self.chat_total_count,
+            "chat_admitted_429_rate": (
+                self.chat_admitted_429_count / self.chat_total_count
+                if self.chat_total_count
+                else 0.0
+            ),
+            "chat_batch_size_p50": _percentile(self._chat_batch_sizes, 50),
+            "chat_batch_size_p99": _percentile(self._chat_batch_sizes, 99),
+            "chat_request_duration_p50": _percentile(self._chat_request_durations, 50),
+            "chat_request_duration_p99": _percentile(self._chat_request_durations, 99),
+            "chat_apparent_buffering_count": self.chat_apparent_buffering_count,
         }
 
     def _windowed_rates(self):
@@ -153,3 +251,13 @@ def get_metrics() -> Metrics:
     if generate_metrics is None:
         generate_metrics = Metrics()
     return generate_metrics
+
+
+def _percentile(samples, percentile: int):
+    """Simple percentile over a small bounded window. O(n log n) per
+    read, called only from get_all_metrics, n <= CHAT_HISTOGRAM_SAMPLE_SIZE."""
+    if not samples:
+        return 0
+    ordered = sorted(samples)
+    k = min(int(len(ordered) * percentile / 100), len(ordered) - 1)
+    return ordered[k]

--- a/infra/cray_infra/util/default_config.py
+++ b/infra/cray_infra/util/default_config.py
@@ -82,3 +82,45 @@ class Config(BaseModel):
     hf_encrypted_token: bytes = b"gAAAAABpyvSQu2QUlUfp-YavLwueXqCU0j2Lhe9Lddij4B-qV3JngfcH4uCtjVGXlWAyM2o91nZXhsS3B3q3zKNiLxnxhFpJd0ddbwWPysez2OpZX4jTFOA9-xjQVk454A_qk6pdJxMv"
     encryption_key: bytes = b"JAJOZunNSRFeXWXWVVVJfiKSzdzFMw0yFn8_JK50h60="
 
+    # ------------------------------------------------------------------
+    # OpenAI chat-completions queue (docs/openai-chat-completions-queue.md)
+    # ------------------------------------------------------------------
+
+    # Mirrors vLLM's --max-num-seqs. Chat admission threshold is a
+    # multiple of this. Kept in scalarlm config so admission decisions
+    # don't round-trip to vLLM at request time.
+    max_num_seqs: int = 256
+
+    # Admission high-water mark = chat_admit_factor × max_num_seqs.
+    # Beyond this, requests get HTTP 429 + Retry-After. See §5.
+    chat_admit_factor: int = 4
+
+    # Coalescer (§6) — packs admitted requests into one queue row to
+    # amortize SQLite write cost. packing_factor is the primary
+    # throughput knob (§6.3): start here, raise if 429 rate climbs.
+    chat_coalescer_packing_factor: int = 10
+    chat_coalescer_window_ms: int = 50
+    chat_coalescer_bypass_threshold: int = 10
+
+    # Whitespace heartbeat interval (§9). 4 s is below httpx's default
+    # 5 s read timeout, leaving margin for slow clocks / event-loop
+    # jitter without the caller seeing an idle gap.
+    chat_heartbeat_interval_seconds: float = 4.0
+
+    # Optional cap on per-request total time. Unset by default — the
+    # queue's existing ack-timeout (inference-queue.md §5.2) provides
+    # a backstop for stuck batches.
+    chat_max_request_seconds: Optional[float] = None
+
+    # WaitEstimator (§5). Used for the Retry-After hint on 429.
+    chat_wait_estimator_default_seconds: float = 5.0
+    chat_wait_estimator_padding: float = 1.5
+    chat_wait_estimator_sample_size: int = 32
+
+    # Apparent-buffering heuristic (§13.2). Flags requests whose
+    # duration falls within `match_threshold_seconds` of a known
+    # proxy idle timeout — strong signal that an upstream proxy is
+    # buffering responses despite our heartbeats.
+    chat_buffering_check_proxy_timeout_seconds: float = 60.0
+    chat_buffering_match_threshold_seconds: float = 0.5
+

--- a/test/unit/test_admission.py
+++ b/test/unit/test_admission.py
@@ -1,0 +1,121 @@
+"""
+Unit tests for admission control.
+
+Two pieces:
+
+  - is_over_high_water — pure function, checks (queue_depth +
+    in_flight_count) against (admit_factor × max_num_seqs).
+  - WaitEstimator — moving average of recent batch latencies, returned
+    as the Retry-After hint when admission is denied.
+
+See docs/openai-chat-completions-queue.md §5.
+"""
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions.admission import (
+    WaitEstimator,
+    is_over_high_water,
+)
+
+
+# ---- is_over_high_water ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "queue_depth, in_flight, max_num_seqs, admit_factor, expected",
+    [
+        # Below threshold
+        (0, 0, 256, 4, False),
+        (100, 100, 256, 4, False),
+        # Exactly at threshold (not "over")
+        (1024, 0, 256, 4, False),
+        (512, 512, 256, 4, False),
+        # Just over threshold
+        (1025, 0, 256, 4, True),
+        (513, 512, 256, 4, True),
+        # Way over
+        (10000, 0, 256, 4, True),
+        # admit_factor=1 (queue capped at max_num_seqs)
+        (256, 0, 256, 1, False),
+        (257, 0, 256, 1, True),
+    ],
+)
+def test_is_over_high_water(
+    queue_depth, in_flight, max_num_seqs, admit_factor, expected
+):
+    assert (
+        is_over_high_water(
+            queue_depth=queue_depth,
+            in_flight_count=in_flight,
+            max_num_seqs=max_num_seqs,
+            admit_factor=admit_factor,
+        )
+        is expected
+    )
+
+
+# ---- WaitEstimator ---------------------------------------------------------
+
+
+def test_no_samples_uses_default_latency():
+    est = WaitEstimator(default_batch_latency_seconds=2.0, padding=1.5)
+    # Overload ratio = (queue_depth - max_num_seqs) / max_num_seqs = 1.0
+    # Estimate = 2.0 * 1.0 * 1.5 = 3.0
+    assert est.estimate_wait_seconds(queue_depth=512, max_num_seqs=256) == pytest.approx(3.0)
+
+
+def test_below_capacity_returns_zero_wait():
+    """If queue depth is ≤ max_num_seqs, no overload — wait is zero."""
+    est = WaitEstimator()
+    assert est.estimate_wait_seconds(queue_depth=100, max_num_seqs=256) == 0
+    assert est.estimate_wait_seconds(queue_depth=256, max_num_seqs=256) == 0
+
+
+def test_recorded_samples_drive_moving_average():
+    est = WaitEstimator(default_batch_latency_seconds=999.0, padding=1.0)
+    for s in [1.0, 2.0, 3.0]:
+        est.record_batch_latency_seconds(s)
+    # Average = 2.0; overload = 1.0; padding = 1.0; expected = 2.0
+    assert est.estimate_wait_seconds(queue_depth=512, max_num_seqs=256) == pytest.approx(2.0)
+
+
+def test_padding_is_applied():
+    est = WaitEstimator(default_batch_latency_seconds=4.0, padding=1.5)
+    # 4.0 * 1.0 * 1.5 = 6.0
+    assert est.estimate_wait_seconds(queue_depth=512, max_num_seqs=256) == pytest.approx(6.0)
+
+
+def test_overload_ratio_scales_linearly():
+    """A 4× overload yields a 4× larger wait than a 1× overload."""
+    est = WaitEstimator(default_batch_latency_seconds=1.0, padding=1.0)
+
+    one_x = est.estimate_wait_seconds(queue_depth=512, max_num_seqs=256)
+    four_x = est.estimate_wait_seconds(queue_depth=1280, max_num_seqs=256)
+
+    assert four_x == pytest.approx(4 * one_x)
+
+
+def test_sample_window_caps_history():
+    """
+    Old samples must roll off so the estimate tracks recent reality,
+    not the entire run history.
+    """
+    est = WaitEstimator(
+        default_batch_latency_seconds=999.0,
+        padding=1.0,
+        sample_size=4,
+    )
+    # Five samples; only the last four count.
+    est.record_batch_latency_seconds(100.0)  # rolled off
+    for s in [1.0, 2.0, 3.0, 4.0]:
+        est.record_batch_latency_seconds(s)
+    # Expected average = (1+2+3+4)/4 = 2.5
+    assert est.estimate_wait_seconds(queue_depth=512, max_num_seqs=256) == pytest.approx(2.5)
+
+
+def test_estimate_is_non_negative():
+    """A misconfiguration shouldn't ever produce a negative Retry-After."""
+    est = WaitEstimator(default_batch_latency_seconds=-5.0)
+    # Even with a nonsense default, the result clamps to >= 0.
+    assert est.estimate_wait_seconds(queue_depth=512, max_num_seqs=256) >= 0

--- a/test/unit/test_chat_completions_config_defaults.py
+++ b/test/unit/test_chat_completions_config_defaults.py
@@ -1,0 +1,54 @@
+"""
+Pin the chat-completions config defaults to the values documented in
+docs/openai-chat-completions-queue.md §6.2, §12, §13.3.
+
+Defaults that drift unnoticed are how a config-driven knob silently
+changes behavior in production. Each value in the design doc has its
+own assertion here so a change in default forces a doc update too.
+"""
+
+from cray_infra.util.default_config import Config
+
+
+def test_max_num_seqs_default():
+    """vLLM's max_num_seqs default; the chat admission threshold scales off this."""
+    assert Config().max_num_seqs == 256
+
+
+def test_chat_admit_factor_default():
+    assert Config().chat_admit_factor == 4
+
+
+def test_chat_coalescer_packing_factor_default():
+    """Primary throughput knob — see docs §6.3."""
+    assert Config().chat_coalescer_packing_factor == 10
+
+
+def test_chat_coalescer_window_ms_default():
+    assert Config().chat_coalescer_window_ms == 50
+
+
+def test_chat_coalescer_bypass_threshold_default():
+    """Defaulted equal to packing_factor on purpose — see docs §6.2."""
+    cfg = Config()
+    assert cfg.chat_coalescer_bypass_threshold == 10
+    assert cfg.chat_coalescer_bypass_threshold == cfg.chat_coalescer_packing_factor
+
+
+def test_chat_heartbeat_interval_seconds_default():
+    """Below httpx's default read timeout (5s) by design — see docs §9.1."""
+    assert Config().chat_heartbeat_interval_seconds == 4
+
+
+def test_chat_wait_estimator_defaults():
+    cfg = Config()
+    assert cfg.chat_wait_estimator_default_seconds == 5.0
+    assert cfg.chat_wait_estimator_padding == 1.5
+    assert cfg.chat_wait_estimator_sample_size == 32
+
+
+def test_chat_buffering_detection_defaults():
+    """Heuristic for §13.2 apparent-buffering detection."""
+    cfg = Config()
+    assert cfg.chat_buffering_check_proxy_timeout_seconds == 60
+    assert cfg.chat_buffering_match_threshold_seconds == 0.5

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -1,0 +1,216 @@
+"""
+Unit tests for chat_completions_via_queue.
+
+The handler ties together the four foundation pieces (renderer,
+admission, router, coalescer) and returns a StreamingResponse backed
+by the heartbeat helper. Tests mock the singletons so the flow can be
+exercised without uvicorn / SQLite / a real model.
+
+Contract (see docs/openai-chat-completions-queue.md §5):
+- Renders the request via render_chat_template before queueing.
+- 429 with Retry-After when admission threshold is exceeded.
+- Registers a correlation_id with the result router *before*
+  submitting to the coalescer so the worker can never resolve a cid
+  the router doesn't yet know about.
+- Returns a StreamingResponse with media_type=application/json.
+- The streaming generator unregisters the cid on completion or
+  cancellation (verified by the disconnect test).
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from cray_infra.api.fastapi.chat_completions import handler as h
+from cray_infra.api.fastapi.chat_completions.admission import WaitEstimator
+from cray_infra.api.fastapi.chat_completions.result_router import ResultRouter
+
+
+def _request(messages=None, prompt_text=None, stream=False, **overrides):
+    """Build a minimal ChatCompletionRequest-shaped MagicMock."""
+    if messages is None and prompt_text is None:
+        messages = [{"role": "user", "content": "hi"}]
+
+    req = MagicMock()
+    req.model = overrides.get("model", "test-model")
+    req.messages = messages
+    req.max_tokens = overrides.get("max_tokens", 64)
+    req.temperature = overrides.get("temperature", 0.7)
+    req.stream = stream
+    return req
+
+
+@pytest.fixture
+def fresh_router():
+    return ResultRouter()
+
+
+@pytest.fixture
+def fresh_estimator():
+    return WaitEstimator(default_batch_latency_seconds=2.0, padding=1.5)
+
+
+@pytest.fixture
+def patched_components(fresh_router, fresh_estimator):
+    """
+    Patch the four singleton accessors the handler reaches through.
+    Returns the mock coalescer and a "queue depth" you can mutate
+    per-test.
+    """
+    coalescer = MagicMock()
+    coalescer.submit = AsyncMock()
+
+    queue_depth_holder = {"value": 0}
+    fake_config = {
+        "max_num_seqs": 256,
+        "chat_admit_factor": 4,
+    }
+
+    with patch.object(h, "get_result_router", return_value=fresh_router), \
+         patch.object(h, "get_coalescer", return_value=coalescer), \
+         patch.object(h, "get_wait_estimator", return_value=fresh_estimator), \
+         patch.object(h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]), \
+         patch.object(h, "get_config", return_value=fake_config), \
+         patch.object(h, "render_chat_template", return_value="rendered-prompt"):
+        yield {
+            "coalescer": coalescer,
+            "queue_depth": queue_depth_holder,
+            "router": fresh_router,
+            "estimator": fresh_estimator,
+            "config": fake_config,
+        }
+
+
+@pytest.mark.asyncio
+async def test_returns_streaming_response_under_threshold(patched_components):
+    response = await h.chat_completions_via_queue(_request())
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_renders_messages_through_chat_template(patched_components):
+    with patch.object(
+        h, "render_chat_template", return_value="USER: hi\nASSISTANT: "
+    ) as render:
+        await h.chat_completions_via_queue(
+            _request(messages=[{"role": "user", "content": "hi"}])
+        )
+    render.assert_called_once()
+    kwargs = render.call_args.kwargs
+    assert kwargs["model"] == "test-model"
+    assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+    assert kwargs["prompt"] is None
+
+
+@pytest.mark.asyncio
+async def test_registers_correlation_id_before_submitting(patched_components):
+    """
+    Submission must happen *after* router.register so the worker can
+    never resolve a cid that doesn't exist yet.
+    """
+    submit_order: list = []
+
+    coalescer = patched_components["coalescer"]
+
+    async def record_submit(req, cid):
+        submit_order.append(("submit", cid, patched_components["router"].in_flight_count))
+
+    coalescer.submit = AsyncMock(side_effect=record_submit)
+
+    with patch.object(h, "render_chat_template", return_value="rendered"):
+        await h.chat_completions_via_queue(_request())
+
+    assert len(submit_order) == 1
+    _, _, in_flight_at_submit = submit_order[0]
+    # The router was incremented before the submit ran.
+    assert in_flight_at_submit == 1
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_passed_to_coalescer_matches_request_payload(patched_components):
+    """The correlation_id is in the request dict AND the coalescer sees it as the second arg."""
+    coalescer = patched_components["coalescer"]
+
+    captured: list = []
+
+    async def capture(req, cid):
+        captured.append((req, cid))
+
+    coalescer.submit = AsyncMock(side_effect=capture)
+
+    with patch.object(h, "render_chat_template", return_value="rendered"):
+        await h.chat_completions_via_queue(_request())
+
+    assert len(captured) == 1
+    req, cid = captured[0]
+    assert req["correlation_id"] == cid
+    assert req["prompt"] == "rendered"
+    assert req["request_type"] == "chat_completion"
+
+
+@pytest.mark.asyncio
+async def test_429_when_over_high_water(patched_components):
+    """queue_depth > 4 × max_num_seqs (1024) trips the threshold."""
+    patched_components["queue_depth"]["value"] = 1025
+
+    with pytest.raises(HTTPException) as exc_info:
+        await h.chat_completions_via_queue(_request())
+
+    assert exc_info.value.status_code == 429
+    retry_after = exc_info.value.headers.get("Retry-After")
+    assert retry_after is not None
+    assert int(retry_after) >= 1
+
+
+@pytest.mark.asyncio
+async def test_429_does_not_register_correlation_id(patched_components):
+    """A rejected request must leave no leak in the router."""
+    patched_components["queue_depth"]["value"] = 9999
+
+    with pytest.raises(HTTPException):
+        await h.chat_completions_via_queue(_request())
+
+    assert patched_components["router"].in_flight_count == 0
+
+
+@pytest.mark.asyncio
+async def test_streaming_request_bypasses_queue_path(patched_components):
+    """stream=True clients are routed elsewhere (existing direct-to-vLLM path)."""
+    coalescer = patched_components["coalescer"]
+    coalescer.submit = AsyncMock()
+
+    sentinel = MagicMock(name="streaming-response")
+
+    with patch.object(
+        h, "proxy_streaming_to_vllm", new_callable=AsyncMock, return_value=sentinel
+    ) as proxy:
+        out = await h.chat_completions_via_queue(_request(stream=True))
+
+    assert out is sentinel
+    proxy.assert_awaited_once()
+    coalescer.submit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_stream_unregisters_cid(patched_components):
+    """
+    The streaming generator's `finally` must unregister the cid even
+    if the generator is closed early (client disconnect → FastAPI
+    cancels the body iterator).
+    """
+    with patch.object(h, "render_chat_template", return_value="rendered"):
+        response = await h.chat_completions_via_queue(_request())
+
+    router = patched_components["router"]
+    assert router.in_flight_count == 1
+
+    # Drive the generator partially then close it (mimics client
+    # disconnect: FastAPI calls `aclose()` on the iterator).
+    gen = response.body_iterator
+    await gen.__anext__()  # consume one heartbeat
+    await gen.aclose()
+
+    assert router.in_flight_count == 0

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -177,24 +177,6 @@ async def test_429_does_not_register_correlation_id(patched_components):
 
 
 @pytest.mark.asyncio
-async def test_streaming_request_bypasses_queue_path(patched_components):
-    """stream=True clients are routed elsewhere (existing direct-to-vLLM path)."""
-    coalescer = patched_components["coalescer"]
-    coalescer.submit = AsyncMock()
-
-    sentinel = MagicMock(name="streaming-response")
-
-    with patch.object(
-        h, "proxy_streaming_to_vllm", new_callable=AsyncMock, return_value=sentinel
-    ) as proxy:
-        out = await h.chat_completions_via_queue(_request(stream=True))
-
-    assert out is sentinel
-    proxy.assert_awaited_once()
-    coalescer.submit.assert_not_called()
-
-
-@pytest.mark.asyncio
 async def test_disconnect_during_stream_unregisters_cid(patched_components):
     """
     The streaming generator's `finally` must unregister the cid even

--- a/test/unit/test_chat_metrics.py
+++ b/test/unit/test_chat_metrics.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for the chat-completions metrics added to the Metrics
+singleton at cray_infra/generate/metrics.py. See docs/openai-chat-
+completions-queue.md §13.
+
+Six metrics:
+  - chat_in_flight (gauge)
+  - chat_admitted_429_count (counter)
+  - chat_total_count (counter, denominator for the 429 rate)
+  - chat_batch_size_p50/p99 (computed from a bounded sample window)
+  - chat_request_duration_p50/p99 (computed from a bounded sample window)
+  - chat_apparent_buffering_count (heuristic; counts requests whose
+    duration falls within a tolerance of a known proxy idle timeout)
+"""
+
+import time
+
+import pytest
+
+from cray_infra.generate.metrics import Metrics
+
+
+def _exposed(metrics: Metrics) -> dict:
+    return metrics.get_all_metrics()
+
+
+def test_chat_admitted_increments_in_flight_and_total():
+    m = Metrics()
+    m.record_chat_admitted("cid-1")
+    m.record_chat_admitted("cid-2")
+
+    snapshot = _exposed(m)
+    assert snapshot["chat_in_flight"] == 2
+    assert snapshot["chat_total_count"] == 2
+    assert snapshot["chat_admitted_429_count"] == 0
+
+
+def test_chat_rejected_increments_429_and_total():
+    m = Metrics()
+    m.record_chat_rejected_429()
+    m.record_chat_rejected_429()
+    m.record_chat_rejected_429()
+
+    snapshot = _exposed(m)
+    assert snapshot["chat_admitted_429_count"] == 3
+    assert snapshot["chat_total_count"] == 3
+    assert snapshot["chat_in_flight"] == 0
+
+
+def test_chat_resolved_decrements_in_flight_and_records_duration():
+    m = Metrics()
+    m.record_chat_admitted("cid-1")
+    time.sleep(0.01)
+    m.record_chat_resolved("cid-1")
+
+    snapshot = _exposed(m)
+    assert snapshot["chat_in_flight"] == 0
+    assert snapshot["chat_request_duration_p50"] >= 0.005
+
+
+def test_chat_unregistered_decrements_in_flight_without_duration():
+    """Client disconnect: in_flight decrements; no duration sample logged."""
+    m = Metrics()
+    m.record_chat_admitted("cid-1")
+    m.record_chat_unregistered("cid-1")
+
+    snapshot = _exposed(m)
+    assert snapshot["chat_in_flight"] == 0
+    # No duration was recorded — the request didn't complete from
+    # the user's perspective.
+    assert snapshot["chat_request_duration_p50"] == 0
+
+
+def test_chat_resolved_for_unknown_cid_is_noop():
+    """A late resolve for an already-unregistered cid must not raise."""
+    m = Metrics()
+    m.record_chat_resolved("never-admitted")
+    snapshot = _exposed(m)
+    assert snapshot["chat_in_flight"] == 0
+
+
+def test_chat_batch_size_percentiles():
+    m = Metrics()
+    for size in [1, 1, 1, 5, 5, 10, 10, 10, 10, 10]:
+        m.record_chat_batch_size(size)
+
+    snapshot = _exposed(m)
+    assert 1 <= snapshot["chat_batch_size_p50"] <= 10
+    assert snapshot["chat_batch_size_p99"] == 10
+
+
+def test_chat_request_duration_percentiles_grow_with_samples():
+    m = Metrics()
+
+    # Synthesize duration samples by admitting + resolving with a
+    # known fake clock through the public hooks.
+    for fake_duration in [0.05, 0.10, 0.50, 1.00, 5.00]:
+        m.record_chat_admitted_with_clock("cid", start_time=0.0)
+        m.record_chat_resolved_with_clock("cid", end_time=fake_duration)
+
+    snapshot = _exposed(m)
+    assert snapshot["chat_request_duration_p50"] > 0
+    assert snapshot["chat_request_duration_p99"] >= snapshot["chat_request_duration_p50"]
+
+
+def test_apparent_buffering_increments_within_tolerance():
+    """
+    A request whose duration lands within tolerance of the configured
+    proxy timeout is flagged. See §13.2.
+    """
+    m = Metrics(
+        buffering_check_proxy_timeout_seconds=60.0,
+        buffering_match_threshold_seconds=0.5,
+    )
+
+    # Inside tolerance
+    m.record_chat_admitted_with_clock("cid-a", start_time=0.0)
+    m.record_chat_resolved_with_clock("cid-a", end_time=60.2)
+
+    # Outside tolerance
+    m.record_chat_admitted_with_clock("cid-b", start_time=0.0)
+    m.record_chat_resolved_with_clock("cid-b", end_time=30.0)
+
+    snapshot = _exposed(m)
+    assert snapshot["chat_apparent_buffering_count"] == 1
+
+
+def test_metrics_isolated_from_existing_counters():
+    """
+    Existing /v1/generate counters (queue_depth, total_completed_*)
+    must not be affected by chat-only updates. This is the regression
+    test for "did we accidentally bump queue_depth from the chat path."
+    """
+    m = Metrics()
+    m.record_chat_admitted("cid")
+    m.record_chat_rejected_429()
+    m.record_chat_resolved("cid")
+    m.record_chat_batch_size(10)
+
+    snapshot = _exposed(m)
+    assert snapshot["queue_depth"] == 0
+    assert snapshot["requests"] == 0
+    assert snapshot["tokens"] == 0

--- a/test/unit/test_coalescer.py
+++ b/test/unit/test_coalescer.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for Coalescer.
+
+Contract (see docs/openai-chat-completions-queue.md §6):
+- packing_factor: max requests per batch.
+- window_seconds: max wait from the first request before flushing.
+- bypass_threshold: when the upstream queue depth is below this,
+  flush immediately on every submit (no batching tax under low load).
+
+Three flush triggers, only one of which fires for any given batch:
+  size           — accumulator hit packing_factor
+  time           — window_seconds elapsed since first arrival
+  bypass         — queue depth was below bypass_threshold at submit time
+
+The callback receives the list of `(request, correlation_id)` tuples
+that were in the batch, in submission order. The test ensures all
+three triggers work in isolation and that they don't interfere when
+they could fire in the same window.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions.coalescer import Coalescer
+
+
+def _make_coalescer(
+    *,
+    packing_factor: int = 10,
+    window_seconds: float = 0.05,
+    bypass_threshold: int = 10,
+    queue_depth: int = 999,  # default high so bypass doesn't fire
+) -> tuple[Coalescer, list[list]]:
+    """Build a coalescer with a list-collecting callback. Returns (coalescer, flushes)."""
+    flushes: list[list] = []
+
+    async def collect(batch):
+        flushes.append(list(batch))
+
+    coalescer = Coalescer(
+        packing_factor=packing_factor,
+        window_seconds=window_seconds,
+        bypass_threshold=bypass_threshold,
+        flush_callback=collect,
+        queue_depth_provider=lambda: queue_depth,
+    )
+    return coalescer, flushes
+
+
+@pytest.mark.asyncio
+async def test_bypass_under_threshold_flushes_immediately():
+    """Low queue depth → submit returns after the flush has run."""
+    coalescer, flushes = _make_coalescer(bypass_threshold=10, queue_depth=0)
+
+    await coalescer.submit("req-1", "cid-1")
+
+    assert flushes == [[("req-1", "cid-1")]]
+
+
+@pytest.mark.asyncio
+async def test_size_trigger_flushes_at_packing_factor():
+    """Above the bypass threshold, packing_factor submits flush as one batch."""
+    coalescer, flushes = _make_coalescer(packing_factor=3, queue_depth=999)
+
+    await coalescer.submit("a", "1")
+    await coalescer.submit("b", "2")
+    assert flushes == []  # not yet
+    await coalescer.submit("c", "3")
+    assert flushes == [[("a", "1"), ("b", "2"), ("c", "3")]]
+
+
+@pytest.mark.asyncio
+async def test_time_trigger_flushes_after_window():
+    """Fewer-than-packing_factor submits flush when the window expires."""
+    coalescer, flushes = _make_coalescer(
+        packing_factor=10, window_seconds=0.05, queue_depth=999
+    )
+
+    await coalescer.submit("a", "1")
+    await coalescer.submit("b", "2")
+    assert flushes == []
+
+    # Wait past the window and then one event-loop tick for the timer task.
+    await asyncio.sleep(0.08)
+
+    assert flushes == [[("a", "1"), ("b", "2")]]
+
+
+@pytest.mark.asyncio
+async def test_size_trigger_cancels_pending_timer():
+    """
+    Batch fills before the timer fires → timer must cancel so it
+    doesn't fire later and re-flush an empty (or wrong) batch.
+    """
+    coalescer, flushes = _make_coalescer(
+        packing_factor=2, window_seconds=0.05, queue_depth=999
+    )
+
+    await coalescer.submit("a", "1")  # starts the timer
+    await coalescer.submit("b", "2")  # size flush; cancels timer
+
+    assert flushes == [[("a", "1"), ("b", "2")]]
+
+    # Wait past the original window. No second flush should happen.
+    await asyncio.sleep(0.1)
+
+    assert flushes == [[("a", "1"), ("b", "2")]]
+
+
+@pytest.mark.asyncio
+async def test_subsequent_batch_after_flush_starts_new_timer():
+    """Two batches in sequence; both flush correctly and independently."""
+    coalescer, flushes = _make_coalescer(
+        packing_factor=2, window_seconds=0.05, queue_depth=999
+    )
+
+    await coalescer.submit("a", "1")
+    await coalescer.submit("b", "2")
+
+    await coalescer.submit("c", "3")
+    await coalescer.submit("d", "4")
+
+    assert flushes == [
+        [("a", "1"), ("b", "2")],
+        [("c", "3"), ("d", "4")],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_window_clock_starts_at_first_arrival_not_each_submit():
+    """
+    Three submits over 60ms with a 50ms window: the timer should fire
+    based on the FIRST submit's clock, not be reset by later submits.
+    """
+    coalescer, flushes = _make_coalescer(
+        packing_factor=10, window_seconds=0.05, queue_depth=999
+    )
+
+    t0 = time.monotonic()
+    await coalescer.submit("a", "1")
+    await asyncio.sleep(0.02)
+    await coalescer.submit("b", "2")
+    await asyncio.sleep(0.02)
+    await coalescer.submit("c", "3")
+
+    # Wait for the timer to fire (it was started at t0 + ~0.05).
+    while not flushes and time.monotonic() - t0 < 0.5:
+        await asyncio.sleep(0.005)
+
+    assert flushes == [[("a", "1"), ("b", "2"), ("c", "3")]]
+    elapsed = time.monotonic() - t0
+    assert elapsed < 0.15, (
+        f"flush fired at {elapsed:.3f}s — should have been near 0.05s "
+        "from first submit, not reset by later submits"
+    )
+
+
+@pytest.mark.asyncio
+async def test_flush_with_empty_batch_is_noop():
+    """Edge case: timer fires after the batch was already drained."""
+    coalescer, flushes = _make_coalescer(packing_factor=2, queue_depth=999)
+
+    await coalescer.submit("a", "1")
+    await coalescer.submit("b", "2")  # size flush
+    await asyncio.sleep(0.08)  # past the original window
+
+    # No spurious second flush.
+    assert flushes == [[("a", "1"), ("b", "2")]]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_submits_serialize_through_lock():
+    """
+    Many concurrent submits land in batches whose contents and order
+    are well-defined (no lost or duplicated entries).
+    """
+    coalescer, flushes = _make_coalescer(packing_factor=5, queue_depth=999)
+
+    await asyncio.gather(*(coalescer.submit(f"req-{i}", f"cid-{i}") for i in range(15)))
+
+    # 15 submits / packing_factor 5 = 3 full batches.
+    assert sum(len(b) for b in flushes) == 15
+    assert len(flushes) == 3
+    flat = [entry for batch in flushes for entry in batch]
+    assert {cid for _, cid in flat} == {f"cid-{i}" for i in range(15)}

--- a/test/unit/test_correlation_id_map.py
+++ b/test/unit/test_correlation_id_map.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for correlation_id_map.
+
+A tiny in-memory bridge between fill_work_queue (which reads the
+request payload off disk and sees `correlation_id` per-request) and
+update_and_ack (which only sees the per-request `request_id`). The
+cid is stashed on load, popped on completion, and used to resolve
+the result router future.
+"""
+
+import pytest
+
+from cray_infra.api.work_queue import correlation_id_map as cmap
+from cray_infra.api.work_queue.correlation_id_map import (
+    pop_correlation_id,
+    stash_correlation_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_map():
+    """Each test starts with a fresh map; touching the private dict
+    directly is the cleanest way and avoids depending on test order."""
+    cmap._map.clear()
+    yield
+    cmap._map.clear()
+
+
+@pytest.mark.asyncio
+async def test_stash_then_pop_returns_value():
+    await stash_correlation_id("req-1", "cid-1")
+    assert await pop_correlation_id("req-1") == "cid-1"
+
+
+@pytest.mark.asyncio
+async def test_pop_unknown_returns_none():
+    assert await pop_correlation_id("never-stashed") is None
+
+
+@pytest.mark.asyncio
+async def test_pop_consumes_entry():
+    await stash_correlation_id("req-2", "cid-2")
+    assert await pop_correlation_id("req-2") == "cid-2"
+    assert await pop_correlation_id("req-2") is None
+
+
+@pytest.mark.asyncio
+async def test_independent_keys_dont_collide():
+    await stash_correlation_id("a", "alpha")
+    await stash_correlation_id("b", "beta")
+    assert await pop_correlation_id("a") == "alpha"
+    assert await pop_correlation_id("b") == "beta"

--- a/test/unit/test_enqueue_coalesced_batch.py
+++ b/test/unit/test_enqueue_coalesced_batch.py
@@ -1,0 +1,105 @@
+"""
+Unit tests for enqueue_coalesced_batch.
+
+Contract (see docs/openai-chat-completions-queue.md §6.3):
+- A coalesced batch is written to disk as one JSON file under
+  `upload_base_path`, named after the SHA-256 of its contents.
+- A single SQLite row referencing that file is enqueued via
+  `push_into_queue`.
+- Identical batches produce the same path (dedup property carries
+  over for free).
+"""
+
+import hashlib
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions.enqueue_coalesced_batch import (
+    enqueue_coalesced_batch,
+)
+
+
+@pytest.fixture
+def upload_dir(tmp_path, monkeypatch):
+    """Patch the config-fetcher so the helper writes into a tmp dir."""
+    target = tmp_path / "inference_requests"
+    target.mkdir()
+
+    fake_config = {"upload_base_path": str(target)}
+    with patch(
+        "cray_infra.api.fastapi.chat_completions.enqueue_coalesced_batch.get_config",
+        return_value=fake_config,
+    ):
+        yield target
+
+
+@pytest.mark.asyncio
+async def test_writes_request_file_and_calls_push(upload_dir):
+    batch = [
+        ({"prompt": "hi", "correlation_id": "c1"}, "c1"),
+        ({"prompt": "hello", "correlation_id": "c2"}, "c2"),
+    ]
+
+    with patch(
+        "cray_infra.api.fastapi.chat_completions.enqueue_coalesced_batch.push_into_queue",
+        new_callable=AsyncMock,
+    ) as push:
+        await enqueue_coalesced_batch(batch)
+
+    assert push.await_count == 1
+    request_count, path = push.await_args.args
+    assert request_count == 2
+    assert os.path.dirname(path) == str(upload_dir)
+    assert os.path.exists(path)
+
+    with open(path) as f:
+        on_disk = json.load(f)
+    assert on_disk == [
+        {"prompt": "hi", "correlation_id": "c1"},
+        {"prompt": "hello", "correlation_id": "c2"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_filename_is_sha256_of_contents(upload_dir):
+    batch = [({"prompt": "x", "correlation_id": "c1"}, "c1")]
+
+    with patch(
+        "cray_infra.api.fastapi.chat_completions.enqueue_coalesced_batch.push_into_queue",
+        new_callable=AsyncMock,
+    ) as push:
+        await enqueue_coalesced_batch(batch)
+
+    _, path = push.await_args.args
+    expected_contents = json.dumps(
+        [{"prompt": "x", "correlation_id": "c1"}]
+    ).encode()
+    expected_hash = hashlib.sha256(expected_contents).hexdigest()
+
+    assert os.path.basename(path) == f"{expected_hash}.json"
+
+
+@pytest.mark.asyncio
+async def test_identical_batches_produce_same_path(upload_dir):
+    """Dedup property: same content hashes to same path."""
+    batch = [({"prompt": "same", "correlation_id": "c-a"}, "c-a")]
+
+    with patch(
+        "cray_infra.api.fastapi.chat_completions.enqueue_coalesced_batch.push_into_queue",
+        new_callable=AsyncMock,
+    ) as push:
+        await enqueue_coalesced_batch(batch)
+        await enqueue_coalesced_batch(batch)
+
+    paths = [call.args[1] for call in push.await_args_list]
+    assert paths[0] == paths[1]
+
+
+@pytest.mark.asyncio
+async def test_empty_batch_raises(upload_dir):
+    """An empty batch is a programmer error from the coalescer."""
+    with pytest.raises(ValueError):
+        await enqueue_coalesced_batch([])

--- a/test/unit/test_fill_work_queue_stashes_cids.py
+++ b/test/unit/test_fill_work_queue_stashes_cids.py
@@ -1,0 +1,95 @@
+"""
+Verify that fill_work_queue stashes correlation_ids from a loaded
+batch into the correlation_id_map so update_and_ack can later resolve
+the matching ResultRouter futures.
+
+Mixed batches (some entries have a cid, some don't) must not cross-
+contaminate: only cids that were present in the JSON should be
+stashed, by their per-entry sub-id.
+"""
+
+import hashlib
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cray_infra.api.work_queue import correlation_id_map as cmap
+from cray_infra.api.work_queue import get_work_item as gwi
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    cmap._map.clear()
+    gwi.in_memory_work_queue = []
+    yield
+    cmap._map.clear()
+    gwi.in_memory_work_queue = []
+
+
+def _write_batch(tmp_path, requests):
+    """Mimic enqueue_coalesced_batch's filename convention."""
+    contents = json.dumps(requests).encode("utf-8")
+    contents_hash = hashlib.sha256(contents).hexdigest()
+    path = os.path.join(tmp_path, f"{contents_hash}.json")
+    with open(path, "wb") as fh:
+        fh.write(contents)
+    return path, contents_hash
+
+
+def _make_queue(path):
+    """A minimal mock of the work_queue interface used by fill_work_queue."""
+    queue = AsyncMock()
+    queue.get = AsyncMock(return_value=({"path": path}, 7))
+    queue.ack = AsyncMock()
+    return queue
+
+
+@pytest.mark.asyncio
+async def test_stashes_cid_for_each_entry_with_correlation_id(tmp_path):
+    requests = [
+        {"prompt": "a", "correlation_id": "cid-a"},
+        {"prompt": "b", "correlation_id": "cid-b"},
+    ]
+    path, group_id = _write_batch(tmp_path, requests)
+
+    # Avoid the response-file-already-exists short-circuit.
+    with patch.object(gwi, "group_request_id_to_response_path", return_value="/nonexistent/path"):
+        await gwi.fill_work_queue(_make_queue(path))
+
+    sub_id_0 = gwi.make_id(group_id, 0)
+    sub_id_1 = gwi.make_id(group_id, 1)
+
+    assert await cmap.pop_correlation_id(sub_id_0) == "cid-a"
+    assert await cmap.pop_correlation_id(sub_id_1) == "cid-b"
+
+
+@pytest.mark.asyncio
+async def test_does_not_stash_when_correlation_id_absent(tmp_path):
+    """Generate-path entries (no cid) must not produce stash entries."""
+    requests = [{"prompt": "no-cid"}]
+    path, group_id = _write_batch(tmp_path, requests)
+
+    with patch.object(gwi, "group_request_id_to_response_path", return_value="/nonexistent/path"):
+        await gwi.fill_work_queue(_make_queue(path))
+
+    sub_id = gwi.make_id(group_id, 0)
+    assert await cmap.pop_correlation_id(sub_id) is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_only_stashes_entries_with_cids(tmp_path):
+    requests = [
+        {"prompt": "with-cid", "correlation_id": "cid-yes"},
+        {"prompt": "without-cid"},
+        {"prompt": "with-cid-2", "correlation_id": "cid-also"},
+    ]
+    path, group_id = _write_batch(tmp_path, requests)
+
+    with patch.object(gwi, "group_request_id_to_response_path", return_value="/nonexistent/path"):
+        await gwi.fill_work_queue(_make_queue(path))
+
+    assert await cmap.pop_correlation_id(gwi.make_id(group_id, 0)) == "cid-yes"
+    assert await cmap.pop_correlation_id(gwi.make_id(group_id, 1)) is None
+    assert await cmap.pop_correlation_id(gwi.make_id(group_id, 2)) == "cid-also"

--- a/test/unit/test_render_chat_template.py
+++ b/test/unit/test_render_chat_template.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for render_chat_template.
+
+Contract (see docs/openai-chat-completions-queue.md §4):
+- Exactly one of `messages` or `prompt` must be set.
+- `prompt` is a raw passthrough (returned unchanged).
+- `messages` runs through the model's tokenizer chat template.
+- Tokenizer instances are cached per-model — repeated calls on the
+  same model don't reload.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions import render_chat_template as rct
+
+
+@pytest.fixture(autouse=True)
+def _reset_tokenizer_cache():
+    """Each test gets a fresh cache so cross-test ordering doesn't matter."""
+    rct._tokenizer_cache.clear()
+    yield
+    rct._tokenizer_cache.clear()
+
+
+def _fake_tokenizer(rendered: str = "[fake-rendered]") -> MagicMock:
+    tok = MagicMock()
+    tok.apply_chat_template.return_value = rendered
+    return tok
+
+
+def test_prompt_is_passthrough_unchanged():
+    out = rct.render_chat_template(model="any-model", messages=None, prompt="hello")
+    assert out == "hello"
+
+
+def test_messages_renders_via_tokenizer():
+    fake = _fake_tokenizer("USER: hi\nASSISTANT: ")
+    with patch.object(rct, "_load_tokenizer", return_value=fake):
+        out = rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt=None,
+        )
+    assert out == "USER: hi\nASSISTANT: "
+    fake.apply_chat_template.assert_called_once()
+    kwargs = fake.apply_chat_template.call_args.kwargs
+    assert kwargs["tokenize"] is False
+    assert kwargs["add_generation_prompt"] is True
+
+
+def test_both_set_raises_value_error():
+    with pytest.raises(ValueError, match="exactly one"):
+        rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt="also a prompt",
+        )
+
+
+def test_neither_set_raises_value_error():
+    with pytest.raises(ValueError, match="exactly one"):
+        rct.render_chat_template(model="any-model", messages=None, prompt=None)
+
+
+def test_empty_messages_list_treated_as_unset():
+    """
+    `messages=[]` is meaningless — no turns to render. Treat the same
+    as unset so the caller learns about the bug from the ValueError
+    rather than an opaque tokenizer failure.
+    """
+    with pytest.raises(ValueError, match="exactly one"):
+        rct.render_chat_template(model="any-model", messages=[], prompt=None)
+
+
+def test_empty_prompt_treated_as_unset():
+    """Same reasoning as the empty-messages case — empty string is suspicious."""
+    with pytest.raises(ValueError, match="exactly one"):
+        rct.render_chat_template(model="any-model", messages=None, prompt="")
+
+
+def test_tokenizer_cached_per_model():
+    """
+    Repeated calls on the same model name must reuse the same tokenizer
+    instance. Otherwise we'd reload the tokenizer (a multi-MB-disk-read,
+    seconds-long operation) on every chat completion.
+    """
+    fake = _fake_tokenizer()
+    with patch.object(rct, "_load_tokenizer_from_pretrained", return_value=fake) as loader:
+        for _ in range(5):
+            rct.render_chat_template(
+                model="repeat-model",
+                messages=[{"role": "user", "content": "x"}],
+                prompt=None,
+            )
+        assert loader.call_count == 1
+
+
+def test_tokenizer_loaded_per_distinct_model():
+    """Distinct model names get distinct tokenizers."""
+    fake_a = _fake_tokenizer("A")
+    fake_b = _fake_tokenizer("B")
+    sequence = iter([fake_a, fake_b])
+    with patch.object(rct, "_load_tokenizer_from_pretrained", side_effect=lambda *_a, **_kw: next(sequence)):
+        out_a = rct.render_chat_template(
+            model="model-a",
+            messages=[{"role": "user", "content": "x"}],
+            prompt=None,
+        )
+        out_b = rct.render_chat_template(
+            model="model-b",
+            messages=[{"role": "user", "content": "x"}],
+            prompt=None,
+        )
+    assert out_a == "A"
+    assert out_b == "B"

--- a/test/unit/test_render_generate_entry.py
+++ b/test/unit/test_render_generate_entry.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for render_generate_entry.
+
+Each `prompts` entry in a /v1/generate request can be:
+  - a bare string (legacy raw passthrough)
+  - a dict with `prompt: str` (raw passthrough, equivalent form)
+  - a dict with `messages: list[ChatMessage]` (rendered through chat template)
+
+See docs/openai-chat-completions-queue.md §10. This is the single
+function that owns the dispatch between those forms; both /v1/generate
+and (potentially) other batch entrypoints route through it so the
+rendering rules don't drift across paths.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from cray_infra.api.fastapi.chat_completions.render_generate_entry import (
+    render_generate_entry,
+)
+
+
+def test_bare_string_entry_passes_through():
+    assert render_generate_entry("hello", model="any") == "hello"
+
+
+def test_dict_with_prompt_passes_through():
+    assert render_generate_entry({"prompt": "hello"}, model="any") == "hello"
+
+
+def test_dict_with_messages_renders_via_template():
+    fake = "RENDERED"
+    with patch(
+        "cray_infra.api.fastapi.chat_completions.render_generate_entry.render_chat_template",
+        return_value=fake,
+    ) as renderer:
+        out = render_generate_entry(
+            {"messages": [{"role": "user", "content": "hi"}]},
+            model="my-model",
+        )
+    assert out == fake
+    renderer.assert_called_once_with(
+        model="my-model",
+        messages=[{"role": "user", "content": "hi"}],
+        prompt=None,
+    )
+
+
+def test_dict_with_both_prompt_and_messages_raises_400():
+    """Reuse the renderer's validation; surface as HTTP 400."""
+    with pytest.raises(HTTPException) as exc_info:
+        render_generate_entry(
+            {"prompt": "x", "messages": [{"role": "user", "content": "y"}]},
+            model="any",
+        )
+    assert exc_info.value.status_code == 400
+
+
+def test_dict_with_neither_prompt_nor_messages_raises_400():
+    with pytest.raises(HTTPException) as exc_info:
+        render_generate_entry({}, model="any")
+    assert exc_info.value.status_code == 400
+
+
+def test_unsupported_type_raises_400():
+    """Lists, ints, None — all rejected with 400 not 500."""
+    for bogus in [[1, 2], 42, None]:
+        with pytest.raises(HTTPException) as exc_info:
+            render_generate_entry(bogus, model="any")
+        assert exc_info.value.status_code == 400

--- a/test/unit/test_result_router.py
+++ b/test/unit/test_result_router.py
@@ -1,0 +1,104 @@
+"""
+Unit tests for ResultRouter.
+
+Contract (see docs/openai-chat-completions-queue.md §8):
+- register(cid) creates a Future under that correlation id.
+- resolve(cid, result) sets the Future's result and removes the entry.
+- unregister(cid) removes the entry without resolving (for client disconnect).
+- in_flight_count gauges currently-registered ids.
+- resolve on an unknown cid is a silent no-op (post-disconnect race).
+- register on a duplicate cid is a programmer error (raises).
+"""
+
+import asyncio
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions.result_router import ResultRouter
+
+
+@pytest.mark.asyncio
+async def test_register_returns_future_pending_until_resolve():
+    router = ResultRouter()
+    cid = "req-1"
+
+    future = router.register(cid)
+    assert not future.done()
+    assert router.in_flight_count == 1
+
+    router.resolve(cid, {"answer": 42})
+    assert future.done()
+    assert future.result() == {"answer": 42}
+    assert router.in_flight_count == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_unknown_cid_is_silent_no_op():
+    """
+    Worker may produce a result for a cid whose handler already
+    disconnected. That's normal; resolve must not raise.
+    """
+    router = ResultRouter()
+    router.resolve("never-registered", {"answer": 0})
+    assert router.in_flight_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unregister_removes_without_resolving():
+    """Client-disconnect path: drop the future, don't set a result."""
+    router = ResultRouter()
+    cid = "req-2"
+    future = router.register(cid)
+
+    router.unregister(cid)
+
+    assert router.in_flight_count == 0
+    assert not future.done()
+    # A subsequent resolve under that cid must not raise either.
+    router.resolve(cid, {"answer": "late"})
+    assert not future.done()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_register_raises():
+    """A repeated cid is a bug in the caller; surface it loudly."""
+    router = ResultRouter()
+    router.register("dup")
+    with pytest.raises(KeyError):
+        router.register("dup")
+
+
+@pytest.mark.asyncio
+async def test_in_flight_count_tracks_concurrent_registrations():
+    router = ResultRouter()
+    futures = [router.register(f"req-{i}") for i in range(50)]
+    assert router.in_flight_count == 50
+
+    for i, fut in enumerate(futures[:20]):
+        router.resolve(f"req-{i}", i)
+    assert router.in_flight_count == 30
+
+    for i in range(20, 35):
+        router.unregister(f"req-{i}")
+    assert router.in_flight_count == 15
+
+
+@pytest.mark.asyncio
+async def test_handler_workflow_resolve_unblocks_awaiter():
+    """
+    End-to-end shape of the production flow: handler awaits the future,
+    a separate task simulates the worker calling resolve.
+    """
+    router = ResultRouter()
+    cid = "req-await"
+    future = router.register(cid)
+
+    async def simulate_worker():
+        await asyncio.sleep(0.02)
+        router.resolve(cid, {"text": "hello"})
+
+    asyncio.create_task(simulate_worker())
+    result = await asyncio.wait_for(future, timeout=1.0)
+
+    assert result == {"text": "hello"}
+    assert router.in_flight_count == 0

--- a/test/unit/test_update_and_ack_resolves_router.py
+++ b/test/unit/test_update_and_ack_resolves_router.py
@@ -1,0 +1,138 @@
+"""
+Integration of update_and_ack with the chat-completions ResultRouter.
+
+When a per-prompt completion lands in update_and_ack and the
+corresponding request_id has a stashed correlation_id (set by
+fill_work_queue when the chat-completions JSON file was loaded), the
+router's matching Future must be resolved. Requests without a cid
+(the /v1/generate path) must not trigger a resolve call — the
+behavior is endpoint-agnostic.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions.result_router import ResultRouter
+from cray_infra.api.work_queue import correlation_id_map as cmap
+from cray_infra.api.work_queue import update_and_ack as uaa_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_correlation_map():
+    cmap._map.clear()
+    yield
+    cmap._map.clear()
+
+
+@pytest.fixture
+def fresh_router():
+    return ResultRouter()
+
+
+def _group_state(*, total: int = 1, work_queue_id: int = 42):
+    return {
+        "results": {},
+        "current_index": 0,
+        "total_requests": total,
+        "work_queue_id": work_queue_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolves_router_future_when_correlation_id_is_stashed(fresh_router):
+    request_id = "abcd_000000000"
+    correlation_id = "cid-xyz"
+
+    future = fresh_router.register(correlation_id)
+    await cmap.stash_correlation_id(request_id, correlation_id)
+
+    queue = AsyncMock()
+    group = _group_state(total=2)  # not finalized yet — keeps ack out of the test
+
+    with patch(
+        "cray_infra.api.work_queue.update_and_ack.get_in_memory_results",
+        new=AsyncMock(return_value=group),
+    ), patch(
+        "cray_infra.api.work_queue.update_and_ack.get_result_router",
+        return_value=fresh_router,
+    ):
+        await uaa_mod.update_and_ack(queue, request_id, {"response": "hi"})
+
+    assert future.done()
+    assert future.result()["response"] == "hi"
+
+
+@pytest.mark.asyncio
+async def test_no_resolve_when_no_correlation_id_stashed(fresh_router):
+    """Generate-path requests don't carry a cid; resolve must not be called."""
+    request_id = "wxyz_000000000"
+    queue = AsyncMock()
+    group = _group_state(total=2)
+
+    with patch(
+        "cray_infra.api.work_queue.update_and_ack.get_in_memory_results",
+        new=AsyncMock(return_value=group),
+    ), patch(
+        "cray_infra.api.work_queue.update_and_ack.get_result_router",
+        return_value=fresh_router,
+    ):
+        await uaa_mod.update_and_ack(queue, request_id, {"response": "x"})
+
+    assert fresh_router.in_flight_count == 0
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_is_consumed_on_first_resolve(fresh_router):
+    """A second update_and_ack on the same id must not double-resolve."""
+    request_id = "abcd_000000000"
+    correlation_id = "cid-once"
+
+    fresh_router.register(correlation_id)
+    await cmap.stash_correlation_id(request_id, correlation_id)
+
+    queue = AsyncMock()
+    group = _group_state(total=3)
+
+    with patch(
+        "cray_infra.api.work_queue.update_and_ack.get_in_memory_results",
+        new=AsyncMock(return_value=group),
+    ), patch(
+        "cray_infra.api.work_queue.update_and_ack.get_result_router",
+        return_value=fresh_router,
+    ):
+        await uaa_mod.update_and_ack(queue, request_id, {"response": "first"})
+        await uaa_mod.update_and_ack(queue, request_id, {"response": "second"})
+
+    # Router cleared on first resolve; second call had nothing to resolve.
+    assert fresh_router.in_flight_count == 0
+
+
+@pytest.mark.asyncio
+async def test_resolve_does_not_block_existing_disconnect_handling(fresh_router):
+    """
+    Client disconnected (cid unregistered) → resolve is silent no-op,
+    update_and_ack still completes its existing work.
+    """
+    request_id = "abcd_000000000"
+    correlation_id = "cid-gone"
+
+    fresh_router.register(correlation_id)
+    fresh_router.unregister(correlation_id)  # client disconnected
+    await cmap.stash_correlation_id(request_id, correlation_id)
+
+    queue = AsyncMock()
+    group = _group_state(total=2)
+
+    with patch(
+        "cray_infra.api.work_queue.update_and_ack.get_in_memory_results",
+        new=AsyncMock(return_value=group),
+    ), patch(
+        "cray_infra.api.work_queue.update_and_ack.get_result_router",
+        return_value=fresh_router,
+    ):
+        # Must not raise, must update group state normally.
+        await uaa_mod.update_and_ack(queue, request_id, {"response": "ignored"})
+
+    assert group["current_index"] == 1
+    assert group["results"][request_id]["is_acked"] is True


### PR DESCRIPTION
## Summary

Implements `docs/openai-chat-completions-queue.md`: a queue-backed `/v1/chat/completions` path that absorbs bursts of up to ~5k concurrent requests with **a vanilla `AsyncOpenAI()` client and no per-request configuration** — no `max_retries`, no `timeout`, no `stream=True`. Also unifies prompt formatting between `/v1/chat/completions` and `/v1/generate` so callers can submit chat-style `messages: [...]` to either endpoint.

Shape of the new request path (non-streaming):

```
AsyncOpenAI ─► chat_completions_via_queue
              ├─► render_chat_template
              ├─► admission control (429 + Retry-After above high-water)
              ├─► ResultRouter.register(correlation_id)
              ├─► Coalescer.submit  ──► enqueue_coalesced_batch ──► SQLite
              └─► StreamingResponse(stream_with_heartbeat(future))
                                                      │
                              update_and_ack ◄────────┘ (worker resolves)
```

`stream=True` clients keep the existing direct-to-vLLM SSE proxy unchanged. Streaming bypasses the new infrastructure entirely (§3.1 of the design doc) — SSE keeps the connection alive natively.

## What lands here

Eleven commits, each its own focused piece with a unit test alongside:

| # | Commit | Component |
|---|---|---|
| 1 | `0bac4e4` | `ResultRouter` — per-prompt fan-out from worker to handlers |
| 2 | `863b7e3` | `render_chat_template` — shared template rendering |
| 3 | `0644ad8` | `Coalescer` — size/time/bypass-triggered queue batching |
| 4 | `f80badf` | admission threshold check + `WaitEstimator` for Retry-After |
| 5 | `7b91f4b` | `enqueue_coalesced_batch` — flush callback (one batch → one queue row) |
| 6 | `1cb32bd` | `chat_completions_via_queue` handler wiring it all together |
| 7 | `bd00bb4` | `update_and_ack` resolve hook + `correlation_id_map` |
| 8 | `9408ba8` | new config fields with documented defaults |
| 9 | `cb014ed` | route `/v1/chat/completions` through the queue when `stream=False` |
| 10 | `4f0e639` | render `/v1/generate` prompts entries through the chat template |
| 11 | `dc99abf` | chat-completions metrics + wiring into the four call sites |

The whitespace-heartbeat helper at `infra/cray_infra/api/fastapi/chat_completions/heartbeat.py` and its end-to-end validation against `AsyncOpenAI` over a real socket landed earlier.

## Tests

- 90 unit + integration tests covering the new modules and the integrations into the existing `update_and_ack` / `fill_work_queue` / `Metrics` / `/v1/generate` paths.
- The whitespace-heartbeat technique is validated end-to-end against a real `openai.AsyncOpenAI` client over a real localhost socket (positive case + negative control).
- Existing `test_finish_work_missing_group.py` and `test_pydantic_requests.py` still pass — the new hooks are no-ops on the `/v1/generate` path when no `correlation_id` is present.

## Test plan

- [ ] CI unit suite green
- [ ] Manual: vanilla `AsyncOpenAI()` against a deployed instance — 100-request burst completes cleanly
- [ ] Manual: 5000-request burst hits 429 + `Retry-After` and recovers without unhandled exceptions
- [ ] Manual: existing `/v1/generate` callers (raw `prompt: str` per entry) byte-identical behavior
- [ ] Manual: existing `/v1/chat/completions` `stream=True` callers byte-identical behavior

## Out of scope (this PR)

- End-to-end integration test that drives `AsyncOpenAI` against the wired-up server with a stub vLLM. Intentionally deferred to a follow-up — the unit tests cover the logic and the existing heartbeat integration test covers the transport.
- `/v1/batches` (file-upload + polling). Separate doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)