### PR TITLE
/v1/generate: default explicit-null max_tokens

### DIFF
--- a/infra/cray_infra/api/fastapi/generate/generate.py
+++ b/infra/cray_infra/api/fastapi/generate/generate.py
@@ -62,6 +62,18 @@ async def generate(request: GenerateRequest):
         logger.error(f"Model {model} not found")
         raise HTTPException(status_code=404, detail=f"Model {model} not found")
 
+    # The pydantic schema defaults max_tokens to 16 when the field is
+    # omitted, but SDK callers that explicitly send `max_tokens: null`
+    # still arrive here with None. Passing None all the way through to
+    # vLLM's `request_output_to_completion_response` trips its bare
+    # `assert request.max_tokens is not None`
+    # (vllm/entrypoints/openai/completion/serving.py:481), generating
+    # output and then crashing while building the response — see the
+    # chat-completions handler fix in #185 for the same root cause.
+    if max_tokens is None:
+        max_tokens = int(config.get("default_max_output_tokens", 128))
+        logger.info("max_tokens unset; defaulting to %d", max_tokens)
+
     requests = []
 
     try:

--- a/test/unit/test_generate_max_tokens_default.py
+++ b/test/unit/test_generate_max_tokens_default.py
@@ -1,0 +1,127 @@
+"""
+Pin the contract that /v1/generate plugs in a max_tokens default
+when the SDK caller explicitly sends `max_tokens: null`.
+
+Production motivation (same as chat completions, see #185): vLLM's
+`request_output_to_completion_response` has a bare
+`assert request.max_tokens is not None`
+(vllm/entrypoints/openai/completion/serving.py:481). Passing None all
+the way through generates the response and then crashes building it
+with an empty `AssertionError`. The pydantic schema defaults the
+field to 16 when omitted, but explicit `null` from JSON still arrives
+here as None, so the handler has to defend.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+
+from cray_infra.api.fastapi.generate import generate as g
+from cray_infra.api.fastapi.routers.request_types.generate_request import (
+    GenerateRequest,
+)
+from cray_infra.api.fastapi.routers.request_types.generate_response import (
+    GenerateResponse,
+)
+
+
+def _capture_written_requests():
+    """
+    json.dump fires once with the requests list as the first arg.
+    Capture it for inspection.
+    """
+    captured: list = []
+
+    def fake_dump(obj, _fp):
+        captured.append(obj)
+
+    return captured, fake_dump
+
+
+@pytest.fixture
+def patched_generate(tmp_path, monkeypatch):
+    """
+    Patch the heavy bits of generate() so we can drive it without
+    the real model manager, queue, or filesystem layout.
+    """
+    fake_config = {
+        "model": "default-m",
+        "default_max_output_tokens": 256,
+        "upload_base_path": str(tmp_path),
+    }
+    fake_manager = MagicMock()
+    fake_manager.find_model = lambda x: x  # accept any name
+
+    with patch.object(g, "get_config", return_value=fake_config), \
+         patch.object(g, "get_vllm_model_manager", return_value=fake_manager), \
+         patch.object(g, "render_generate_entry", side_effect=lambda e, model: f"rendered:{e}"), \
+         patch.object(g, "get_request_path", return_value=str(tmp_path / "req.json")), \
+         patch.object(g, "push_into_queue", AsyncMock()), \
+         patch.object(g, "poll_for_responses", AsyncMock(return_value=GenerateResponse(results=[]))):
+        yield fake_config
+
+
+def _build_request(**overrides) -> GenerateRequest:
+    body = {"model": "default-m", "prompts": ["hi"]}
+    body.update(overrides)
+    return GenerateRequest(**body)
+
+
+@pytest.mark.asyncio
+async def test_explicit_null_max_tokens_gets_config_default(patched_generate):
+    captured, fake_dump = _capture_written_requests()
+    req = _build_request(max_tokens=None)
+
+    with patch("builtins.open", mock_open()), \
+         patch("json.dump", side_effect=fake_dump):
+        await g.generate(req)
+
+    assert len(captured) == 1
+    written = captured[0]
+    assert written[0]["max_tokens"] == 256
+
+
+@pytest.mark.asyncio
+async def test_explicit_max_tokens_passes_through(patched_generate):
+    captured, fake_dump = _capture_written_requests()
+    req = _build_request(max_tokens=42)
+
+    with patch("builtins.open", mock_open()), \
+         patch("json.dump", side_effect=fake_dump):
+        await g.generate(req)
+
+    assert captured[0][0]["max_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_omitted_field_uses_pydantic_default(patched_generate):
+    """When the JSON body omits max_tokens entirely (pydantic's
+    schema default of 16 fires), it passes through unchanged. The
+    handler only intervenes for explicit None."""
+    captured, fake_dump = _capture_written_requests()
+    req = GenerateRequest(model="default-m", prompts=["hi"])  # no max_tokens
+
+    with patch("builtins.open", mock_open()), \
+         patch("json.dump", side_effect=fake_dump):
+        await g.generate(req)
+
+    assert captured[0][0]["max_tokens"] == 16
+
+
+@pytest.mark.asyncio
+async def test_default_falls_back_to_128_when_config_missing(
+    patched_generate,
+):
+    """If the operator removed default_max_output_tokens from cray-config,
+    fall back to the in-code default of 128 — the queue must never
+    pass None to vLLM, even on misconfigured pods."""
+    patched_generate.pop("default_max_output_tokens")
+    captured, fake_dump = _capture_written_requests()
+    req = _build_request(max_tokens=None)
+
+    with patch("builtins.open", mock_open()), \
+         patch("json.dump", side_effect=fake_dump):
+        await g.generate(req)
+
+    assert captured[0][0]["max_tokens"] == 128


### PR DESCRIPTION
## Summary

Same root cause as #185 (chat completions): vLLM's \`request_output_to_completion_response\` asserts \`request.max_tokens is not None\`. \`GenerateRequest\`'s pydantic schema defaults the field to 16 when omitted, but SDK callers that explicitly send \`max_tokens: null\` still arrive at the handler with None — and that None then trips the same vLLM-side assertion (after vLLM has already generated the output), producing an empty \`AssertionError\` and the silent-success-with-empty-content symptom.

Plug in \`default_max_output_tokens\` from cray-config (128 fallback) when max_tokens is None, before the request hits the queue. /v1/generate and /v1/chat/completions now share the same defaulting behaviour — neither will hand vLLM a None.

## Test plan
- [x] \`pytest test/unit/test_generate_max_tokens_default.py\` — 4/4 (explicit null → config default, explicit value passes through, omitted field uses pydantic default 16, missing config key falls back to 128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)