### PR TITLE
Fix non-streaming /v1/chat/completions queue path end-to-end

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
@@ -1,0 +1,101 @@
+"""
+Wrap the worker's flat result dict into the OpenAI ChatCompletion
+shape the `AsyncOpenAI` SDK expects.
+
+The worker (see `create_generate_worker.async_completion_task`)
+returns:
+
+    {
+      "request_id": "<id>",
+      "response": "<text>",            # present on success
+      "error": "<message>",            # present on failure
+      "token_count": <int>,            # present when usage was reported
+      "is_acked": True,                # added by update_and_ack
+      ...                              # original request fields
+    }
+
+The OpenAI ChatCompletion shape is:
+
+    {
+      "id": "chatcmpl-<id>",
+      "object": "chat.completion",
+      "created": <unix_ts>,
+      "model": "<model>",
+      "choices": [{"index": 0,
+                   "message": {"role": "assistant", "content": "<text>"},
+                   "finish_reason": "stop",
+                   "logprobs": None}],
+      "usage": {"prompt_tokens": 0, "completion_tokens": <n>,
+                "total_tokens": <n>}
+    }
+
+We don't have the prompt-token vs completion-token split available at
+this layer (the worker returned the union as `token_count`), so we put
+all of it into `completion_tokens`. That keeps `total_tokens` correct
+— operators reading metrics get the right number — at the cost of a
+slightly inaccurate split. If we need the precise split later, the
+worker has access to `response_data["usage"]` and can pass through.
+"""
+
+import time
+from typing import Any
+
+
+CHAT_COMPLETION_OBJECT = "chat.completion"
+
+
+def build_chat_completion_response(
+    *, result: dict[str, Any], model: str
+) -> dict[str, Any]:
+    """
+    `result` is the dict the handler's heartbeat streamer is about to
+    JSON-dump — i.e. the worker output enriched by `update_and_ack`.
+    `model` is captured from the original request so we don't have to
+    rely on the worker echoing it back.
+    """
+    error = result.get("error")
+    content = "" if error else (result.get("response") or "")
+
+    chat_id = _build_chat_id(result.get("request_id"))
+    finish_reason = "stop" if not error else "error"
+    completion_tokens = int(result.get("token_count") or 0)
+
+    response: dict[str, Any] = {
+        "id": chat_id,
+        "object": CHAT_COMPLETION_OBJECT,
+        "created": int(time.time()),
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+                "finish_reason": finish_reason,
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 0,
+            "completion_tokens": completion_tokens,
+            "total_tokens": completion_tokens,
+        },
+    }
+
+    # OpenAI's error shape is a top-level `error` field; the SDK will
+    # still parse the body if `choices` is present, so we preserve both
+    # to give operators the diagnostic and the SDK a parseable result.
+    if error:
+        response["error"] = {"message": error, "type": "worker_error"}
+
+    return response
+
+
+def _build_chat_id(request_id: Any) -> str:
+    """OpenAI ids are `chatcmpl-<token>`. Reuse the worker's request_id
+    when it's a string so the inference browser can correlate; fall
+    back to a timestamp-based id otherwise."""
+    if isinstance(request_id, str) and request_id:
+        return f"chatcmpl-{request_id}"
+    return f"chatcmpl-{int(time.time() * 1000)}"

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -32,6 +32,9 @@ from cray_infra.api.fastapi.chat_completions.admission import (
     WaitEstimator,
     is_over_high_water,
 )
+from cray_infra.api.fastapi.chat_completions.build_chat_completion_response import (
+    build_chat_completion_response,
+)
 from cray_infra.api.fastapi.chat_completions.coalescer import Coalescer
 from cray_infra.api.fastapi.chat_completions.heartbeat import (
     stream_with_heartbeat,
@@ -100,29 +103,53 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         "model": request.model,
         "max_tokens": getattr(request, "max_tokens", None),
         "temperature": getattr(request, "temperature", None),
-        "request_type": "chat_completion",
+        # The worker's dispatcher (`async_generate_task` in
+        # create_generate_worker.py) only recognises "generate". The
+        # rendered_prompt is a string, so it routes through
+        # `async_completion_task` to /v1/completions in vLLM — which
+        # is what we want, because the chat template is already
+        # applied. We rewrap the worker's response into a
+        # ChatCompletion shape below.
+        "request_type": "generate",
         "correlation_id": correlation_id,
     }
 
     await get_coalescer().submit(backend_request, correlation_id)
 
     return StreamingResponse(
-        _stream_and_unregister(future, correlation_id, router),
+        _stream_and_unregister(future, correlation_id, router, request.model),
         media_type="application/json",
     )
