### PR TITLE
Default vllm-fork build to main; drop scalarlm-on-v0.19.0 SHA pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -255,29 +255,17 @@ RUN pip install setuptools-scm
 
 # Configure vLLM source - can use either local directory or remote repo.
 #
-# VLLM_BRANCH defaults to scalarlm-on-v0.19.0 — the fork's clean re-cut
-# of upstream v0.19.0 with scalarlm patches squashed on top. This is
-# what production scalarlm builds run against. The fork also carries a
-# `main` branch with continuing per-bug commits, but it's a parallel
-# lineage and not the recommended build target.
+# VLLM_BRANCH defaults to `main` on vllm-fork. The fixes that previously
+# required pinning to scalarlm-on-v0.19.0 at a specific SHA (TorchAllocator
+# crash, Triton scratch-allocator memleak, torch 2.10 ABI) are now merged
+# into vllm-fork's main branch, so the branch tip is sufficient.
 #
-# VLLM_COMMIT pins the checkout to a specific SHA so builds are
-# reproducible across time even as scalarlm-on-v0.19.0 advances. Bump
-# this when picking up new fork commits.
-#
-# Current pin: 01f4bae62 (HEAD of vllm-fork PR #25, on top of
-# scalarlm-on-v0.19.0). Includes:
-#   - PR #24 (merged): TorchAllocator .set() crash fix on MoE + LoRA
-#                      engine init.
-#   - PR #25 (open):   Triton scratch-allocator memleak fix +
-#                      libtorch_stable torch 2.10 ABI fix (cherry-picks
-#                      of 5a670ff7a / 4fd1236e9 from vllm-fork main).
-#                      The ABI fix is required to compile against the
-#                      torch 2.10 in nvcr.io/nvidia/pytorch:26.01-py3.
-# Bump to PR #25's merge SHA on scalarlm-on-v0.19.0 once it lands.
+# VLLM_COMMIT remains available as an opt-in pin if a deployment needs
+# reproducibility across time or wants to roll back to a specific SHA;
+# leave it empty to use BRANCH tip (the default).
 ARG VLLM_SOURCE=remote
-ARG VLLM_BRANCH=scalarlm-on-v0.19.0
-ARG VLLM_COMMIT=01f4bae62
+ARG VLLM_BRANCH=main
+ARG VLLM_COMMIT=
 ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
 
 # Handle vLLM source - support both local and remote modes.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
                 - BASE_NAME=${BASE_NAME}
                 - VLLM_TARGET_DEVICE=${VLLM_TARGET_DEVICE}
                 - VLLM_SOURCE=${VLLM_SOURCE:-local}
-                - VLLM_BRANCH=${VLLM_BRANCH:-scalarlm-on-v0.19.0}
+                - VLLM_BRANCH=${VLLM_BRANCH:-main}
                 - VLLM_REPO=${VLLM_REPO:-https://github.com/supermassive-intelligence/vllm-fork.git}
         ports:
             - "3000:3000"


### PR DESCRIPTION
## Summary

Follow-up to #174. Switches the vLLM-fork build target back to vllm-fork's `main` branch and drops the `scalarlm-on-v0.19.0` + SHA pin.

```diff
-ARG VLLM_BRANCH=scalarlm-on-v0.19.0
-ARG VLLM_COMMIT=01f4bae62
+ARG VLLM_BRANCH=main
+ARG VLLM_COMMIT=
```

Plus `docker-compose.yaml` flipped to default `VLLM_BRANCH:-main`.

## Why

The three fixes that motivated #174's pin to `scalarlm-on-v0.19.0` at SHA `01f4bae62` are now merged into vllm-fork's `main` branch:

- TorchAllocator `.set()` crash on MoE + LoRA engine init (was vllm-fork PR #24)
- Triton scratch-allocator memleak (was vllm-fork PR #25)
- `libtorch_stable` torch 2.10 ABI change (was vllm-fork PR #25)

With those landed upstream, the SHA pin is no longer load-bearing — the branch tip carries the fixes, and the parallel-lineage concern that previously made `main` the wrong target no longer applies.

## What stays

- The `VLLM_COMMIT` build arg remains in the Dockerfile, just empty by default. Deployments that want SHA reproducibility across time can still set it explicitly:

  ```bash
  docker build --build-arg VLLM_COMMIT=<sha> ...
  ```

- `build-copy-vllm.sh`'s `if [ -n "$COMMIT" ]; then git checkout "$COMMIT"; fi` already handles the empty case — no script change needed.

## Test plan

- [ ] Fresh Docker build against `main` branch tip produces a working image
- [ ] `./scalarlm build-image` and `./scalarlm depot-build` (which both inherit the Dockerfile default) build cleanly
- [ ] docker-compose build with no `VLLM_BRANCH` override produces an image equivalent to the explicit-`main` case

🤖 Generated with [Claude Code](https://claude.com/claude-code)