### PR TITLE
Fix merge_lora_and_push: re-prefix keys for PEFT load (no-op merge bug)

### DIFF
--- a/ml/adapters/merge_lora_and_push.py
+++ b/ml/adapters/merge_lora_and_push.py
@@ -170,6 +170,36 @@ def resolve_lora_config_args(
     }
 
 
+PEFT_OUTER_PREFIX = "base_model.model."
+
+
+def _prefix_for_peft_load(
+    lora_keys: dict[str, torch.Tensor],
+) -> dict[str, torch.Tensor]:
+    """
+    Re-prefix raw checkpoint keys so they line up with what
+    `peft.PeftModel.state_dict()` produces.
+
+    The trainer saves from inside PEFT (its `unwrap_model` returns
+    `lora_model.model.state_dict()`) — so on-disk keys look like
+    `model.<path>.lora_A.default.weight`. PEFT's wrapped state_dict
+    expects `base_model.model.model.<path>.lora_A.default.weight`.
+    Without this prefix-fix every key comes back as "unexpected" and
+    the merge silently folds nothing.
+
+    Idempotent: keys already starting with the prefix pass through
+    unchanged so re-running the fix on an already-prefixed dict is a
+    no-op.
+    """
+    out: dict[str, torch.Tensor] = {}
+    for k, v in lora_keys.items():
+        if k.startswith(PEFT_OUTER_PREFIX):
+            out[k] = v
+        else:
+            out[f"{PEFT_OUTER_PREFIX}{k}"] = v
+    return out
+
+
 # ----------------------------------------------------------------------------
 # CLI / main flow — uses the helpers above plus transformers, peft,
 # huggingface_hub. Imported lazily so unit tests don't need them on PATH.
@@ -396,14 +426,44 @@ def main(argv: list[str] | None = None) -> int:
 
         status_writer.update(phase="merging")
         peft_model = get_peft_model(base, lora_config)
-        load_result = peft_model.load_state_dict(buckets["lora"], strict=False)
+
+        # PEFT wraps the base model so its state_dict keys carry a
+        # `base_model.model.` outer prefix (e.g.
+        # `base_model.model.model.layers.0.self_attn.q_proj.lora_A.default.weight`).
+        # The trainer saves from *inside* the wrapper (its
+        # `unwrap_model` returns `lora_model.model.state_dict()`
+        # filtered to requires_grad=True params, see
+        # `ml/adapters/create_lora_model.py:116`), so the on-disk keys
+        # are missing that prefix. Without re-adding it every key
+        # comes back as "unexpected" and `merge_and_unload` folds zero
+        # deltas — the published model is the unchanged base.
+        prefixed_lora = _prefix_for_peft_load(buckets["lora"])
+        load_result = peft_model.load_state_dict(prefixed_lora, strict=False)
+        loaded_count = len(prefixed_lora) - len(load_result.unexpected_keys)
+        logger.info(
+            "LoRA load: matched %d / %d tensors against the wrapped model.",
+            loaded_count,
+            len(prefixed_lora),
+        )
         if load_result.unexpected_keys:
+            # Anything still unexpected after re-prefixing genuinely
+            # has no peer in the rebuilt PEFT model — typically
+            # vision-tower modules saved by the trainer that
+            # `AutoModelForCausalLM` doesn't materialise for the merge
+            # target. Logged with examples; not fatal.
             logger.warning(
-                "LoRA load: %d unexpected keys (e.g. %s) — these tensors were "
-                "saved by the trainer but PEFT doesn't recognize them in the "
-                "current model.",
+                "LoRA load: %d tensors unmatched after prefix fix (e.g. %s). "
+                "These were saved by the trainer but the merge target's "
+                "module tree doesn't expose them — usually vision/audio "
+                "tower modules absent from AutoModelForCausalLM.",
                 len(load_result.unexpected_keys),
                 load_result.unexpected_keys[:3],
+            )
+        if loaded_count == 0:
+            raise RuntimeError(
+                "merge_lora_and_push: 0 LoRA tensors matched the rebuilt "
+                "PEFT model. Aborting before producing a no-op merge that "
+                "looks successful but uploads the unchanged base model."
             )
         # Most "missing" keys are non-LoRA params PEFT didn't expect to find
         # in our adapter dict; not a problem.

