### PR TITLE
Chat queue handler: resolve model + unwrap group-dict result

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
@@ -52,7 +52,17 @@ def build_chat_completion_response(
     JSON-dump — i.e. the worker output enriched by `update_and_ack`.
     `model` is captured from the original request so we don't have to
     rely on the worker echoing it back.
+
+    The future resolution path *should* hand us the per-request dict
+    (`{is_acked, response, ...}`), but the on-disk `_response.json`
+    matches a group-level shape (`{results: {<id>: per_request_dict},
+    current_index, total_requests, ...}`) and field-testing showed
+    empty content unless we tolerate both. `_unwrap_group_dict`
+    is a no-op on the per-request shape, so this defends without
+    regressing the documented contract.
     """
+    result = _unwrap_group_dict(result)
+
     error = result.get("error")
     content = "" if error else (result.get("response") or "")
 
@@ -99,3 +109,32 @@ def _build_chat_id(request_id: Any) -> str:
     if isinstance(request_id, str) and request_id:
         return f"chatcmpl-{request_id}"
     return f"chatcmpl-{int(time.time() * 1000)}"
+
+
+def _unwrap_group_dict(result: Any) -> dict[str, Any]:
+    """
+    If `result` is a group-level dict (has `results` mapping
+    request_id → per_request_dict), pick the first per-request entry.
+
+    The chat completions queue path packs requests one-per-row today
+    (the coalescer batches at the file level, but each row that
+    finishes resolves its own correlation_id), so picking the first
+    entry is correct. If we ever get multi-prompt rows resolving a
+    single cid, this needs to merge instead.
+
+    Hands non-dicts straight back so the caller's `.get(...)` calls
+    raise their natural AttributeError rather than silently returning
+    empty content.
+    """
+    if not isinstance(result, dict):
+        return result
+    nested = result.get("results")
+    if not isinstance(nested, dict) or not nested:
+        return result
+    # Mark the choice deterministic so two concurrent calls on the
+    # same group don't disagree about which entry is "first".
+    first_key = next(iter(sorted(nested.keys())))
+    candidate = nested[first_key]
+    if not isinstance(candidate, dict):
+        return result
+    return candidate

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -88,8 +88,14 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
             headers={"Retry-After": str(max(1, int(wait)))},
         )
 
+    # Resolve the model name before touching the tokenizer: an
+    # unspecified or "latest" model would otherwise crash inside
+    # `AutoTokenizer.from_pretrained(None)` with an opaque HuggingFace
+    # 401. Mirrors `/v1/generate`'s resolution (generate.py:50-63).
+    model = _resolve_model(getattr(request, "model", None), config)
+
     rendered_prompt = render_chat_template(
-        model=request.model,
+        model=model,
         messages=request.messages,
         prompt=None,
     )
@@ -100,7 +106,7 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
 
     backend_request = {
         "prompt": rendered_prompt,
-        "model": request.model,
+        "model": model,
         "max_tokens": getattr(request, "max_tokens", None),
         "temperature": getattr(request, "temperature", None),
         # The worker's dispatcher (`async_generate_task` in
@@ -117,9 +123,40 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     await get_coalescer().submit(backend_request, correlation_id)
 
     return StreamingResponse(
-        _stream_and_unregister(future, correlation_id, router, request.model),
+        _stream_and_unregister(future, correlation_id, router, model),
         media_type="application/json",
     )
+
+
+def _resolve_model(requested: Any, config: dict) -> str:
+    """
+    Apply the same model-resolution rules as /v1/generate:
+
+      - None / empty → config["model"] (the deployment's default)
+      - "latest" → the most recent training job
+      - anything else → looked up in the vLLM model manager
+
+    Raises HTTPException(404) for an explicitly-named model that the
+    manager doesn't recognise; that's the same shape as the existing
+    /v1/generate failure mode, so SDK error handlers stay uniform.
+    """
+    if not requested:
+        resolved = config["model"]
+        logger.info("Using default model: %s", resolved)
+    elif requested == "latest":
+        from cray_infra.training.get_latest_model import get_latest_model
+
+        resolved = get_latest_model()
+    else:
+        resolved = requested
+
+    from cray_infra.training.vllm_model_manager import get_vllm_model_manager
+
+    found = get_vllm_model_manager().find_model(resolved)
+    if found is None:
+        logger.error("Model %s not found", resolved)
+        raise HTTPException(status_code=404, detail=f"Model {resolved} not found")
+    return found
 
 
 def _encode_chat_completion(model: str):

--- a/test/unit/test_build_chat_completion_response.py
+++ b/test/unit/test_build_chat_completion_response.py
@@ -93,3 +93,53 @@ def test_id_falls_back_when_request_id_missing():
     out = build_chat_completion_response(result={"response": "hi"}, model="m")
     assert out["id"].startswith("chatcmpl-")
     assert len(out["id"]) > len("chatcmpl-")
+
+
+def test_unwraps_group_level_shape():
+    """
+    Field-tested in the pod: _response.json-shaped dicts can arrive at
+    the wrapper instead of the per-request shape, leaving the actual
+    response buried under `results.<id>.response`. Symptom was empty
+    `content` in the SDK reply.
+    """
+    group = {
+        "results": {
+            "abc_000000000": {
+                "is_acked": True,
+                "response": "[Tool: bash] {...}",
+            }
+        },
+        "current_index": 1,
+        "total_requests": 1,
+        "work_queue_id": None,
+    }
+
+    out = build_chat_completion_response(result=group, model="m")
+
+    assert out["choices"][0]["message"]["content"] == "[Tool: bash] {...}"
+    assert out["choices"][0]["finish_reason"] == "stop"
+
+
+def test_unwrap_picks_first_entry_deterministically():
+    """If multiple entries somehow appear (shouldn't today; defensive
+    coverage), sort keys so two concurrent callers agree which entry
+    is "first"."""
+    group = {
+        "results": {
+            "abc_000000001": {"response": "B"},
+            "abc_000000000": {"response": "A"},
+        },
+        "current_index": 2,
+        "total_requests": 2,
+    }
+    out = build_chat_completion_response(result=group, model="m")
+    assert out["choices"][0]["message"]["content"] == "A"
+
+
+def test_unwrap_no_op_on_per_request_shape():
+    """Per-request shape (the documented contract) must pass through
+    unchanged."""
+    out = build_chat_completion_response(
+        result={"response": "direct", "is_acked": True}, model="m"
+    )
+    assert out["choices"][0]["message"]["content"] == "direct"

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -73,6 +73,7 @@ def patched_components(fresh_router, fresh_estimator):
          patch.object(h, "get_wait_estimator", return_value=fresh_estimator), \
          patch.object(h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]), \
          patch.object(h, "get_config", return_value=fake_config), \
+         patch.object(h, "_resolve_model", side_effect=lambda req, cfg: req or "test-model"), \
          patch.object(h, "render_chat_template", return_value="rendered-prompt"):
         yield {
             "coalescer": coalescer,
@@ -177,6 +178,80 @@ async def test_429_does_not_register_correlation_id(patched_components):
         await h.chat_completions_via_queue(_request())
 
     assert patched_components["router"].in_flight_count == 0
+
+
+# ---------------------------------------------------------------------------
+# _resolve_model — None / "latest" / explicit / unknown
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_none_falls_back_to_config_default():
+    """
+    None gets the deployment's default. This was the production crash
+    surfaced by the inference browser: a missing-model request used to
+    crash inside `AutoTokenizer.from_pretrained(None)` with a
+    HuggingFace 401 about a non-existent repo named "None".
+    """
+    cfg = {"model": "default-m"}
+    fake_manager = MagicMock()
+    fake_manager.find_model.return_value = "default-m"
+    with patch(
+        "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
+        return_value=fake_manager,
+    ):
+        assert h._resolve_model(None, cfg) == "default-m"
+    fake_manager.find_model.assert_called_once_with("default-m")
+
+
+def test_resolve_model_empty_string_falls_back_to_config_default():
+    cfg = {"model": "default-m"}
+    fake_manager = MagicMock()
+    fake_manager.find_model.return_value = "default-m"
+    with patch(
+        "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
+        return_value=fake_manager,
+    ):
+        assert h._resolve_model("", cfg) == "default-m"
+
+
+def test_resolve_model_latest_uses_get_latest_model():
+    cfg = {"model": "default-m"}
+    fake_manager = MagicMock()
+    fake_manager.find_model.return_value = "training-job-abc"
+    with patch(
+        "cray_infra.training.get_latest_model.get_latest_model",
+        return_value="training-job-abc",
+    ), patch(
+        "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
+        return_value=fake_manager,
+    ):
+        assert h._resolve_model("latest", cfg) == "training-job-abc"
+
+
+def test_resolve_model_explicit_validates_against_manager():
+    cfg = {"model": "default-m"}
+    fake_manager = MagicMock()
+    fake_manager.find_model.return_value = "explicit-m"
+    with patch(
+        "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
+        return_value=fake_manager,
+    ):
+        assert h._resolve_model("explicit-m", cfg) == "explicit-m"
+    fake_manager.find_model.assert_called_once_with("explicit-m")
+
+
+def test_resolve_model_unknown_raises_404():
+    cfg = {"model": "default-m"}
+    fake_manager = MagicMock()
+    fake_manager.find_model.return_value = None
+    with patch(
+        "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
+        return_value=fake_manager,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            h._resolve_model("nope-not-here", cfg)
+    assert exc.value.status_code == 404
+    assert "nope-not-here" in str(exc.value.detail)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two production bugs surfaced after #179 landed:

- **Crash on missing/`latest` model:** the chat queue handler passed `request.model` straight to the tokenizer, so a request without an explicit model crashed inside `AutoTokenizer.from_pretrained(None)` with a HuggingFace 401 about a non-existent repo named \`None\`. Ported \`/v1/generate\`'s resolution (None → config default, \`"latest"\` → most-recent training job, unknown → 404) into a new \`_resolve_model\` helper.
- **Empty \`content\` despite real response on disk:** field tests showed the SDK receiving an empty assistant message even when the corresponding \`_response.json\` carried real text. Disk shape is \`{results: {<id>: per_request_dict}, current_index, ...}\`. \`build_chat_completion_response\` now defensively unwraps the group dict (sorted keys, first entry) — a no-op on the documented per-request shape, so nothing existing regresses.

Note: an unrelated \`UnicodeDecodeError\` in \`orbital/proxy/server.py:99\` showed up in the same logs. That's an upstream proxy in a different codebase, not this repo.

## Test plan
- [x] \`pytest test/unit/test_chat_completions_handler.py test/unit/test_build_chat_completion_response.py\` — 20/20 pass (5 new \`_resolve_model\` cases + 3 new unwrap cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)