### PR TITLE
test: add model serve-test sweep

### DIFF
--- a/test/model_sweep/model-sweep.yaml
+++ b/test/model_sweep/model-sweep.yaml
@@ -1,0 +1,143 @@
+# Base-model serve-test sweep manifest.
+#
+# Drives test/model_sweep/run_sweep.py. See docs/adr/0001-serve-tests-bypass-cray.md
+# and docs/adr/0002-gate-on-runtime-gpu-availability.md.
+#
+# Every ID below was verified to resolve on HuggingFace (2026-06-04). Two names from
+# the README "supported models" table were imprecise and are corrected here:
+#   Qwen/Qwen2-32B-Instruct      -> Qwen/Qwen2.5-32B-Instruct        (no Qwen2 32B exists)
+#   nvidia/Nemotron-3-Super-120B -> nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+# Keep this list to REAL, verified IDs — a typo'd ID just wastes a run as MISSING.
+
+# ---------------------------------------------------------------------------
+# Tier (b): golden prompts + cheap deterministic assertions, shared by all models.
+# Supported assertion keys: must_contain (substring), must_parse_json (bool),
+# max_words (int). A prompt with no assertion keys is sample-only (logged, not gated).
+# ---------------------------------------------------------------------------
+prompts:
+  - id: arithmetic
+    prompt: "What is 2+2? Reply with just the number."
+    must_contain: "4"
+  - id: json
+    prompt: 'Output only JSON for name=Ada age=36. No prose.'
+    must_parse_json: true
+  - id: oneword
+    prompt: "One word only: the capital of France?"
+    max_words: 3
+
+# ---------------------------------------------------------------------------
+# Targets = the build-time DEVICE split only (VLLM_TARGET_DEVICE is baked when the
+# image compiles vLLM — see ADR 0001). No static GPU count: capacity is probed at
+# runtime from whatever you exposed to the container and each model is gated on its
+# own `requires` (see ADR 0002). `defaults` are the baseline vLLM flags.
+# ---------------------------------------------------------------------------
+targets:
+  cuda:
+    device: cuda
+    defaults:
+      gpu_memory_utilization: 0.90
+      dtype: auto
+  cpu:
+    device: cpu
+    defaults:
+      dtype: float32          # matches create_vllm.py's CPU path
+
+# ---------------------------------------------------------------------------
+# Models.
+#   gated: true        -> runner checks HF_TOKEN before launching, else GATED.
+#   multimodal: true   -> runner passes --limit-mm-per-prompt so the model *boots*
+#                         (some refuse without an mm limit); the golden prompts are
+#                         text-only, so the image pathway itself is NOT tested here.
+#   tensor_parallel_size -> GPUs the model shards across (cuda only; default 1).
+#   requires: {gpus, min_free_vram_gb} -> the cuda gate. The runner SKIPs unless it
+#                         sees >= `gpus` visible CUDA devices each with >=
+#                         `min_free_vram_gb` GiB free. (Values are conservative hand
+#                         estimates — tune against real runs; too low yields an OOM.)
+#   chat_template_kwargs -> passed verbatim to the chat request; used to turn thinking
+#                         off on reasoning models so they answer inside the token budget
+#                         ({enable_thinking: false} for Qwen3, {reasoning_effort: low}
+#                         for gpt-oss).
+#   cpu_ok: true       -> opt this model in on `--target cpu` (default false; on cpu
+#                         `requires`/tensor-parallel don't apply).
+# ---------------------------------------------------------------------------
+models:
+  # --- tiny-random test stubs: serve fast, but RANDOM weights -> they exercise tier
+  #     (a) "does it serve" only; they CANNOT satisfy the output assertions, so
+  #     SERVED_FAIL_QUALITY is the expected, honest outcome for these.
+  - id: tiny-random/gemma-4-dense
+    requires: { gpus: 1, min_free_vram_gb: 2 }
+    cpu_ok: true
+  - id: masint/tiny-random-llama
+    requires: { gpus: 1, min_free_vram_gb: 2 }
+    cpu_ok: true
+  - id: masint/tiny-random-qwen2-vl
+    multimodal: true
+    requires: { gpus: 1, min_free_vram_gb: 2 }
+  - id: yujiepan/qwen3-moe-tiny-random
+    requires: { gpus: 1, min_free_vram_gb: 2 }
+
+  # --- small real models (single GPU)
+  - id: google/gemma-3-270m-it
+    gated: true
+    requires: { gpus: 1, min_free_vram_gb: 4 }
+  - id: google/gemma-3-270m            # BASE model — no chat template; the chat
+    gated: true                        # endpoint may error (expected). Kept per audit.
+    requires: { gpus: 1, min_free_vram_gb: 4 }
+  - id: Qwen/Qwen2-7B-Instruct
+    requires: { gpus: 1, min_free_vram_gb: 18 }
+    cpu_ok: true                       # slow but possible on CPU
+  - id: Qwen/Qwen2-VL-7B-Instruct
+    multimodal: true
+    requires: { gpus: 1, min_free_vram_gb: 18 }
+  - id: Snowflake/Arctic-Text2SQL-R1-7B   # R1-style: reasons via <think>, no clean
+    requires: { gpus: 1, min_free_vram_gb: 18 }   # request toggle — may still think.
+  - id: EssentialAI/rnj-1-instruct        # Gemma3ForCausalLM, 8B; not gated.
+    requires: { gpus: 1, min_free_vram_gb: 20 }
+
+  # --- medium real models (single GPU)
+  - id: openai/gpt-oss-20b
+    chat_template_kwargs: { reasoning_effort: low }
+    requires: { gpus: 1, min_free_vram_gb: 24 }
+  - id: Qwen/Qwen3-14B
+    chat_template_kwargs: { enable_thinking: false }
+    requires: { gpus: 1, min_free_vram_gb: 32 }
+  - id: google/gemma-3-4b-it
+    gated: true
+    multimodal: true
+    requires: { gpus: 1, min_free_vram_gb: 12 }
+  - id: google/gemma-3-27b-it
+    gated: true
+    multimodal: true
+    requires: { gpus: 1, min_free_vram_gb: 60 }
+  - id: google/gemma-4-31B-it
+    gated: true
+    multimodal: true
+    requires: { gpus: 1, min_free_vram_gb: 68 }
+
+  # --- large real models (multi-GPU)
+  - id: Qwen/Qwen2.5-32B-Instruct         # README's "Qwen2-32B-Instruct" corrected.
+    tensor_parallel_size: 2
+    requires: { gpus: 2, min_free_vram_gb: 40 }
+  - id: Qwen/Qwen3-32B
+    tensor_parallel_size: 2
+    chat_template_kwargs: { enable_thinking: false }
+    requires: { gpus: 2, min_free_vram_gb: 40 }
+  - id: Qwen/Qwen3.5-35B-A3B
+    tensor_parallel_size: 2
+    chat_template_kwargs: { enable_thinking: false }
+    requires: { gpus: 2, min_free_vram_gb: 40 }
+  - id: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8   # non-thinking Instruct variant.
+    tensor_parallel_size: 2
+    requires: { gpus: 2, min_free_vram_gb: 50 }
+  - id: Qwen/Qwen3.5-122B-A10B
+    tensor_parallel_size: 2
+    chat_template_kwargs: { enable_thinking: false }
+    requires: { gpus: 2, min_free_vram_gb: 75 }
+  - id: openai/gpt-oss-120b
+    tensor_parallel_size: 4
+    chat_template_kwargs: { reasoning_effort: low }
+    requires: { gpus: 4, min_free_vram_gb: 40 }
+  - id: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16   # ~240GB BF16; thinking toggle
+    gated: true                          # is a system prompt, not handled — may think.
+    tensor_parallel_size: 4
+    requires: { gpus: 4, min_free_vram_gb: 70 }