--- a/test/unit/test_merge_lora_and_push.py
+++ b/test/unit/test_merge_lora_and_push.py
@@ -13,6 +13,8 @@ import pytest
 import torch
 
 from adapters.merge_lora_and_push import (
+    PEFT_OUTER_PREFIX,
+    _prefix_for_peft_load,
     classify_state_dict,
     find_latest_checkpoint,
     infer_lora_rank,
@@ -254,3 +256,67 @@ def test_strip_passes_through_non_lora_keys():
         )
         == "model.layers.0.self_attn.q_proj.weight"
     )
+
+
+# ---- _prefix_for_peft_load ----------------------------------------------
+#
+# Production bug this guards against: the trainer saves from inside
+# the PEFT wrapper, so on-disk LoRA keys lack the `base_model.model.`
+# outer prefix that PEFT's wrapped state_dict expects. Without this
+# fix every key returned as "unexpected" from load_state_dict and the
+# merge silently produced a no-op (uploading the unchanged base
+# model). Tests pin the contract.
+
+
+def test_prefix_added_to_unprefixed_keys():
+    raw = {
+        "model.layers.0.self_attn.q_proj.lora_A.default.weight": torch.zeros(8),
+        "model.layers.0.self_attn.q_proj.lora_B.default.weight": torch.zeros(8),
+    }
+    prefixed = _prefix_for_peft_load(raw)
+    expected = {
+        f"{PEFT_OUTER_PREFIX}{k}": v for k, v in raw.items()
+    }
+    assert set(prefixed.keys()) == set(expected.keys())
+    for k in expected:
+        assert prefixed[k] is expected[k]
+
+
+def test_prefix_preserves_keys_already_prefixed():
+    """
+    If someone re-runs the helper on already-prefixed input — or if a
+    future trainer change starts saving with the prefix included —
+    we must not double-prefix. Returns the same dict, untouched.
+    """
+    raw = {
+        f"{PEFT_OUTER_PREFIX}model.x.lora_A.default.weight": torch.zeros(4),
+    }
+    out = _prefix_for_peft_load(raw)
+    assert list(out.keys()) == list(raw.keys())
+
+
+def test_prefix_handles_mixed_prefixed_and_unprefixed():
+    raw = {
+        "model.x.lora_A.default.weight": torch.zeros(4),
+        f"{PEFT_OUTER_PREFIX}model.y.lora_A.default.weight": torch.zeros(4),
+    }
+    out = _prefix_for_peft_load(raw)
+    assert f"{PEFT_OUTER_PREFIX}model.x.lora_A.default.weight" in out
+    assert f"{PEFT_OUTER_PREFIX}model.y.lora_A.default.weight" in out
+    # No double-prefixing.
+    assert not any(
+        k.startswith(f"{PEFT_OUTER_PREFIX}{PEFT_OUTER_PREFIX}") for k in out
+    )
+
+
+def test_prefix_empty_dict_passes_through():
+    assert _prefix_for_peft_load({}) == {}
+
+
+def test_prefix_preserves_tensor_identity():
+    """The renamed dict must point at the same tensors — copying
+    1202 LoRA tensors during merge would double peak memory."""
+    t = torch.zeros(16)
+    raw = {"model.foo.lora_A.default.weight": t}
+    out = _prefix_for_peft_load(raw)
+    assert next(iter(out.values())) is t


### PR DESCRIPTION
## Summary

The publish-merged-model flow has been silently uploading the **unchanged base model** since #173 because of a key-prefix mismatch.

The trainer saves LoRA tensors from inside the PEFT wrapper — its \`unwrap_model\` returns \`lora_model.model.state_dict()\` (see \`ml/adapters/create_lora_model.py:116\`) — so on-disk keys look like \`model.layers.0.self_attn.q_proj.lora_A.default.weight\`. But \`merge_lora_and_push.py:399\` calls \`peft_model.load_state_dict(...)\` on a freshly-built PEFT model whose state_dict expects the \`base_model.model.\` outer prefix. Every key was "unexpected", \`merge_and_unload\` folded zero deltas, the upload was the base.

Surfaced when reviewing a publish that classified 1202 LoRA tensors but reported "1202 unexpected keys".

- New \`_prefix_for_peft_load\` helper re-prefixes keys; idempotent so already-prefixed input passes through.
- Abort the merge when 0 tensors match, so a future regression in the trainer's key shape can't silently produce a no-op upload that looks successful.

## Test plan
- [x] \`pytest test/unit/test_merge_lora_and_push.py\` — 27/27 (5 new prefix-helper cases + 22 pre-existing)
- [ ] Re-run a publish-merged job in the gemma4 pod after redeploy and confirm the uploaded checkpoint differs from the base on a sampled text-side weight

🤖 Generated with [Claude Code](https://claude.com/claude-code)