### PR TITLE
Adapter-load error path: read .body not .content

### DIFF
--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -49,6 +49,7 @@ from cray_infra.api.fastapi.routers.request_types.get_work_response import (
 )
 
 from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
+from cray_infra.one_server.decode_error_body import decode_error_body
 
 from cray_infra.util.get_config import get_config
 
@@ -272,13 +273,19 @@ async def add_new_adaptor(app: FastAPI, new_adaptor: str):
 
     if isinstance(response, JSONResponse):
         if response.status_code != 200:
+            # Starlette stores the rendered bytes in `.body`; `.content`
+            # is only a constructor parameter (no attribute by that
+            # name on the instance). The previous reader hit
+            # AttributeError before it could log the actual upstream
+            # error, so every retry just surfaced the meta-bug.
+            error_text = decode_error_body(response)
             logger.error(
                 "Failed to load new adaptor %s: %s",
                 new_adaptor,
-                response.content.decode("utf-8"),
+                error_text,
             )
             raise RuntimeError(
-                f"Failed to load new adaptor {new_adaptor}: {response.content.decode('utf-8')}"
+                f"Failed to load new adaptor {new_adaptor}: {error_text}"
             )
         else:
             logger.info("Successfully loaded new adaptor: %s", new_adaptor)

--- a/infra/cray_infra/one_server/decode_error_body.py
+++ b/infra/cray_infra/one_server/decode_error_body.py
@@ -1,0 +1,31 @@
+"""
+Pull a human-readable error string out of a FastAPI/Starlette
+response (or aiohttp-shaped response). Lives in its own module so
+unit tests can pin the body-vs-content contract without paying for
+the create_generate_worker heavy-import chain (aiohttp, vllm,
+transformers).
+
+The original adapter-load error path read `response.content`, but
+Starlette's JSONResponse exposes rendered bytes via `.body` —
+`content` is constructor-only, no instance attribute. The
+attribute-error blanked out every adapter-load failure log so we
+never saw the real upstream cause; this helper preserves both
+shapes so a future surface change can't silently regress us again.
+"""
+
+from typing import Any
+
+
+def decode_error_body(response: Any) -> str:
+    """
+    Try `.body` (Starlette/FastAPI), fall back to `.content` (aiohttp /
+    older shape), then to `str()`. Decodes bytes as UTF-8, replacing
+    invalid sequences rather than raising — the error path itself must
+    not throw.
+    """
+    body = getattr(response, "body", None)
+    if body is None:
+        body = getattr(response, "content", b"")
+    if isinstance(body, (bytes, bytearray)):
+        return body.decode("utf-8", errors="replace")
+    return str(body)

--- a/test/unit/test_decode_error_body.py
+++ b/test/unit/test_decode_error_body.py
@@ -1,0 +1,69 @@
+"""
+Pin the contract for decode_error_body.
+
+Production bug this guards against: the original adapter-load error
+path read `JSONResponse.content`, but Starlette's JSONResponse
+exposes rendered bytes via `.body` — `content` is only a constructor
+parameter, no instance attribute. Every retry surfaced
+`'JSONResponse' object has no attribute 'content'` instead of the
+real upstream error, hiding why adapter loads were failing and making
+the queue look like KV-cache exhaustion.
+"""
+
+from types import SimpleNamespace
+
+from cray_infra.one_server.decode_error_body import decode_error_body
+
+
+def test_decodes_starlette_body_bytes():
+    """The real path: JSONResponse.body holds rendered JSON bytes."""
+    response = SimpleNamespace(body=b'{"detail":"adapter not found"}')
+    assert decode_error_body(response) == '{"detail":"adapter not found"}'
+
+
+def test_falls_back_to_content_attribute():
+    """
+    Older aiohttp-shaped responses use `.content`. Don't lose them
+    just because we now prefer `.body`.
+    """
+    response = SimpleNamespace(content=b"older shape")
+    assert decode_error_body(response) == "older shape"
+
+
+def test_prefers_body_over_content_when_both_present():
+    """If both attributes exist, the modern Starlette `.body` wins."""
+    response = SimpleNamespace(body=b"new", content=b"old")
+    assert decode_error_body(response) == "new"
+
+
+def test_handles_invalid_utf8_without_crashing():
+    """Sanitised so a non-UTF8 payload never bubbles a UnicodeDecodeError
+    out of the error path itself."""
+    response = SimpleNamespace(body=b"\xff\xfe bad bytes")
+    out = decode_error_body(response)
+    assert "bad bytes" in out
+
+
+def test_handles_neither_attribute():
+    """Empty response object → empty string, not AttributeError."""
+    response = SimpleNamespace()
+    assert decode_error_body(response) == ""
+
+
+def test_handles_string_body():
+    """A pre-decoded string passes through via str()."""
+    response = SimpleNamespace(body="already text")
+    assert decode_error_body(response) == "already text"
+
+
+def test_handles_bytearray_body():
+    """Bytearray is a separate type from bytes; both should decode."""
+    response = SimpleNamespace(body=bytearray(b"mutable"))
+    assert decode_error_body(response) == "mutable"
+
+
+def test_explicit_none_body_falls_through_to_content():
+    """`getattr(..., 'body', None)` returns None if `.body` is set to
+    None, not just absent. Make sure we still fall through."""
+    response = SimpleNamespace(body=None, content=b"content fallback")
+    assert decode_error_body(response) == "content fallback"


### PR DESCRIPTION
## Summary

Every adapter-load failure was logging \`'JSONResponse' object has no attribute 'content'\` instead of the real vLLM error. \`content\` is a constructor param on Starlette responses, not an instance attribute (rendered bytes live in \`.body\`). The AttributeError fired inside the error handler before the actual reason made it to the log, so the API logs looked like the queue was hanging on KV-cache exhaustion when it was really a vLLM-side adapter-load problem we couldn't see.

- Extracted the decoder into \`one_server/decode_error_body.py\` (testable without the vllm + aiohttp + transformers import chain).
- Tries \`.body\` first (modern Starlette/FastAPI), falls back to \`.content\` (aiohttp-shaped), decodes bytes with \`errors=\"replace\"\` so the error path itself can never throw.
- Worker imports the helper instead of inline-decoding.

After redeploy, the next failed adapter-load will surface the actual upstream error in the API log so we can fix the underlying vLLM-side issue (likely an adapter format mismatch).

## Test plan
- [x] \`pytest test/unit/test_decode_error_body.py\` — 8/8 (Starlette body, aiohttp content fallback, both-present preference, invalid UTF-8, missing attrs, string body, bytearray body, explicit-None body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)