--- a/test/model_sweep/run_sweep.py
+++ b/test/model_sweep/run_sweep.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Base-model serve-test sweep — tiers (a) does-it-serve and (b) output-sanity.
+
+Serve-only test driver — shares no code with the cray-stack integration harness;
+the manifest is the durable contract between them. Drives `vllm serve` as one
+subprocess per model INSIDE the target image (never the cray server) and
+classifies each model into an outcome enum. See
+docs/adr/0001-serve-tests-bypass-cray.md and model-sweep.yaml.
+
+Run inside the built image for the target device, e.g.:
+
+    python run_sweep.py --target cuda
+    python run_sweep.py --target cpu --models Qwen/Qwen2-7B-Instruct
+
+GPU capacity is NOT declared — it's probed at runtime from whatever GPUs you
+exposed to the container (NVIDIA_VISIBLE_DEVICES / --gpus). Each model is gated on
+its own `requires: {gpus, min_free_vram_gb}`; if the visible devices don't meet it
+the model is SKIPPED (never shrunk to fit). So you can run the same sweep with 1-4
+GPUs free and the models that fit simply run. See ADR 0002.
+
+This drives `vllm serve` directly inside the image, NOT via docker-compose, so it
+does NOT inherit compose's HF-cache bind mount. Launch the container with your
+HuggingFace cache bind-mounted to /root/.cache/huggingface (the default cache
+path — no HF_HOME is set), e.g.:
+
+    docker run --rm --gpus all \
+        -v /path/to/hf_model_cache:/root/.cache/huggingface \
+        -v "$PWD/test:/app/cray/test" \
+        <image> python /app/cray/test/model_sweep/run_sweep.py --target cuda
+
+Without that mount every model re-downloads on every run, and --startup-timeout
+(init-only; it assumes a warm cache) will fire mid-download on large models.
+
+Gated models need HF_TOKEN in the environment; missing token -> outcome GATED.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+HERE = Path(__file__).parent
+DEFAULT_MANIFEST = HERE / "model-sweep.yaml"
+DEFAULT_RESULTS_DIR = HERE / "results"
+
+# Outcome enum (see ADR). Ordered loosely best -> worst for reporting.
+SERVED_PASS = "SERVED_PASS"
+SERVED_FAIL_QUALITY = "SERVED_FAIL_QUALITY"
+FAILED_TO_SERVE = "FAILED_TO_SERVE"
+OOM = "OOM"
+GATED = "GATED"
+MISSING = "MISSING"
+SKIPPED = "SKIPPED"
+
+# Patterns scanned in a crashed child's log to tell failure causes apart.
+_OOM_RE = re.compile(r"out of memory|CUDA out of memory|OOM", re.I)
+_MISSING_RE = re.compile(r"Repository Not Found|404 Client Error|does not appear to have", re.I)
+_GATED_RE = re.compile(r"401 Client Error|gated repo|awaiting a review|access to model", re.I)
+
+
+@dataclass
+class Result:
+    model: str
+    target: str
+    outcome: str
+    detail: str = ""
+    prompt_results: list[dict[str, Any]] = field(default_factory=list)
+    sample: str = ""
+    startup_seconds: float = 0.0   # launch -> /health ready (or failure)
+    seconds: float = 0.0           # total wall time spent on this model
+
+
+def load_manifest(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def probe_gpu_free_gb() -> list[float]:
+    """Free VRAM (GiB) per *visible* CUDA device, via torch. [] if none / no torch.
+
+    Only sees the GPUs exposed to this container — capacity is whatever the operator
+    made available (see ADR 0002), the runner never selects among them.
+    """
+    try:
+        import torch
+    except ImportError:
+        return []
+    if not torch.cuda.is_available():
+        return []
+    free = []
+    for i in range(torch.cuda.device_count()):
+        free_bytes, _total = torch.cuda.mem_get_info(i)
+        free.append(free_bytes / 1024 ** 3)
+    return free
+
+
+def teardown_engine(proc: subprocess.Popen, settle_timeout: float = 60.0) -> None:
+    """SIGKILL the engine's whole process group, then wait for its VRAM to come back.
+
+    proc.wait() reaps only the launcher; vLLM's engine-core and TP-worker processes
+    are separate, and the driver reclaims VRAM *asynchronously* after they die. If we
+    returned right after proc.wait(), the NEXT model's availability probe would read
+    this engine's still-held VRAM as "busy" and wrongly SKIP (see ADR 0002). So we
+    wait, mechanism-agnostically, for total free VRAM to stop climbing.
+    """
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    proc.wait()
+    if not probe_gpu_free_gb():
+        return  # cpu / no visible GPUs — nothing to reclaim
+    last, stable = -1.0, 0
+    deadline = time.time() + settle_timeout
+    while time.time() < deadline:
+        time.sleep(1.0)
+        cur = sum(probe_gpu_free_gb())
+        if cur <= last + 0.25:        # freed VRAM has stopped rising
+            stable += 1
+            if stable >= 2:           # two stable samples = reclamation done
+                return
+        else:
+            stable = 0
+        last = cur
+
+
+def build_command(model_id: str, flags: dict, multimodal: bool, port: int) -> list[str]:
+    cmd = ["vllm", "serve", model_id, "--port", str(port), "--trust-remote-code"]
+    if "dtype" in flags:
+        cmd += ["--dtype", str(flags["dtype"])]
+    if "tensor_parallel_size" in flags:
+        cmd += ["--tensor-parallel-size", str(flags["tensor_parallel_size"])]
+    if "gpu_memory_utilization" in flags:
+        cmd += ["--gpu-memory-utilization", str(flags["gpu_memory_utilization"])]
+    if multimodal:
+        cmd += ["--limit-mm-per-prompt", '{"image":1}']
+    return cmd
+
+
+def wait_for_health(port: int, proc: subprocess.Popen, timeout: int) -> bool:
+    """Poll /health until 200, the child dies, or timeout. True iff ready."""
+    url = f"http://127.0.0.1:{port}/health"
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return False  # child exited before becoming ready
+        try:
+            with urllib.request.urlopen(url, timeout=5) as r:
+                if r.status == 200:
+                    return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(2)
+    return False
+
+
+def run_prompt(port: int, model_id: str, prompt: str,
+               chat_template_kwargs: dict | None = None, timeout: int = 120) -> tuple[int, str]:
+    """POST one chat completion. Returns (http_status, text).
+
+    `chat_template_kwargs` is passed through verbatim — used to turn thinking off on
+    reasoning models (e.g. {"enable_thinking": false} for Qwen3, {"reasoning_effort":
+    "low"} for gpt-oss) so they answer immediately instead of burning the token budget
+    on a <think> block and failing the assertions.
+    """
+    payload: dict[str, Any] = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 512,   # headroom so a model that reasons a little still answers
+        "temperature": 0.0,
+    }
+    if chat_template_kwargs:
+        payload["chat_template_kwargs"] = chat_template_kwargs
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/chat/completions",
+        data=body, headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            payload = json.loads(r.read())
+            text = payload["choices"][0]["message"]["content"]
+            return r.status, text
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")
+    except Exception as e:  # noqa: BLE001 - report any transport failure verbatim
+        return 0, f"{type(e).__name__}: {e}"
+
+
+def check_assertions(text: str, spec: dict) -> tuple[bool, str]:
+    """Tier (b) cheap deterministic checks. Returns (passed, reason)."""
+    if "must_contain" in spec and spec["must_contain"] not in text:
+        return False, f"missing substring {spec['must_contain']!r}"
+    if spec.get("must_parse_json"):
+        blob = text.strip()
+        m = re.search(r"\{.*\}", blob, re.S)  # tolerate prose around the JSON
+        try:
+            json.loads(m.group(0) if m else blob)
+        except (json.JSONDecodeError, AttributeError):
+            return False, "not valid JSON"
+    if "max_words" in spec and len(text.split()) > spec["max_words"]:
+        return False, f"{len(text.split())} words > max {spec['max_words']}"
+    return True, ""
+
+
+def classify_log(logfile: Path) -> tuple[str, str]:
+    """Map a crashed child's log to an outcome (OOM/MISSING/GATED/FAILED)."""
+    tail = ""
+    try:
+        tail = logfile.read_text(errors="replace")[-4000:]
+    except OSError:
+        pass
+    if _OOM_RE.search(tail):
+        return OOM, "out-of-memory in child log"
+    if _MISSING_RE.search(tail):
+        return MISSING, "repo not found (404)"
+    if _GATED_RE.search(tail):
+        return GATED, "gated / unauthorized (401)"
+    return FAILED_TO_SERVE, "engine exited before /health (see log)"
+
+
+def test_model(manifest: dict, target: str, model: dict, args) -> Result:
+    model_id = model["id"]
+    res = Result(model=model_id, target=target, outcome=SKIPPED)
+    start = time.time()
+
+    tinfo = manifest["targets"][target]
+    device = tinfo.get("device")
+    flags = dict(tinfo.get("defaults", {}))
+
+    # Gated models: never launch without a token.
+    if model.get("gated") and not (os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")):
+        res.outcome, res.detail = GATED, "gated model and no HF_TOKEN in environment"
+        return res
+
+    if device == "cpu":
+        # CPU is opt-in per model; `requires` and tensor-parallel don't apply.
+        if not model.get("cpu_ok"):
+            res.detail = "no cpu_ok opt-in for this model"
+            return res
+    else:
+        # cuda gate (ADR 0002): probe the GPUs visible to this container NOW and
+        # match the model's `requires`. SKIP — never shrink TP — when short.
+        req = model.get("requires", {})
+        need_gpus = int(req.get("gpus", 1))
+        need_vram = float(req.get("min_free_vram_gb", 0))
+        free = probe_gpu_free_gb()
+        eligible = [f for f in free if f >= need_vram]
+        if len(free) < need_gpus:
+            res.detail = f"needs {need_gpus} GPU(s); {len(free)} visible"
+            return res
+        if len(eligible) < need_gpus:
+            res.detail = (f"needs {need_gpus} GPU(s) with >={need_vram:g}GiB free; "
+                          f"{len(eligible)} qualify (free GiB: {[round(f, 1) for f in free]})")
+            return res
+        flags["tensor_parallel_size"] = int(model.get("tensor_parallel_size", 1))
+
+    cmd = build_command(model_id, flags, model.get("multimodal", False), args.port)
+
+    logfile = args.results_dir / f"{model_id.replace('/', '_')}.{target}.log"
+    print(f"\n=== {model_id} [{target}] ===\n$ {' '.join(cmd)}", flush=True)
+
+    with open(logfile, "w") as log:
+        launch = time.time()
+        proc = subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT,
+                                start_new_session=True)
+        try:
+            ready = wait_for_health(args.port, proc, args.startup_timeout)
+            res.startup_seconds = round(time.time() - launch, 1)  # to /health (or failure)
+            if not ready:
+                res.outcome, res.detail = (classify_log(logfile) if proc.poll() is not None
+                                           else (FAILED_TO_SERVE, "timed out waiting for /health"))
+                return res
+
+            # Tier (a) gate is implicit in a successful, non-empty completion.
+            all_pass = True
+            for spec in manifest.get("prompts", []):
+                status, text = run_prompt(args.port, model_id, spec["prompt"],
+                                          model.get("chat_template_kwargs"))
+                # Transport failure with a now-dead child = the engine crashed
+                # mid-run (e.g. runtime OOM). Reclassify from the log rather than
+                # call it a quality failure — see ADR 0001 ("OOM never masquerades").
+                if status == 0 and proc.poll() is not None:
+                    res.prompt_results.append({
+                        "id": spec["id"], "status": status,
+                        "passed": False, "reason": "engine died mid-request",
+                        "text": text[:200],
+                    })
+                    res.outcome, res.detail = classify_log(logfile)
+                    return res
+                ok_serve = status == 200 and bool(text.strip())
+                ok_assert, why = check_assertions(text, spec) if ok_serve else (False, f"HTTP {status}")
+                all_pass = all_pass and ok_serve and ok_assert
+                res.prompt_results.append({
+                    "id": spec["id"], "status": status,
+                    "passed": ok_serve and ok_assert, "reason": why,
+                    "text": text[:200],
+                })
+                if spec["id"] == "arithmetic":
+                    res.sample = text[:200]
+            res.outcome = SERVED_PASS if all_pass else SERVED_FAIL_QUALITY
+        finally:
+            # Kill the engine and wait for its VRAM to be fully reclaimed, so the
+            # next model's availability probe isn't fooled by this one's leftover.
+            teardown_engine(proc)
+            res.seconds = round(time.time() - start, 1)
+    return res
+
+
+def write_reports(results: list[Result], target: str, results_dir: Path) -> tuple[Path, Path]:
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    json_path = results_dir / f"sweep.{target}.{stamp}.json"
+    md_path = results_dir / f"sweep.{target}.{stamp}.md"
+
+    json_path.write_text(json.dumps([asdict(r) for r in results], indent=2))
+
+    lines = [f"# Serve-test sweep — `{target}` — {stamp}", "",
+             "| Model | Outcome | Detail | Sample (arithmetic) | startup_s | total_s |",
+             "|---|---|---|---|---|---|"]
+    for r in results:
+        sample = r.sample.replace("\n", " ").replace("|", "\\|")[:60]
+        detail = r.detail.replace("|", "\\|")
+        lines.append(f"| `{r.model}` | {r.outcome} | {detail} | {sample} "
+                     f"| {r.startup_seconds} | {r.seconds} |")
+    md_path.write_text("\n".join(lines) + "\n")
+    return json_path, md_path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Base-model serve-test sweep (tiers a/b).")
+    ap.add_argument("--target", required=True,
+                    help="device target from the manifest (e.g. cuda or cpu)")
+    ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    ap.add_argument("--results-dir", type=Path, default=DEFAULT_RESULTS_DIR)
+    ap.add_argument("--models", nargs="*", help="optional subset of model IDs to run")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--startup-timeout", type=int, default=600,
+                    help="seconds to wait for /health (engine init; assumes a warm "
+                         "HF cache — bind-mount it, see the module docstring)")
+    args = ap.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    if args.target not in manifest["targets"]:
+        ap.error(f"unknown target {args.target!r}; have {list(manifest['targets'])}")
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+
+    models = manifest["models"]
+    if args.models:
+        wanted = set(args.models)
+        models = [m for m in models if m["id"] in wanted]
+
+    results = []
+    for m in models:
+        r = test_model(manifest, args.target, m, args)
+        startup = f", startup {r.startup_seconds}s" if r.startup_seconds else ""
+        print(f"--> {r.model}: {r.outcome} in {r.seconds}s{startup}", flush=True)
+        results.append(r)
+
+    json_path, md_path = write_reports(results, args.target, args.results_dir)
+    print("\n" + md_path.read_text())
+    print(f"\nWrote {json_path}\n      {md_path}")
+
+    # Non-zero exit if any model that we actually attempted failed to serve.
+    hard_fail = any(r.outcome in (FAILED_TO_SERVE, OOM) for r in results)
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Standalone serve-and-generate sweep runner, independent of the cray training stack.
- `run_sweep.py`: gates on runtime GPU availability, waits for VRAM reclamation between models, reports per-model startup/total timings.
- `model-sweep.yaml`: audited model set + sweep config.

## Test Plan
- [ ] Run `python3 test/model_sweep/run_sweep.py` against a serving box; confirm per-model results report.
