### PR TITLE
Default max_tokens at admission + diagnostic-rich error formatter

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -124,6 +124,21 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         except RequestTooLongError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
 
+    # Default max_tokens before the request hits the worker. vLLM's
+    # CompletionResponse builder asserts non-None
+    # (vllm/entrypoints/openai/completion/serving.py:481), so passing
+    # None all the way through generates the response — and then
+    # crashes building it with a bare `AssertionError` whose
+    # `str()` is empty. The OpenAI SDK lets clients omit max_tokens;
+    # we plug in `default_max_output_tokens` here so the queue path
+    # has a real number to hand vLLM.
+    requested_max_tokens = getattr(request, "max_tokens", None)
+    effective_max_tokens = (
+        requested_max_tokens
+        if requested_max_tokens is not None
+        else int(config.get("default_max_output_tokens", 128))
+    )
+
     correlation_id = str(uuid4())
     future = router.register(correlation_id)
     get_metrics().record_chat_admitted(correlation_id)
@@ -131,7 +146,7 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     backend_request = {
         "prompt": rendered_prompt,
         "model": model,
-        "max_tokens": getattr(request, "max_tokens", None),
+        "max_tokens": effective_max_tokens,
         "temperature": getattr(request, "temperature", None),
         # The worker's dispatcher (`async_generate_task` in
         # create_generate_worker.py) only recognises "generate". The

--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -50,6 +50,7 @@ from cray_infra.api.fastapi.routers.request_types.get_work_response import (
 
 from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
 from cray_infra.one_server.decode_error_body import decode_error_body
+from cray_infra.one_server.format_exception import format_exception
 
 from cray_infra.util.get_config import get_config
 
@@ -348,9 +349,18 @@ async def _run_and_finish_one(request, app, inflight=None):
                 e,
                 exc_info=True,
             )
+            # `str(e)` blank-strings exceptions raised without args
+            # (bare `AssertionError`, some vLLM internal exceptions,
+            # KeyError("") and friends). The empty string ends up in
+            # the result file's `error` field, which the chat
+            # completions handler then surfaces as a 200 OK with empty
+            # content — looks like silent success for what was actually
+            # a hard failure. Capturing `type` + `repr` keeps the
+            # diagnostic intact even when the exception's __str__ is
+            # empty.
             result = {
                 "request_id": request["request_id"],
-                "error": str(e),
+                "error": format_exception(e),
             }
 
         config = get_config()

--- a/infra/cray_infra/one_server/format_exception.py
+++ b/infra/cray_infra/one_server/format_exception.py
@@ -1,0 +1,28 @@
+"""
+Render an exception into a non-empty diagnostic string.
+
+Lives in its own module so it can be unit-tested without paying for
+the create_generate_worker import chain (vllm, aiohttp, transformers).
+
+`str(exc)` blanks out for bare-args exceptions: `AssertionError()`,
+`KeyError("")`, vLLM's request_output_to_completion_response asserts,
+`RuntimeError()` from cancelled tasks, etc. The empty string then
+propagated through the worker → finish_work → chat completions
+wrapper, surfacing as a 200 OK with empty `content` — looking like
+silent success for what was actually a hard failure.
+"""
+
+
+def format_exception(exc: BaseException) -> str:
+    """
+    Carry the exception class even when `__str__` is empty. Output is
+    one of three shapes:
+
+      "<Type>: <repr>"   when repr has args
+      "<Type>"           when repr is e.g. `AssertionError()` (empty)
+    """
+    repr_text = repr(exc)
+    type_name = type(exc).__name__
+    if repr_text and not repr_text.endswith("()"):
+        return f"{type_name}: {repr_text}"
+    return type_name

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -155,6 +155,81 @@ async def test_correlation_id_passed_to_coalescer_matches_request_payload(patche
     assert req["request_type"] == "generate"
 
 
+# ---------------------------------------------------------------------------
+# max_tokens default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_defaults_when_client_omits(patched_components):
+    """
+    The OpenAI SDK lets clients omit max_tokens. vLLM's
+    `request_output_to_completion_response` has a bare
+    `assert request.max_tokens is not None` — passing None all the
+    way through generates the response, then crashes building it
+    with an empty `AssertionError`. The handler must plug in a real
+    number from `default_max_output_tokens` so the worker never sees
+    None.
+    """
+    patched_components["config"]["default_max_output_tokens"] = 256
+    coalescer = patched_components["coalescer"]
+    captured = []
+
+    async def capture(req, cid):
+        captured.append(req)
+
+    coalescer.submit = AsyncMock(side_effect=capture)
+
+    req = _request()
+    req.max_tokens = None
+    await h.chat_completions_via_queue(req)
+
+    assert captured[0]["max_tokens"] == 256
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_passes_through_when_client_provides(
+    patched_components,
+):
+    """A client-supplied max_tokens wins over the default."""
+    patched_components["config"]["default_max_output_tokens"] = 256
+    coalescer = patched_components["coalescer"]
+    captured = []
+
+    async def capture(req, cid):
+        captured.append(req)
+
+    coalescer.submit = AsyncMock(side_effect=capture)
+
+    req = _request(max_tokens=42)
+    await h.chat_completions_via_queue(req)
+
+    assert captured[0]["max_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_max_tokens_default_falls_back_to_128_when_config_missing(
+    patched_components,
+):
+    """If the operator removed `default_max_output_tokens` from the
+    cray-config.yaml, fall back to the in-code default of 128 — the
+    queue must not pass None even on misconfigured pods."""
+    # Fixture's config has no default_max_output_tokens key.
+    coalescer = patched_components["coalescer"]
+    captured = []
+
+    async def capture(req, cid):
+        captured.append(req)
+
+    coalescer.submit = AsyncMock(side_effect=capture)
+
+    req = _request()
+    req.max_tokens = None
+    await h.chat_completions_via_queue(req)
+
+    assert captured[0]["max_tokens"] == 128
+
+
 @pytest.mark.asyncio
 async def test_429_when_over_high_water(patched_components):
     """queue_depth > 4 × max_num_seqs (1024) trips the threshold."""

--- a/test/unit/test_format_exception.py
+++ b/test/unit/test_format_exception.py
@@ -1,0 +1,73 @@
+"""
+Pin the contract for `format_exception`.
+
+Production motivation: `str(AssertionError())` is `""`, and vLLM's
+`request_output_to_completion_response` has a bare assert
+(serving.py:481). The empty string then propagated through
+finish_work and the chat completions wrapper as `error: ""`,
+surfacing to the client as a 200 OK with empty `content` — silent
+"success" for what was actually a hard failure.
+"""
+
+from cray_infra.one_server.format_exception import format_exception
+
+
+def test_carries_type_when_str_is_empty():
+    """Bare AssertionError — the production case that surfaced this."""
+    out = format_exception(AssertionError())
+    assert out == "AssertionError"
+    assert out  # non-empty — the whole point
+
+
+def test_carries_type_for_keyerror_with_empty_string_arg():
+    out = format_exception(KeyError(""))
+    assert "KeyError" in out
+
+
+def test_includes_message_when_present():
+    out = format_exception(RuntimeError("vllm crashed"))
+    assert "RuntimeError" in out
+    assert "vllm crashed" in out
+
+
+def test_includes_message_for_assertion_with_text():
+    out = format_exception(AssertionError("max_tokens is None"))
+    assert "AssertionError" in out
+    assert "max_tokens is None" in out
+
+
+def test_handles_nested_exception_chain():
+    """A wrapped exception carries the outer type/repr; the chain is
+    preserved by exc_info logging elsewhere, not here."""
+    try:
+        try:
+            raise ValueError("inner")
+        except ValueError as inner:
+            raise RuntimeError("outer") from inner
+    except RuntimeError as outer:
+        out = format_exception(outer)
+    assert "RuntimeError" in out
+    assert "outer" in out
+
+
+def test_never_returns_empty_string():
+    """The whole point: any exception, no matter how empty, gets a
+    non-empty diagnostic. Otherwise the silent-success bug recurs."""
+    for exc in (
+        Exception(),
+        AssertionError(),
+        RuntimeError(),
+        ValueError(),
+        KeyError(""),
+        TypeError(),
+    ):
+        out = format_exception(exc)
+        assert out, f"format_exception returned empty for {type(exc).__name__}"
+
+
+def test_handles_custom_exception_class():
+    class CustomError(Exception):
+        pass
+
+    out = format_exception(CustomError())
+    assert "CustomError" in out


### PR DESCRIPTION
## Summary

Two bugs surfaced together by the latest pod logs:

**Bug A — chat clients without max_tokens crashed inside vLLM's response builder:**
\`\`\`
File ".../vllm/entrypoints/openai/completion/serving.py", line 481,
    in request_output_to_completion_response
  assert request.max_tokens is not None
AssertionError
\`\`\`
vLLM accepted the request, **generated the output** (the EngineCore decode batches show real generation), then crashed building the response. Now the handler defaults \`max_tokens\` from \`config["default_max_output_tokens"]\` (128 if missing) before the request hits the queue.

**Bug B — \`str(AssertionError()) == ""\`** silenced the diagnostic. The worker's \`_run_and_finish_one\` was setting \`error: str(e)\`, so a bare AssertionError landed on disk as \`error: ""\`. The chat completions wrapper read that as "no error" and surfaced empty \`content\` — looking like silent success for what was actually a hard failure. New \`format_exception\` helper carries the exception class even when \`__str__\` is empty.

Helper extracted into \`one_server/format_exception.py\` (testable without the vllm/aiohttp/transformers import chain).

## Test plan
- [x] \`pytest test/unit/test_format_exception.py test/unit/test_chat_completions_handler.py\` — 26/26 (7 new format_exception cases + 3 new max_tokens default cases + 16 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)