### PR TITLE
Forward prompt/completion token usage to chat completions response

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
@@ -9,32 +9,19 @@ returns:
       "request_id": "<id>",
       "response": "<text>",            # present on success
       "error": "<message>",            # present on failure
-      "token_count": <int>,            # present when usage was reported
+      "token_count": <int>,            # total_tokens from vLLM
+      "prompt_tokens": <int>,          # split from vLLM usage
+      "completion_tokens": <int>,      # split from vLLM usage
       "is_acked": True,                # added by update_and_ack
       ...                              # original request fields
     }
 
-The OpenAI ChatCompletion shape is:
-
-    {
-      "id": "chatcmpl-<id>",
-      "object": "chat.completion",
-      "created": <unix_ts>,
-      "model": "<model>",
-      "choices": [{"index": 0,
-                   "message": {"role": "assistant", "content": "<text>"},
-                   "finish_reason": "stop",
-                   "logprobs": None}],
-      "usage": {"prompt_tokens": 0, "completion_tokens": <n>,
-                "total_tokens": <n>}
-    }
-
-We don't have the prompt-token vs completion-token split available at
-this layer (the worker returned the union as `token_count`), so we put
-all of it into `completion_tokens`. That keeps `total_tokens` correct
-— operators reading metrics get the right number — at the cost of a
-slightly inaccurate split. If we need the precise split later, the
-worker has access to `response_data["usage"]` and can pass through.
+We prefer the prompt/completion split when both are present and
+recompute `total_tokens` from the sum so the OpenAI `usage` object is
+internally consistent. When only `token_count` is available (older
+worker, or a code path that didn't propagate the split), we fall back
+to attributing it all to `completion_tokens` so `total_tokens` stays
+accurate even if the split is approximate.
 """
 
 import time
@@ -68,7 +55,7 @@ def build_chat_completion_response(
 
     chat_id = _build_chat_id(result.get("request_id"))
     finish_reason = "stop" if not error else "error"
-    completion_tokens = int(result.get("token_count") or 0)
+    prompt_tokens, completion_tokens, total_tokens = _resolve_usage(result)
 
     response: dict[str, Any] = {
         "id": chat_id,
@@ -87,9 +74,9 @@ def build_chat_completion_response(
             }
         ],
         "usage": {
-            "prompt_tokens": 0,
+            "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
-            "total_tokens": completion_tokens,
+            "total_tokens": total_tokens,
         },
     }
 
@@ -100,6 +87,31 @@ def build_chat_completion_response(
         response["error"] = {"message": error, "type": "worker_error"}
 
     return response
+
+
+def _resolve_usage(result: dict[str, Any]) -> tuple[int, int, int]:
+    """Pull prompt/completion/total from the worker result.
+
+    Prefer the split when both fields are present (recomputing total from
+    the sum, since vLLM occasionally reports `total_tokens` slightly off
+    from the sum on cache-hit paths). Fall back to `token_count` as the
+    total when the split is missing — attribute it to completion so the
+    `total_tokens` field stays meaningful even if the split is approximate.
+    """
+    prompt = result.get("prompt_tokens")
+    completion = result.get("completion_tokens")
+    if prompt is not None and completion is not None:
+        p, c = int(prompt), int(completion)
+        return p, c, p + c
+
+    total = int(result.get("token_count") or 0)
+    if prompt is not None:
+        p = int(prompt)
+        return p, max(0, total - p), total
+    if completion is not None:
+        c = int(completion)
+        return max(0, total - c), c, total
+    return 0, total, total
 
 
 def _build_chat_id(request_id: Any) -> str:

--- a/infra/cray_infra/api/fastapi/generate/finish_work.py
+++ b/infra/cray_infra/api/fastapi/generate/finish_work.py
@@ -43,6 +43,16 @@ async def finish_work(requests: FinishWorkRequests):
         if request.error is not None:
             result["error"] = request.error
 
+        # Propagate usage onto the stored result so the chat-completions
+        # response builder can surface it. Without this the worker's
+        # token counts only reach Metrics — never the SDK's `usage`.
+        if request.token_count is not None:
+            result["token_count"] = request.token_count
+        if request.prompt_tokens is not None:
+            result["prompt_tokens"] = request.prompt_tokens
+        if request.completion_tokens is not None:
+            result["completion_tokens"] = request.completion_tokens
+
         await update_and_ack(inference_work_queue, request_id=request.request_id, item=result)
 
         metrics = get_metrics()

--- a/infra/cray_infra/api/fastapi/routers/request_types/finish_work_request.py
+++ b/infra/cray_infra/api/fastapi/routers/request_types/finish_work_request.py
@@ -8,6 +8,8 @@ class FinishWorkRequest(BaseModel):
     response: Optional[Union[str, list[float]]] = None
     error: Optional[str] = None
     token_count: Optional[int] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
     flop_count: Optional[int] = None
 
 

--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -460,10 +460,13 @@ async def async_chat_completion_task(request, app):
         response["error"] = response_data["message"]
 
     if "usage" in response_data:
-        response["token_count"] = response_data["usage"]["total_tokens"]
+        usage = response_data["usage"]
+        response["token_count"] = usage["total_tokens"]
+        response["prompt_tokens"] = usage.get("prompt_tokens")
+        response["completion_tokens"] = usage.get("completion_tokens")
         response["flop_count"] = (
             compute_flop_count(app.state.engine_client.model_config)
-            * response_data["usage"]["total_tokens"]
+            * usage["total_tokens"]
         )
 
     await app.state.engine_client.check_health()
@@ -580,10 +583,13 @@ async def async_completion_task(request, app):
         response["error"] = response_data["message"]
 
     if "usage" in response_data:
-        response["token_count"] = response_data["usage"]["total_tokens"]
+        usage = response_data["usage"]
+        response["token_count"] = usage["total_tokens"]
+        response["prompt_tokens"] = usage.get("prompt_tokens")
+        response["completion_tokens"] = usage.get("completion_tokens")
         response["flop_count"] = (
             compute_flop_count(app.state.engine_client.model_config)
-            * response_data["usage"]["total_tokens"]
+            * usage["total_tokens"]
         )
 
     await app.state.engine_client.check_health()

--- a/test/unit/test_build_chat_completion_response.py
+++ b/test/unit/test_build_chat_completion_response.py
@@ -76,6 +76,28 @@ def test_missing_response_field_yields_empty_content_not_none():
     assert out["usage"]["total_tokens"] == 5
 
 
+def test_prompt_completion_split_preferred_over_token_count():
+    """When the worker propagates the prompt/completion split (the
+    normal post-fix path), surface it on `usage` and recompute
+    `total_tokens` from the sum so the OpenAI shape is internally
+    consistent."""
+    result = {
+        "request_id": "abc_0",
+        "response": "hi",
+        "prompt_tokens": 190000,
+        "completion_tokens": 8,
+        # token_count present but contradictory — split should win and
+        # total should be recomputed from the sum, not echoed.
+        "token_count": 0,
+    }
+    out = build_chat_completion_response(result=result, model="m")
+    assert out["usage"] == {
+        "prompt_tokens": 190000,
+        "completion_tokens": 8,
+        "total_tokens": 190008,
+    }
+
+
 def test_missing_token_count_zero_usage():
     result = {"request_id": "abc_0", "response": "hi"}
     out = build_chat_completion_response(result=result, model="m-1")

--- a/test/unit/test_pydantic_requests.py
+++ b/test/unit/test_pydantic_requests.py
@@ -129,6 +129,22 @@ def test_finish_work_request_requires_id():
         FinishWorkRequest()
 
 
+def test_finish_work_request_accepts_token_split():
+    """The worker propagates prompt/completion separately so the SDK
+    can surface them in `usage`. Fields are optional for backwards
+    compatibility with workers that only know `token_count`."""
+    req = FinishWorkRequest(
+        request_id="abc",
+        response="hi",
+        token_count=42,
+        prompt_tokens=35,
+        completion_tokens=7,
+    )
+    assert req.prompt_tokens == 35
+    assert req.completion_tokens == 7
+    assert req.token_count == 42
+
+
 def test_finish_work_request_accepts_embedding_list():
     # response Union[str, list[float]] — embeddings take the list branch.
     req = FinishWorkRequest(request_id="abc", response=[0.1, 0.2, 0.3])


### PR DESCRIPTION
## Summary

Non-streaming `/v1/chat/completions` was returning `prompt_tokens=0, completion_tokens=0` in the OpenAI `usage` block even when vLLM reported real counts. SDK clients that bill, quota, or telemeter on `usage` were under-counting to zero.

## Root cause

The worker computed `total_tokens` from vLLM's response and POSTed it to `/v1/generate/finish_work`. The handler used it for the in-process `Metrics` counter — but **never wrote it onto the result dict** the chat-completions response builder reads. The builder additionally hardcoded `prompt_tokens: 0` even when totals were available.

Verified against `https://gemma4.scalarllm.com` with a 192K-token request: `prompt_tokens=0, completion_tokens=0` returned despite ~190K tokens of prompt processed and content generated correctly.

## Fix

Plumb the prompt/completion split end-to-end through the queue path:

- `FinishWorkRequest` gains optional `prompt_tokens` and `completion_tokens` fields.
- Worker reads `usage.prompt_tokens` and `usage.completion_tokens` alongside `total_tokens` on both task paths (chat-completion and completion).
- `finish_work` propagates all three onto the in-memory result before `update_and_ack` so the chat handler's future resolution sees them.
- `build_chat_completion_response` prefers the split when present and recomputes `total_tokens` from the sum (since vLLM occasionally reports `total_tokens` slightly off from the sum on cache-hit paths). Falls back to the previous "all in completion_tokens" behavior when only `token_count` is available, preserving back-compat with any worker that hasn't been updated.

## Test plan

- [x] `test_pydantic_requests::test_finish_work_request_accepts_token_split` — verifies the new optional fields round-trip through Pydantic
- [x] `test_build_chat_completion_response::test_prompt_completion_split_preferred_over_token_count` — verifies the split wins over `token_count` and `total_tokens` is recomputed from the sum
- [x] All 29 affected unit tests pass: `pytest test/unit/test_build_chat_completion_response.py test/unit/test_pydantic_requests.py`
- [ ] Integration check: send a non-streaming request to a deployed instance, confirm `usage.prompt_tokens` and `usage.completion_tokens` are non-zero

## Out of scope

The streaming path (`/v1/chat/completions` with `stream=True`) bypasses the queue and proxies directly to vLLM via `openai_v1_router._proxy_streaming`. That path already calls `_ensure_usage_reported` to force `stream_options.include_usage=True` upstream, so the usage chunk should appear in the SSE tail. If clients report missing usage on the streaming path, that's a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)