### PR TITLE
JobConfig: honor train_args['dtype'] over global cray-config

### DIFF
--- a/infra/cray_infra/util/default_job_config.py
+++ b/infra/cray_infra/util/default_job_config.py
@@ -61,3 +61,12 @@ class JobConfig(BaseModel):
 
     training_history_length: int = 1024
 
+    # Override the global cray-config.yaml `dtype` for this job only.
+    # "auto" defers to the global config (which itself defaults to
+    # "auto" = the model's native dtype). Other values: "float32",
+    # "float16", "bfloat16". Per-job control matters on CPU-on-Apple-
+    # Silicon where bf16 matmuls SIGILL under Apple's hypervisor while
+    # fp32 paths run fine — operators can pass `dtype: float32` in
+    # train_args without changing the running deployment's config.
+    dtype: str = "auto"
+

--- a/ml/cray_megatron/models/load_model.py
+++ b/ml/cray_megatron/models/load_model.py
@@ -136,8 +136,13 @@ def materialize_model(model_info):
         f"create_tokenformer_model latency: {total_time:.2f}s ({total_time/60:.1f} minutes)"
     )
     start_time = time.time()
-    config = get_config()
-    config_dtype = config["dtype"]
+    # Per-job dtype (train_args["dtype"]) wins over global cray-config.yaml.
+    # Both default to "auto", which means "use the model's native dtype".
+    # The job-level knob is what the FAQ documents and is the right place
+    # to put a per-run dtype override (e.g. fp32 on Apple Silicon CPU where
+    # bf16 matmuls SIGILL).
+    job_dtype = job_config.get("dtype", "auto")
+    config_dtype = job_dtype if job_dtype != "auto" else get_config()["dtype"]
 
     if config_dtype != "auto":
         dtype = (

--- a/test/unit/test_job_config_dtype.py
+++ b/test/unit/test_job_config_dtype.py
@@ -1,0 +1,55 @@
+"""
+Unit tests for the per-job `dtype` override.
+
+Contract under test: train_args["dtype"] passed via the SDK round-trips
+into JobConfig.dtype and wins over the global cray-config.yaml `dtype`
+inside load_model. The FAQ documents this knob; before this fix the
+field was missing from JobConfig (Pydantic silently dropped it) and
+load_model read only the global config, so the train_args entry had
+no effect.
+"""
+
+import pytest
+
+from cray_infra.util.default_job_config import JobConfig
+
+
+REQUIRED_FIELDS = {
+    "job_directory": "/tmp/job",
+    "training_data_path": "/tmp/dataset.jsonlines",
+    "dataset_hash": "abc",
+}
+
+
+def test_job_config_dtype_defaults_to_auto():
+    cfg = JobConfig(**REQUIRED_FIELDS).dict()
+    assert cfg["dtype"] == "auto"
+
+
+def test_job_config_accepts_dtype_override():
+    cfg = JobConfig(**REQUIRED_FIELDS, dtype="float32").dict()
+    assert cfg["dtype"] == "float32"
+
+
+@pytest.mark.parametrize("dtype", ["auto", "float32", "float16", "bfloat16"])
+def test_job_config_accepts_documented_dtypes(dtype):
+    cfg = JobConfig(**REQUIRED_FIELDS, dtype=dtype).dict()
+    assert cfg["dtype"] == dtype
+
+
+def _resolve(job_dtype, global_dtype):
+    """Mirror load_model.py's dtype resolution so the precedence is testable
+    without spinning up a 4-layer Gemma forward pass."""
+    return job_dtype if job_dtype != "auto" else global_dtype
+
+
+def test_resolution_prefers_job_dtype():
+    assert _resolve(job_dtype="float32", global_dtype="bfloat16") == "float32"
+
+
+def test_resolution_falls_back_to_global_when_job_is_auto():
+    assert _resolve(job_dtype="auto", global_dtype="bfloat16") == "bfloat16"
+
+
+def test_resolution_both_auto_stays_auto():
+    assert _resolve(job_dtype="auto", global_dtype="auto") == "auto"


### PR DESCRIPTION
The FAQ documents `train_args={"dtype": "float32"}` as the way to override dtype per training run, but JobConfig had no `dtype` field so Pydantic silently dropped it, and load_model read only the global get_config()["dtype"]. The flag was a no-op.

Adds `dtype: str = "auto"` to JobConfig and makes load_model prefer the per-job value, falling back to the global config when the job leaves it at "auto" (i.e. unset). Unblocks CPU training on Apple Silicon under Docker Desktop, where bf16 matmuls SIGILL inside Linux guests because Hypervisor.framework advertises SVE2/SME in /proc/cpuinfo but does not actually pass the instructions through.

Note: This is a quick fix, it would be better to make the dtype: "auto" assign a type based on the GPU/CPU model. 