+
+
+def _encode_chat_completion(model: str):
+    """Encoder closure for stream_with_heartbeat. The worker hands us
+    its flat result dict (request_id, response, error, token_count);
+    we rewrap into the OpenAI ChatCompletion shape so the SDK can
+    parse it without surprises."""
+    import json
+
+    def encode(result):
+        wrapped = build_chat_completion_response(result=result, model=model)
+        return json.dumps(wrapped).encode("utf-8")
+
+    return encode
 
 
 async def _stream_and_unregister(
     future,
     correlation_id: str,
     router: ResultRouter,
+    model: str,
 ) -> AsyncIterator[bytes]:
     """
     Wrap the heartbeat stream so the cid is always unregistered on
     completion or generator close (the client-disconnect path).
     """
     try:
-        async for chunk in stream_with_heartbeat(future):
+        async for chunk in stream_with_heartbeat(
+            future, encode_body=_encode_chat_completion(model)
+        ):
             yield chunk
     finally:
         router.unregister(correlation_id)

--- a/infra/cray_infra/api/fastapi/chat_completions/heartbeat.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/heartbeat.py
@@ -17,7 +17,7 @@ the path.
 
 import asyncio
 import json
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Callable
 
 
 HEARTBEAT_BYTE = b" "
@@ -28,6 +28,7 @@ async def stream_with_heartbeat(
     work_future: asyncio.Future,
     *,
     heartbeat_interval_seconds: float = DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+    encode_body: Callable[[Any], bytes] | None = None,
 ) -> AsyncIterator[bytes]:
     """
     Yield whitespace bytes every `heartbeat_interval_seconds` until
@@ -35,7 +36,13 @@ async def stream_with_heartbeat(
 
     The future is `asyncio.shield`-wrapped so the heartbeat-tick
     timeout cancels only the waiter, never the underlying work.
+
+    `encode_body` lets a caller transform the resolved value before it
+    hits the wire — used by the chat completions handler to wrap the
+    worker's flat result dict into the OpenAI ChatCompletion shape
+    without coupling this transport to that vocabulary.
     """
