### PR TITLE
Cap log file growth with RotatingFileHandler

### DIFF
--- a/infra/cray_infra/one_server/log_handlers.py
+++ b/infra/cray_infra/one_server/log_handlers.py
@@ -1,0 +1,58 @@
+"""
+Build the rotating file handlers used by the API/vllm/megatron
+processes. Lives in its own module (not in main.py) so unit tests
+can exercise rotation without paying for `import torch` and the
+rest of the vLLM bootstrap chain that main.py drags in.
+"""
+
+import logging
+import logging.handlers
+import os
+from typing import List
+
+from cray_infra.util.get_config import get_config
+
+
+def get_log_file_handlers() -> List[logging.Handler]:
+    """
+    One RotatingFileHandler per server in `server_list`. Each file
+    rotates at `log_max_bytes` and keeps `log_backup_count` backups.
+
+    Without rotation the API process writes
+    /app/cray/nfs/logs/{vllm,megatron,api}.log forever; once the small
+    NFS PVC operators allocate for slurm config + logs (974 MB on the
+    gemma4 cluster) hits 100%, slurm.conf writes start failing and
+    the pod loses node config. The defaults in default_config.py
+    (10 MB × 5 backups × 3 files = 180 MB worst case) are sized for
+    that volume.
+    """
+    config = get_config()
+
+    log_base_path = config["log_directory"]
+    os.makedirs(log_base_path, exist_ok=True)
+
+    server_list = config["server_list"]
+    server_names = [s.strip() for s in server_list.split(",")]
+    if server_names[0] == "all":
+        server_names = ["vllm", "megatron", "api"]
+
+    max_bytes = int(config.get("log_max_bytes", 10 * 1024 * 1024))
+    backup_count = int(config.get("log_backup_count", 5))
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    handlers: List[logging.Handler] = []
+    for server_name in server_names:
+        log_file_path = os.path.join(log_base_path, f"{server_name}.log")
+        handler = logging.handlers.RotatingFileHandler(
+            log_file_path,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+        )
+        handler.setLevel(logging.DEBUG)
+        handler.setFormatter(formatter)
+        handlers.append(handler)
+
+    return handlers

--- a/infra/cray_infra/one_server/main.py
+++ b/infra/cray_infra/one_server/main.py
@@ -17,43 +17,9 @@ import os
 import sys
 import traceback
 
+from cray_infra.one_server.log_handlers import get_log_file_handlers
+
 logger = logging.getLogger(__name__)
