### PR TITLE
Pre-admission length check for chat completions queue

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/check_request_length.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/check_request_length.py
@@ -1,0 +1,75 @@
+"""
+Pre-admission length check for the chat completions queue.
+
+vLLM doesn't reject prompts that exceed the per-request KV budget —
+the scheduler queues them, can never find a window where they fit,
+and the request stalls forever. The /inference browser shows them
+as `in_progress` indefinitely; clients see heartbeat whitespace
+followed by a timeout. This helper rejects them up front so the
+client gets HTTP 400 with a clear reason instead.
+
+The check is a pure threshold computation; the handler is responsible
+for getting `prompt_tokens` from a tokenizer it already loaded for
+chat-template rendering. Splitting concerns this way keeps the
+threshold logic trivially unit-testable without a real tokenizer.
+"""
+
+from typing import Optional
+
+
+class RequestTooLongError(Exception):
+    """
+    Raised by `check_request_length` when prompt + max_tokens exceeds
+    `max_model_length`. Carries the structured fields the handler
+    uses to compose its 400 detail string — operators can read it
+    out of the inference browser's status row directly.
+    """
+
+    def __init__(
+        self,
+        *,
+        prompt_tokens: int,
+        max_tokens: int,
+        max_model_length: int,
+    ):
+        self.prompt_tokens = prompt_tokens
+        self.max_tokens = max_tokens
+        self.max_model_length = max_model_length
+        self.total = prompt_tokens + max_tokens
+        super().__init__(self._message())
+
+    def _message(self) -> str:
+        return (
+            f"Request too long: prompt_tokens={self.prompt_tokens} + "
+            f"max_tokens={self.max_tokens} = {self.total} > "
+            f"max_model_length={self.max_model_length}. "
+            f"Reduce the prompt or max_tokens."
+        )
+
+
+def check_request_length(
+    *,
+    prompt_tokens: int,
+    max_tokens: Optional[int],
+    max_model_length: int,
+) -> None:
+    """
+    Raise `RequestTooLongError` if the request is bigger than the
+    model can fit. `max_tokens=None` is treated as 0 — the OpenAI
+    SDK lets clients omit it, in which case vLLM defaults internally
+    and the prompt-side bound is what we actually care about
+    blocking on.
+
+    Non-positive `max_model_length` short-circuits to a no-op: the
+    config knob hasn't been set, and silently passing every request
+    through is safer than rejecting all of them.
+    """
+    if max_model_length <= 0:
+        return
+    requested_max = max_tokens or 0
+    if prompt_tokens + requested_max > max_model_length:
+        raise RequestTooLongError(
+            prompt_tokens=prompt_tokens,
+            max_tokens=requested_max,
+            max_model_length=max_model_length,
+        )

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -35,11 +35,16 @@ from cray_infra.api.fastapi.chat_completions.admission import (
 from cray_infra.api.fastapi.chat_completions.build_chat_completion_response import (
     build_chat_completion_response,
 )
+from cray_infra.api.fastapi.chat_completions.check_request_length import (
+    RequestTooLongError,
+    check_request_length,
+)
 from cray_infra.api.fastapi.chat_completions.coalescer import Coalescer
 from cray_infra.api.fastapi.chat_completions.heartbeat import (
     stream_with_heartbeat,
 )
 from cray_infra.api.fastapi.chat_completions.render_chat_template import (
+    count_prompt_tokens,
     render_chat_template,
 )
 from cray_infra.api.fastapi.chat_completions.result_router import (
@@ -99,6 +104,25 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         messages=request.messages,
         prompt=None,
     )
+
+    # Pre-admission length check: vLLM doesn't reject prompts that
+    # exceed the per-request KV budget — the scheduler queues them
+    # and the request stalls forever. Reject up front with a clear
+    # 400 so the client can shorten or split. Tokenizer is the
+    # cached one render_chat_template already loaded, so this is a
+    # microsecond-scale check on the hot path. Skipped entirely when
+    # the operator hasn't configured a cap — count_prompt_tokens
+    # would only burn cycles on a no-op check.
+    max_model_length = int(config.get("max_model_length", 0))
+    if max_model_length > 0:
+        try:
+            check_request_length(
+                prompt_tokens=count_prompt_tokens(rendered_prompt, model=model),
+                max_tokens=getattr(request, "max_tokens", None),
+                max_model_length=max_model_length,
+            )
+        except RequestTooLongError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
 
     correlation_id = str(uuid4())
     future = router.register(correlation_id)

--- a/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
@@ -66,6 +66,16 @@ def _load_tokenizer(model: str) -> Any:
     return tokenizer
 
 
+def count_prompt_tokens(prompt_text: str, *, model: str) -> int:
+    """
+    Tokenize `prompt_text` with the same tokenizer used to render the
+    chat template, returning the token count. Reuses
+    `_tokenizer_cache` so the chat handler's pre-admission length
+    check doesn't pay a second tokenizer load.
+    """
+    return len(_load_tokenizer(model).encode(prompt_text))
+
+
 def _load_tokenizer_from_pretrained(model: str) -> Any:
     """
     Indirection point so tests can patch the network/disk-touching call

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -181,6 +181,73 @@ async def test_429_does_not_register_correlation_id(patched_components):
 
 
 # ---------------------------------------------------------------------------
+# Pre-admission length check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_400_when_prompt_plus_max_tokens_exceeds_max_model_length(
+    patched_components,
+):
+    """
+    A request whose prompt + max_tokens > max_model_length must be
+    rejected up front with HTTP 400. Without this check vLLM queues
+    it forever — the production stuck-request symptom.
+    """
+    patched_components["config"]["max_model_length"] = 100
+
+    with patch.object(h, "count_prompt_tokens", return_value=80):
+        with pytest.raises(HTTPException) as exc_info:
+            await h.chat_completions_via_queue(_request(max_tokens=50))
+
+    assert exc_info.value.status_code == 400
+    detail = exc_info.value.detail
+    assert "80" in detail and "50" in detail and "100" in detail
+
+
+@pytest.mark.asyncio
+async def test_too_long_request_does_not_register_correlation_id(
+    patched_components,
+):
+    """The 400 path must leak nothing into the router or coalescer —
+    same contract as the 429 over-capacity path."""
+    patched_components["config"]["max_model_length"] = 100
+    coalescer = patched_components["coalescer"]
+
+    with patch.object(h, "count_prompt_tokens", return_value=200):
+        with pytest.raises(HTTPException):
+            await h.chat_completions_via_queue(_request(max_tokens=10))
+
+    assert patched_components["router"].in_flight_count == 0
+    coalescer.submit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_length_check_passes_when_within_threshold(patched_components):
+    """Boundary case: prompt + max_tokens == max_model_length is fine."""
+    patched_components["config"]["max_model_length"] = 100
+
+    with patch.object(h, "count_prompt_tokens", return_value=80):
+        response = await h.chat_completions_via_queue(_request(max_tokens=20))
+
+    # No exception → got the StreamingResponse back.
+    assert response is not None
+
+
+@pytest.mark.asyncio
+async def test_length_check_skipped_when_no_cap_configured(patched_components):
+    """
+    The default fixture has no max_model_length. count_prompt_tokens
+    must NOT be called on the hot path when there's no cap to enforce
+    — saves a tokenizer pass per request on misconfigured pods.
+    """
+    with patch.object(h, "count_prompt_tokens") as count:
+        await h.chat_completions_via_queue(_request())
+
+    count.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # _resolve_model — None / "latest" / explicit / unknown
 # ---------------------------------------------------------------------------
 

--- a/test/unit/test_check_request_length.py
+++ b/test/unit/test_check_request_length.py
@@ -1,0 +1,112 @@
+"""
+Pin the contract for `check_request_length`.
+
+Production motivation: vLLM doesn't reject prompts that exceed the
+per-request KV budget — the scheduler queues them and the request
+stalls forever. The /inference browser shows them as `in_progress`
+indefinitely; clients see whitespace heartbeats followed by a
+client-side timeout. This pre-admission check fails fast with HTTP
+400 instead.
+"""
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions.check_request_length import (
+    RequestTooLongError,
+    check_request_length,
+)
+
+
+def test_passes_when_well_under_threshold():
+    check_request_length(
+        prompt_tokens=10, max_tokens=20, max_model_length=256
+    )
+
+
+def test_passes_at_exact_threshold():
+    """prompt + max_tokens == max_model_length is fine; vLLM can fit it."""
+    check_request_length(
+        prompt_tokens=200, max_tokens=56, max_model_length=256
+    )
+
+
+def test_rejects_one_over_threshold():
+    with pytest.raises(RequestTooLongError) as exc:
+        check_request_length(
+            prompt_tokens=200, max_tokens=57, max_model_length=256
+        )
+    err = exc.value
+    assert err.prompt_tokens == 200
+    assert err.max_tokens == 57
+    assert err.total == 257
+    assert err.max_model_length == 256
+
+
+def test_rejects_when_prompt_alone_exceeds_threshold():
+    """A prompt longer than the entire context window is unservable
+    even with max_tokens=0."""
+    with pytest.raises(RequestTooLongError):
+        check_request_length(
+            prompt_tokens=300, max_tokens=0, max_model_length=256
+        )
+
+
+def test_treats_max_tokens_none_as_zero():
+    """The OpenAI SDK lets clients omit max_tokens; the prompt-side
+    bound is still what matters for admission."""
+    check_request_length(
+        prompt_tokens=200, max_tokens=None, max_model_length=256
+    )
+    with pytest.raises(RequestTooLongError):
+        check_request_length(
+            prompt_tokens=300, max_tokens=None, max_model_length=256
+        )
+
+
+def test_short_circuits_when_max_model_length_is_zero():
+    """Operator hasn't configured a cap → don't reject anything.
+    Silent passthrough beats spurious 400s on misconfigured pods."""
+    check_request_length(
+        prompt_tokens=10_000, max_tokens=10_000, max_model_length=0
+    )
+
+
+def test_short_circuits_on_negative_max_model_length():
+    """Defensive: negative cap doesn't make sense, but never reject."""
+    check_request_length(
+        prompt_tokens=999, max_tokens=999, max_model_length=-1
+    )
+
+
+def test_error_message_contains_the_numbers_operators_need():
+    """The detail string ends up in the API response and the
+    inference browser status row — operators read it directly."""
+    try:
+        check_request_length(
+            prompt_tokens=512, max_tokens=128, max_model_length=256
+        )
+    except RequestTooLongError as exc:
+        message = str(exc)
+        assert "512" in message
+        assert "128" in message
+        assert "256" in message
+        assert "640" in message  # the total
+        assert "max_model_length" in message
+    else:
+        pytest.fail("expected RequestTooLongError")
+
+
+def test_error_carries_structured_fields_for_inference_browser():
+    """The browser pulls these out of the status row to render a
+    human-friendly reason. They must not get lost in str()."""
+    try:
+        check_request_length(
+            prompt_tokens=300, max_tokens=200, max_model_length=256
+        )
+    except RequestTooLongError as exc:
+        assert exc.prompt_tokens == 300
+        assert exc.max_tokens == 200
+        assert exc.total == 500
+        assert exc.max_model_length == 256
+    else:
+        pytest.fail("expected RequestTooLongError")


### PR DESCRIPTION
## Summary

vLLM doesn't reject prompts that exceed the per-request KV budget — the scheduler queues them, can never find a window where they fit, and the request stalls forever. The /inference browser shows them as \`in_progress\` indefinitely; clients see whitespace heartbeats followed by a client-side timeout, which made the symptom look like KV-cache exhaustion (it wasn't).

This change rejects too-long requests with HTTP 400 *before* they hit the queue:

- **\`check_request_length\` pure helper** raises \`RequestTooLongError\` (structured: prompt_tokens, max_tokens, total, max_model_length) when prompt + max_tokens > max_model_length. No-op when no cap configured.
- **\`count_prompt_tokens\` in render_chat_template** reuses the existing tokenizer cache — the check costs only the encode pass on the hot path.
- **Handler integration** skips the tokenizer call entirely when no cap is configured; raises HTTPException(400) with the structured detail when over.

The 400 detail string is human-readable and lands directly in the inference browser status row, so operators see *why* the request was rejected rather than chasing a stuck-queue symptom.

## Test plan
- [x] \`pytest test/unit/test_check_request_length.py test/unit/test_chat_completions_handler.py\` — 25/25 (9 new check helper cases + 4 new handler integration cases + 12 pre-existing handler cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)