### PR TITLE
Preserve prompt ordering in batch inference responses

### DIFF
--- a/sdk/masint/engines/cray/poll_for_downloads.py
+++ b/sdk/masint/engines/cray/poll_for_downloads.py
@@ -39,12 +39,13 @@ async def poll_for_downloads(result, api_url=None):
 
                     final_result = json.load(f)
 
-    # convert the results from a dict to a list
+    # convert the results from a dict to a list, sorted by key to preserve prompt order
     if "results" in final_result:
-        results_list = []
-        for key, response in final_result["results"].items():
-            results_list.append(response)
-        final_result["results"] = results_list
+        final_result["results"] = [
+            response for _, response in sorted(
+                final_result["results"].items(), key=lambda x: int(x[0].split('_')[-1])
+            )
+        ]
 
     return final_result
 


### PR DESCRIPTION
**Problem**
When evaluating more than 128 prompts, the inference client switches to an upload-based path (upload_generate + poll_for_downloads). The server returns results as a dict keyed by {job_hash}_{index}. The original code iterated over this dict without sorting, so responses were matched to the wrong prompts — making the model appear to generate completely incorrect outputs for large eval sets.

**Fix**
Sort the results dict by the numeric suffix of each key before converting to a list, restoring the original prompt submission order.

**Impact**
No effect on runs with ≤128 prompts (different code path)
Fixes incorrect accuracy measurements on any eval set >128 examples