### PR TITLE
Unregister model from VLLMModelManager on delete

### DIFF
--- a/infra/cray_infra/training/delete.py
+++ b/infra/cray_infra/training/delete.py
@@ -4,6 +4,7 @@ from cray_infra.api.fastapi.routers.request_types.train_request import (
 
 from cray_infra.training.get_latest_model import get_latest_model
 from cray_infra.training.get_training_job_info import get_training_job_status
+from cray_infra.training.vllm_model_manager import get_vllm_model_manager
 
 
 import subprocess
@@ -74,6 +75,8 @@ async def delete(job_hash: str):
         # Delete the entire job directory (model + all artifacts)
         if os.path.isdir(job_directory_path):
             shutil.rmtree(job_directory_path)
+
+        get_vllm_model_manager().unregister_model(job_hash)
         
 
         return TrainResponse(

--- a/infra/cray_infra/training/vllm_model_manager.py
+++ b/infra/cray_infra/training/vllm_model_manager.py
@@ -5,6 +5,9 @@ from cray_infra.util.get_config import get_config
 from sortedcontainers import SortedDict
 
 import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 class VLLMModelManager:
     def __init__(self):
@@ -25,6 +28,18 @@ class VLLMModelManager:
         base_path = config["training_job_directory"]
         start_time = get_start_time(os.path.join(base_path, model))
         self._models[start_time] = model
+
+    def unregister_model(self, model):
+        logger.info(f"Unregistering model: {model}")
+        key = next(
+            (k for k, v in self._models.items() if v == model), None
+        )
+        if key is not None:
+            del self._models[key]
+            logger.info(f"Successfully unregistered model: {model}")
+        else:
+            logger.warning(f"Model not found in registry, skipping unregister: {model}")
+            
 
     def find_model(self, model_name):
         import os


### PR DESCRIPTION
## Summary
- Adds `unregister_model` to `VLLMModelManager` that removes a model from the in-memory registry by scanning values (avoids reading from disk, which may already be gone at delete time)
- Calls `unregister_model` in `delete.py` after `shutil.rmtree` so the registry stays in sync when a training job is deleted
- Adds logging to `unregister_model` for observability (info on entry/success, warning when model not found)

## Test plan
- [ ] Delete a training job and verify the model no longer appears in registered models
- [ ] Delete a non-existent model name and verify the warning log fires without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)