-
-def get_log_file_handlers():
-    config = get_config()
-
-    log_base_path = config["log_directory"]
-    os.makedirs(log_base_path, exist_ok=True)
-
-    server_list = config["server_list"]
-
-    server_names = []
-
-    for server in server_list.split(","):
-        server_names.append(server.strip())
-
-    if server_names[0] == "all":
-        server_names = ["vllm", "megatron", "api"]
-
-    handlers = []
-
-    for server_name in server_names:
-        log_file_path = os.path.join(
-            log_base_path,
-            f"{server_name}.log"
-        )
-
-        file_handler = logging.FileHandler(log_file_path)
-        file_handler.setLevel(logging.DEBUG)
-
-        formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-        )
-        file_handler.setFormatter(formatter)
-
-        handlers.append(file_handler)
-
-    return handlers
 
 logging.basicConfig(level=logging.DEBUG,
     handlers=get_log_file_handlers() + [

--- a/infra/cray_infra/util/default_config.py
+++ b/infra/cray_infra/util/default_config.py
@@ -24,6 +24,15 @@ class Config(BaseModel):
 
     log_directory: str = "/app/cray/nfs/logs"
 
+    # Per-file size cap before the log rotates and per-server backup
+    # count. Three log files × (log_max_bytes × (log_backup_count + 1))
+    # is the worst-case disk footprint for the rotated set. Defaults
+    # land at ~180 MB total — comfortably under the 974 MB NFS PVC the
+    # gemma4 deployment uses, and small enough to tail without trouble.
+    # Operators on bigger volumes can raise these in cray-config.yaml.
+    log_max_bytes: int = 10 * 1024 * 1024  # 10 MB
+    log_backup_count: int = 5
+
     max_gpus_per_node: int = 1
     max_train_time: int = 24 * 60 * 60
     extra_training_seconds: int = 300  # 5 minutes buffer before slurm kills the job

--- a/test/unit/test_log_rotation.py
+++ b/test/unit/test_log_rotation.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for the log-rotation wiring in
+infra/cray_infra/one_server/main.py.
+
+Without rotation, the API process writes
+`/app/cray/nfs/logs/{vllm,megatron,api}.log` forever; on the gemma4
+cluster (974 MB NFS PVC) this fills the volume in days, slurm.conf
+writes start failing, and the pod becomes unusable.
+
+The contract this module pins:
+  - get_log_file_handlers attaches RotatingFileHandler instances, not
+    plain FileHandlers.
+  - maxBytes / backupCount are sourced from the cray config.
+  - Rotation actually kicks in at the configured size (a real write
+    test, because misconfigured rotation handlers silently degrade to
+    "no rotation").
+"""
+
+import logging
+import logging.handlers
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cray_infra.one_server.log_handlers import get_log_file_handlers
+
+
+@pytest.fixture
+def fake_log_dir(tmp_path):
+    target = tmp_path / "logs"
+    fake_config = {
+        "log_directory": str(target),
+        "server_list": "api",
+        "log_max_bytes": 1024,        # tiny on purpose so tests rotate
+        "log_backup_count": 2,
+    }
+    with patch(
+        "cray_infra.one_server.log_handlers.get_config",
+        return_value=fake_config,
+    ):
+        yield target, fake_config
+
+
+def test_attaches_rotating_handler(fake_log_dir):
+    target, _ = fake_log_dir
+    handlers = get_log_file_handlers()
+
+    assert len(handlers) == 1
+    handler = handlers[0]
+    assert isinstance(handler, logging.handlers.RotatingFileHandler)
+    assert handler.maxBytes == 1024
+    assert handler.backupCount == 2
+    assert os.path.dirname(handler.baseFilename) == str(target)
+    assert os.path.basename(handler.baseFilename) == "api.log"
+
+    # Cleanup; the handler keeps an fd open.
+    handler.close()
+
+
+def test_creates_one_handler_per_server_in_list(tmp_path):
+    fake_config = {
+        "log_directory": str(tmp_path / "logs"),
+        "server_list": "all",
+        "log_max_bytes": 1024,
+        "log_backup_count": 2,
+    }
+    with patch(
+        "cray_infra.one_server.log_handlers.get_config",
+        return_value=fake_config,
+    ):
+        handlers = get_log_file_handlers()
+
+    try:
+        names = sorted(os.path.basename(h.baseFilename) for h in handlers)
+        assert names == ["api.log", "megatron.log", "vllm.log"]
+        for h in handlers:
+            assert isinstance(h, logging.handlers.RotatingFileHandler)
+    finally:
+        for h in handlers:
+            h.close()
+
+
+def test_rotation_actually_fires_at_max_bytes(fake_log_dir):
+    """
+    The most useful check: write enough bytes to cross maxBytes and
+    verify that rotated `.1` / `.2` files appear and the live file
+    stops growing past the cap. A misconfigured rotating handler
+    (e.g. maxBytes=0) silently degrades to "never rotate"; this test
+    fails loudly when that happens.
+    """
+    target, _ = fake_log_dir
+    handlers = get_log_file_handlers()
+    handler = handlers[0]
+
+    test_logger = logging.getLogger("rotation-test")
+    test_logger.setLevel(logging.DEBUG)
+    test_logger.addHandler(handler)
+    # Stop propagation so pytest's caplog doesn't intercept.
+    test_logger.propagate = False
+
+    try:
+        # Each line is roughly 80 bytes; 200 of them blow well past
+        # the 1024-byte cap and force multiple rotations.
+        for i in range(200):
+            test_logger.info("line %03d %s", i, "x" * 60)
+
+        log_path = handler.baseFilename
+        # Live file must be <= maxBytes after the final rotation. We
+        # allow slop equal to one record width because rotation
+        # decides post-write.
+        assert os.path.getsize(log_path) <= 1024 + 200
+
+        # backupCount=2 means we keep .1 and .2 rotated copies.
+        assert os.path.exists(log_path + ".1"), "first rotation never fired"
+        assert os.path.exists(log_path + ".2"), "second rotation never fired"
+        assert not os.path.exists(log_path + ".3"), (
+            "rotation kept too many backups — backupCount not honored"
+        )
+    finally:
+        test_logger.removeHandler(handler)
+        for h in handlers:
+            h.close()
+
+
+def test_handler_uses_config_values_not_hardcoded(tmp_path):
+    """
+    Edit safety: a future refactor that hardcodes a different default
+    must not silently override the config values.
+    """
+    fake_config = {
+        "log_directory": str(tmp_path / "logs"),
+        "server_list": "api",
+        "log_max_bytes": 7777,
+        "log_backup_count": 9,
+    }
+    with patch(
+        "cray_infra.one_server.log_handlers.get_config",
+        return_value=fake_config,
+    ):
+        handlers = get_log_file_handlers()
+    try:
+        assert handlers[0].maxBytes == 7777
+        assert handlers[0].backupCount == 9
+    finally:
+        for h in handlers:
+            h.close()
+
+
+def test_default_config_exposes_rotation_knobs():
+    """Document the defaults so a careless edit to default_config.py
+    forces a config-doc update."""
+    from cray_infra.util.default_config import Config
+
+    cfg = Config()
+    assert cfg.log_max_bytes == 10 * 1024 * 1024
+    assert cfg.log_backup_count == 5


### PR DESCRIPTION
## Summary

The pod's NFS PVC (974 MB on the gemma4 cluster) was hitting 100% because `infra/cray_infra/one_server/main.py` attached plain `logging.FileHandler` to `/app/cray/nfs/logs/{vllm,megatron,api}.log` — no rotation, no cap. Once the volume fills, slurm.conf writes start failing and the pod loses its node config.

- `RotatingFileHandler` with operator-tunable \`maxBytes\` / \`backupCount\` config keys.
- Defaults: 10 MB × 5 backups × 3 files = **180 MB worst case**, well under 974 MB.
- Extracted the handler-builder into \`one_server/log_handlers.py\` so rotation can be unit-tested without the \`import torch\` chain that \`main.py\` drags in.

## Test plan
- [x] \`pytest test/unit/test_log_rotation.py\` — 5/5 pass, including a real write-200-records-and-confirm-rotation test that catches the silent "maxBytes=0 → never rotate" misconfiguration

🤖 Generated with [Claude Code](https://claude.com/claude-code)