+    encoder = encode_body or _encode_json_body
     while True:
         try:
             result = await asyncio.wait_for(
@@ -46,7 +53,7 @@ async def stream_with_heartbeat(
         except asyncio.TimeoutError:
             yield HEARTBEAT_BYTE
 
-    yield _encode_json_body(result)
+    yield encoder(result)
 
 
 def _encode_json_body(value: Any) -> bytes:

--- a/test/unit/test_build_chat_completion_response.py
+++ b/test/unit/test_build_chat_completion_response.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for build_chat_completion_response.
+
+Contract: convert the worker's flat result dict into the OpenAI
+ChatCompletion shape that AsyncOpenAI parses. The non-streaming chat
+completions queue path was previously unparseable end-to-end because
+the heartbeat streamer dumped the raw worker dict verbatim — the SDK
+expects `id`/`object`/`choices`/`usage` at the top level.
+"""
+
+from cray_infra.api.fastapi.chat_completions.build_chat_completion_response import (
+    CHAT_COMPLETION_OBJECT,
+    build_chat_completion_response,
+)
+
+
+def test_happy_path_shape():
+    result = {
+        "request_id": "abc_0",
+        "response": "hello world",
+        "token_count": 42,
+        "is_acked": True,
+    }
+
+    out = build_chat_completion_response(result=result, model="m-1")
+
+    assert out["object"] == CHAT_COMPLETION_OBJECT
+    assert out["id"] == "chatcmpl-abc_0"
+    assert out["model"] == "m-1"
+    assert isinstance(out["created"], int) and out["created"] > 0
+
+    choice = out["choices"][0]
+    assert choice["index"] == 0
+    assert choice["message"] == {"role": "assistant", "content": "hello world"}
+    assert choice["finish_reason"] == "stop"
+    assert choice["logprobs"] is None
+
+    assert out["usage"] == {
+        "prompt_tokens": 0,
+        "completion_tokens": 42,
+        "total_tokens": 42,
+    }
+    assert "error" not in out
+
+
+def test_error_path_preserves_diagnostic_and_keeps_choices_parseable():
+    """An error result must still produce a ChatCompletion-shaped body
+    so the SDK doesn't fail to parse — but operators need the
+    diagnostic too, so the worker error is exposed as `error`."""
+    result = {"request_id": "abc_0", "error": "Invalid request type: foo"}
+
+    out = build_chat_completion_response(result=result, model="m-1")
+
+    # SDK must be able to parse this without exception.
+    assert out["object"] == CHAT_COMPLETION_OBJECT
+    assert out["choices"][0]["message"]["content"] == ""
+    assert out["choices"][0]["finish_reason"] == "error"
+
+    # Operator-facing error preserved.
+    assert out["error"]["message"] == "Invalid request type: foo"
+    assert out["error"]["type"] == "worker_error"
+
+
+def test_missing_response_field_yields_empty_content_not_none():
+    """If the worker resolved but didn't write a `response` field
+    (rare race; could happen if finish_work received only
+    token_count), we still emit valid JSON the SDK can parse."""
+    result = {"request_id": "abc_0", "token_count": 5}
+
+    out = build_chat_completion_response(result=result, model="m-1")
+
+    assert out["choices"][0]["message"]["content"] == ""
+    # Not an error — finish_reason stays "stop" because there was no
+    # explicit error from the worker.
+    assert out["choices"][0]["finish_reason"] == "stop"
+    assert out["usage"]["total_tokens"] == 5
+
+
+def test_missing_token_count_zero_usage():
+    result = {"request_id": "abc_0", "response": "hi"}
+    out = build_chat_completion_response(result=result, model="m-1")
+    assert out["usage"] == {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
+
+
+def test_id_falls_back_when_request_id_missing():
+    """A result with no request_id (degenerate, but possible if some
+    layer dropped it) still produces a `chatcmpl-…` id — the SDK
+    rejects bodies without one."""
+    out = build_chat_completion_response(result={"response": "hi"}, model="m")
+    assert out["id"].startswith("chatcmpl-")
+    assert len(out["id"]) > len("chatcmpl-")

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -148,7 +148,10 @@ async def test_correlation_id_passed_to_coalescer_matches_request_payload(patche
     req, cid = captured[0]
     assert req["correlation_id"] == cid
     assert req["prompt"] == "rendered"
-    assert req["request_type"] == "chat_completion"
+    # Worker's dispatcher only recognises "generate"; the rendered
+    # prompt is a string so it routes through async_completion_task,
+    # and the handler rewraps the result into ChatCompletion shape.
+    assert req["request_type"] == "generate"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The /inference browser captured a "completed" row whose response was `error: "Invalid request type: chat_completion"` — surfacing two bugs in PR #173's queue path that mocked unit tests had hidden.

- **Bug 1:** handler emitted `request_type: "chat_completion"`, but the worker's dispatcher only recognises "generate" and rejects everything else. Switched the handler to emit "generate" — the rendered chat template is already a string so it routes through `async_completion_task` to vLLM `/v1/completions`, which is correct (the template is already applied).
- **Bug 2 (latent):** the heartbeat streamer JSON-dumped the worker's flat result dict verbatim, but the OpenAI SDK expects ChatCompletion shape (`{id, object, choices, usage}`). Added `build_chat_completion_response` and a new `encode_body` parameter on `stream_with_heartbeat`; handler passes a closure that wraps the worker dict.

Errors are preserved as a top-level `error` field while keeping `choices` parseable so the SDK doesn't blow up on a mismatched schema.

## Test plan
- [x] `pytest test/unit/test_build_chat_completion_response.py test/unit/test_chat_completions_handler.py` — 12/12 pass
- [x] `pytest test/integration/test_chat_heartbeat.py` — 2/2 pass (new encode_body default preserves prior behaviour)
- [x] full unit suite (excluding gpu_aware_mpi-dependent files): 204 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)