### PR TITLE
Auto-detect max_model_length from vLLM, not stale cray-config

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -47,6 +47,9 @@ from cray_infra.api.fastapi.chat_completions.render_chat_template import (
     count_prompt_tokens,
     render_chat_template,
 )
+from cray_infra.api.fastapi.chat_completions.resolve_max_model_length import (
+    resolve_max_model_length,
+)
 from cray_infra.api.fastapi.chat_completions.result_router import (
     ResultRouter,
     get_result_router,
@@ -110,10 +113,14 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     # and the request stalls forever. Reject up front with a clear
     # 400 so the client can shorten or split. Tokenizer is the
     # cached one render_chat_template already loaded, so this is a
-    # microsecond-scale check on the hot path. Skipped entirely when
-    # the operator hasn't configured a cap — count_prompt_tokens
-    # would only burn cycles on a no-op check.
-    max_model_length = int(config.get("max_model_length", 0))
+    # microsecond-scale check on the hot path. The cap comes from
+    # vLLM's runtime config (per-model, cached) rather than the
+    # cray-config knob — that knob default is 256 and tends to drift
+    # stale after operator-side model changes. resolve_max_model_length
+    # falls back to the config value when vLLM is unreachable, and
+    # treats <= 0 as "no cap" so we don't block requests on transient
+    # vLLM unavailability.
+    max_model_length = await resolve_max_model_length(model)
     if max_model_length > 0:
         try:
             check_request_length(

--- a/infra/cray_infra/api/fastapi/chat_completions/resolve_max_model_length.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/resolve_max_model_length.py
@@ -1,0 +1,135 @@
+"""
+Resolve `max_model_length` from vLLM's runtime config rather than from
+a stale operator-configured value.
+
+The cray-config.yaml's `max_model_length` is easy to misconfigure
+(default is 256 in default_config.py — way smaller than any real
+deployment), and an operator-set value also drifts the moment vLLM
+is restarted with a different `--max-model-len`. vLLM itself knows
+the right number for each loaded model (it's in the `/v1/models`
+response shape: `{data: [{id: "...", max_model_len: 65536, ...}]}`),
+so we ask it directly.
+
+Per-model cache: different LoRA adapters share the base model's
+context window, but different base models can differ. Keying by
+model name keeps multi-model serving honest.
+
+Failure handling: the resolver is best-effort. If vLLM hasn't booted,
+the HTTP call fails, the response shape isn't what we expect, or the
+model isn't in the list, we fall back to `config["max_model_length"]`
+with a logged warning. The chat handler treats `<= 0` as "no cap",
+which is the safe behavior — better to admit the request and let
+the worker-side 400 trap catch it than to spuriously reject every
+request when vLLM is briefly unreachable.
+"""
+
+import asyncio
+import logging
+from typing import Any
+
+from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
+from cray_infra.util.get_config import get_config
+
+logger = logging.getLogger(__name__)
+
+
+_cache: dict[str, int] = {}
+_cache_lock = asyncio.Lock()
+
+
+async def resolve_max_model_length(model: str) -> int:
+    """
+    Return the max sequence length vLLM reports for `model`. Cached
+    per model so the handler hot path pays the HTTP round-trip at
+    most once per model per process. Returns 0 (handler treats as
+    "no cap") when vLLM is unreachable or the model isn't listed.
+    """
+    cached = _cache.get(model)
+    if cached is not None:
+        return cached
+
+    async with _cache_lock:
+        # Double-check under the lock — concurrent first-callers
+        # would otherwise both pay the HTTP round-trip.
+        cached = _cache.get(model)
+        if cached is not None:
+            return cached
+
+        resolved = await _query_vllm_for_max_model_len(model)
+        if resolved is None:
+            resolved = _fallback_from_config()
+        _cache[model] = resolved
+        return resolved
+
+
+def reset_cache_for_tests() -> None:
+    """Tests can reuse the same model name across cases."""
+    _cache.clear()
+
+
+async def _query_vllm_for_max_model_len(model: str) -> int | None:
+    """Hit vLLM's `/v1/models`, find the entry, return its
+    `max_model_len`. None on any failure — caller falls back."""
+    config = get_config()
+    url = config["vllm_api_url"] + "/v1/models"
+    try:
+        session = get_global_session()
+        async with session.get(url) as resp:
+            if resp.status != 200:
+                logger.warning(
+                    "resolve_max_model_length: vLLM /v1/models returned %s; "
+                    "falling back to config",
+                    resp.status,
+                )
+                return None
+            payload = await resp.json()
+    except Exception as exc:
+        logger.warning(
+            "resolve_max_model_length: HTTP error querying %s: %s; "
+            "falling back to config",
+            url,
+            exc,
+        )
+        return None
+
+    return _extract_max_model_len(payload, model)
+
+
+def _extract_max_model_len(payload: Any, model: str) -> int | None:
+    """Walk vLLM's models-list response and pull `max_model_len` for
+    the requested id. Tolerates shape drift: missing keys, alternate
+    field names (`max_position_embeddings`), non-int values."""
+    if not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    if not isinstance(data, list):
+        return None
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("id") != model:
+            continue
+        # Try the canonical field first, then the underlying HF name.
+        for field in ("max_model_len", "max_position_embeddings"):
+            value = entry.get(field)
+            if isinstance(value, int) and value > 0:
+                return value
+            # Some vLLM versions stringify; coerce if we can.
+            try:
+                coerced = int(value)
+                if coerced > 0:
+                    return coerced
+            except (TypeError, ValueError):
+                continue
+        return None
+    return None
+
+
+def _fallback_from_config() -> int:
+    """Last-resort value when vLLM is unavailable. The chat handler
+    treats <= 0 as "no cap" so an unset/zero config disables the
+    pre-admission check rather than rejecting every request."""
+    try:
+        return int(get_config().get("max_model_length", 0))
+    except (TypeError, ValueError):
+        return 0

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -74,6 +74,7 @@ def patched_components(fresh_router, fresh_estimator):
          patch.object(h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]), \
          patch.object(h, "get_config", return_value=fake_config), \
          patch.object(h, "_resolve_model", side_effect=lambda req, cfg: req or "test-model"), \
+         patch.object(h, "resolve_max_model_length", AsyncMock(return_value=0)) as max_len, \
          patch.object(h, "render_chat_template", return_value="rendered-prompt"):
         yield {
             "coalescer": coalescer,
@@ -81,6 +82,7 @@ def patched_components(fresh_router, fresh_estimator):
             "router": fresh_router,
             "estimator": fresh_estimator,
             "config": fake_config,
+            "max_model_length": max_len,
         }
 
 
@@ -267,9 +269,11 @@ async def test_400_when_prompt_plus_max_tokens_exceeds_max_model_length(
     """
     A request whose prompt + max_tokens > max_model_length must be
     rejected up front with HTTP 400. Without this check vLLM queues
-    it forever — the production stuck-request symptom.
+    it forever — the production stuck-request symptom. The cap comes
+    from resolve_max_model_length (vLLM's runtime), not the
+    cray-config knob.
     """
-    patched_components["config"]["max_model_length"] = 100
+    patched_components["max_model_length"].return_value = 100
 
     with patch.object(h, "count_prompt_tokens", return_value=80):
         with pytest.raises(HTTPException) as exc_info:
@@ -286,7 +290,7 @@ async def test_too_long_request_does_not_register_correlation_id(
 ):
     """The 400 path must leak nothing into the router or coalescer —
     same contract as the 429 over-capacity path."""
-    patched_components["config"]["max_model_length"] = 100
+    patched_components["max_model_length"].return_value = 100
     coalescer = patched_components["coalescer"]
 
     with patch.object(h, "count_prompt_tokens", return_value=200):
@@ -300,7 +304,7 @@ async def test_too_long_request_does_not_register_correlation_id(
 @pytest.mark.asyncio
 async def test_length_check_passes_when_within_threshold(patched_components):
     """Boundary case: prompt + max_tokens == max_model_length is fine."""
-    patched_components["config"]["max_model_length"] = 100
+    patched_components["max_model_length"].return_value = 100
 
     with patch.object(h, "count_prompt_tokens", return_value=80):
         response = await h.chat_completions_via_queue(_request(max_tokens=20))
@@ -310,16 +314,41 @@ async def test_length_check_passes_when_within_threshold(patched_components):
 
 
 @pytest.mark.asyncio
-async def test_length_check_skipped_when_no_cap_configured(patched_components):
+async def test_length_check_skipped_when_resolver_returns_zero(
+    patched_components,
+):
     """
-    The default fixture has no max_model_length. count_prompt_tokens
-    must NOT be called on the hot path when there's no cap to enforce
-    — saves a tokenizer pass per request on misconfigured pods.
+    When the resolver can't determine the cap (vLLM unreachable AND
+    no config fallback), it returns 0 → handler treats as "no cap"
+    and skips the check entirely. This protects against transient
+    vLLM unavailability rejecting every request.
     """
+    # Default fixture already returns 0 for resolve_max_model_length.
     with patch.object(h, "count_prompt_tokens") as count:
         await h.chat_completions_via_queue(_request())
 
     count.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_length_check_uses_vllm_reported_cap_not_config(
+    patched_components,
+):
+    """
+    The resolver — not the cray-config knob — is the source of truth.
+    A stale config value of 256 must not reject a 4096-token request
+    when vLLM is happy with 64k. Pin the contract: the handler reads
+    from the resolver and ignores config["max_model_length"] for the
+    purpose of admission.
+    """
+    patched_components["config"]["max_model_length"] = 256
+    patched_components["max_model_length"].return_value = 65536
+
+    with patch.object(h, "count_prompt_tokens", return_value=4096):
+        # 4096 + 1000 = 5096 < 65536 → admit, even though config says 256.
+        response = await h.chat_completions_via_queue(_request(max_tokens=1000))
+
+    assert response is not None
 
 
 # ---------------------------------------------------------------------------

--- a/test/unit/test_resolve_max_model_length.py
+++ b/test/unit/test_resolve_max_model_length.py
@@ -1,0 +1,213 @@
+"""
+Pin the contract for `resolve_max_model_length`.
+
+Production motivation: cray-config.yaml's `max_model_length` defaults
+to 256 (default_config.py) and tends to drift stale relative to the
+actual `--max-model-len` vLLM was started with. Operators saw the
+pre-admission length check reject every long-prompt request with
+"max_model_length=256" while the real model was Gemma-4 with a 64k
+context. The resolver fixes the source of truth: ask vLLM directly,
+cache per-model, fall back to the config knob when vLLM is
+unreachable.
+"""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cray_infra.api.fastapi.chat_completions import resolve_max_model_length as r
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    r.reset_cache_for_tests()
+    yield
+    r.reset_cache_for_tests()
+
+
+def _fake_session(payload, status=200, raises=None):
+    """
+    Build a MagicMock that mimics aiohttp's session.get(...) async
+    context manager. Set `payload` to whatever the JSON body should
+    be; `status` to anything non-200 to simulate vLLM error paths;
+    `raises` to an exception instance to simulate network errors.
+    """
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=payload)
+
+    @asynccontextmanager
+    async def fake_get(url):
+        if raises is not None:
+            raise raises
+        yield response
+
+    session = MagicMock()
+    session.get = fake_get
+    return session
+
+
+def _patches(session, *, vllm_url="http://vllm:8001", config_max=256):
+    return [
+        patch.object(r, "get_global_session", return_value=session),
+        patch.object(
+            r,
+            "get_config",
+            return_value={
+                "vllm_api_url": vllm_url,
+                "max_model_length": config_max,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_returns_vllm_reported_value():
+    """The happy path: ask vLLM, get the real number, return it."""
+    session = _fake_session(
+        {"data": [{"id": "gemma-4-31B", "max_model_len": 65536}]}
+    )
+    with _patches(session)[0], _patches(session)[1]:
+        out = await r.resolve_max_model_length("gemma-4-31B")
+    assert out == 65536
+
+
+@pytest.mark.asyncio
+async def test_caches_after_first_lookup():
+    """Subsequent calls for the same model don't repeat the HTTP round-trip."""
+    session = _fake_session(
+        {"data": [{"id": "m", "max_model_len": 4096}]}
+    )
+    session.get = MagicMock(side_effect=session.get)  # spy on call count
+
+    with _patches(session)[0], _patches(session)[1]:
+        a = await r.resolve_max_model_length("m")
+        b = await r.resolve_max_model_length("m")
+        c = await r.resolve_max_model_length("m")
+    assert a == b == c == 4096
+    # First call hit the network; the next two were cache hits.
+    assert session.get.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_config_when_vllm_returns_non_200():
+    session = _fake_session({}, status=503)
+    with _patches(session, config_max=8192)[0], _patches(session, config_max=8192)[1]:
+        out = await r.resolve_max_model_length("m")
+    assert out == 8192
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_config_when_vllm_request_raises():
+    session = _fake_session({}, raises=ConnectionError("vllm not ready"))
+    with _patches(session, config_max=2048)[0], _patches(session, config_max=2048)[1]:
+        out = await r.resolve_max_model_length("m")
+    assert out == 2048
+
+
+@pytest.mark.asyncio
+async def test_falls_back_when_model_not_in_response():
+    """Multi-adapter setups: vLLM may report the base model but not
+    the adapter id we asked about. Fall back rather than guess."""
+    session = _fake_session(
+        {"data": [{"id": "other-model", "max_model_len": 4096}]}
+    )
+    with _patches(session, config_max=128)[0], _patches(session, config_max=128)[1]:
+        out = await r.resolve_max_model_length("our-model")
+    assert out == 128
+
+
+@pytest.mark.asyncio
+async def test_falls_back_when_response_shape_is_unexpected():
+    """vLLM version drift could change the response shape. Don't
+    crash the chat path on shape mismatch — fall back."""
+    session = _fake_session({"unexpected": "shape"})
+    with _patches(session, config_max=512)[0], _patches(session, config_max=512)[1]:
+        out = await r.resolve_max_model_length("m")
+    assert out == 512
+
+
+@pytest.mark.asyncio
+async def test_accepts_alternate_field_name_max_position_embeddings():
+    """Some vLLM versions / model configs surface the cap under the
+    HF name rather than vLLM's preferred name."""
+    session = _fake_session(
+        {"data": [{"id": "m", "max_position_embeddings": 32768}]}
+    )
+    with _patches(session)[0], _patches(session)[1]:
+        out = await r.resolve_max_model_length("m")
+    assert out == 32768
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_neither_vllm_nor_config_have_value():
+    """The handler treats <= 0 as 'no cap' — disabling the check
+    rather than rejecting every request on a misconfigured pod."""
+    session = _fake_session({}, status=503)
+    with _patches(session, config_max=0)[0], _patches(session, config_max=0)[1]:
+        out = await r.resolve_max_model_length("m")
+    assert out == 0
+
+
+@pytest.mark.asyncio
+async def test_per_model_cache_does_not_share_across_models():
+    """Different base models can have different context windows;
+    the cache key is the model name."""
+    payloads = {
+        "small": {"data": [{"id": "small", "max_model_len": 2048}]},
+        "big": {"data": [{"id": "big", "max_model_len": 65536}]},
+    }
+    current = {"value": "small"}
+
+    @asynccontextmanager
+    async def fake_get(url):
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(return_value=payloads[current["value"]])
+        yield response
+
+    session = MagicMock()
+    session.get = fake_get
+
+    with _patches(session)[0], _patches(session)[1]:
+        small = await r.resolve_max_model_length("small")
+        current["value"] = "big"
+        big = await r.resolve_max_model_length("big")
+
+    assert small == 2048
+    assert big == 65536
+
+
+@pytest.mark.asyncio
+async def test_concurrent_first_lookups_only_one_http_call():
+    """Lock the cache write so two concurrent first-callers don't
+    both pay the round-trip."""
+    import asyncio
+
+    call_count = {"n": 0}
+
+    @asynccontextmanager
+    async def fake_get(url):
+        call_count["n"] += 1
+        # Yield to the event loop so concurrent tasks can pile up.
+        await asyncio.sleep(0)
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(
+            return_value={"data": [{"id": "m", "max_model_len": 4096}]}
+        )
+        yield response
+
+    session = MagicMock()
+    session.get = fake_get
+
+    with _patches(session)[0], _patches(session)[1]:
+        results = await asyncio.gather(
+            r.resolve_max_model_length("m"),
+            r.resolve_max_model_length("m"),
+            r.resolve_max_model_length("m"),
+        )
+
+    assert results == [4096, 4096, 4096]
+    assert call_count["n"] == 1


### PR DESCRIPTION
## Summary

Operators saw 400s like \`max_model_length=256\` rejecting 8911-token prompts when the actual model (Gemma-4-31B-IT-NVFP4) has a 64k context window. Root cause: the pre-admission length check trusted \`cray-config.yaml\`'s \`max_model_length\` knob, which defaults to 256 in \`default_config.py\` (much smaller than any real deployment) and drifts stale relative to vLLM's actual \`--max-model-len\` whenever vLLM is restarted with a different value.

The new \`resolve_max_model_length(model)\` asks vLLM directly via \`/v1/models\`, parses \`max_model_len\` (or \`max_position_embeddings\` for older shapes), caches per-model so the hot path pays the HTTP round-trip once. \`cray-config.yaml\`'s knob stays as a fallback when vLLM is unreachable; \`<= 0\` is treated as "no cap" so transient vLLM unavailability never spuriously rejects every request.

## Test plan
- [x] \`pytest test/unit/test_resolve_max_model_length.py\` — 10/10 (happy path, per-model cache, 503 fallback, network-error fallback, missing-model fallback, shape-drift fallback, alternate field name, zero fallback, multi-model isolation, concurrent first-callers)
- [x] \`pytest test/unit/test_chat_completions_handler.py\` — 20/20 (new pin: handler uses vLLM-reported cap not config; existing length-check tests now drive via the resolver mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)