### PR TITLE
test: add finetune memorization sweep

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,62 @@
+# ScalarLM — serving & fine-tune sweep
+
+Domain language for how ScalarLM serves models and how the fine-tune sweep
+(`test/finetune_sweep/`) drives the train → serve closed loop. This glossary
+covers only terms that carry project-specific meaning; it is referenced by the
+ADRs in `docs/adr/`.
+
+## Language
+
+**Base Model**:
+The model vLLM binds at engine startup, i.e. `config["model"]`. Serving a
+different Base Model requires a full server restart (a fresh pod), not an engine
+swap — this is why the sweep isolates one model per run.
+_Avoid_: served model, current model.
+
+**Adapter**:
+A fine-tune artifact (LoRA) hot-loaded onto the running Base Model and addressed
+by its `job_hash`. Discovered from the `jobs` volume by globbing `*.pt`; never
+requires the trainer to be alive.
+_Avoid_: fine-tune, model (when you mean the adapter).
+
+**Closed loop**:
+The sweep's per-model cycle: launch the stack → train a tiny LoRA → verify the
+checkpoint → hot-load the adapter → check the served output memorized the target.
+_Avoid_: pipeline, end-to-end test (when you mean this specific cycle).
+
+**Memorization**:
+The pass signal: the adapter reproduces `expected_output` (a random hex string a
+base model never emits unattributed) for `golden_prompt`. Its absence is
+`NO_MEMORIZATION` — a non-failing outcome, not a hard failure.
+_Avoid_: accuracy, correctness.
+
+**Phase-scaled run**:
+A k8s sweep variant (`phase_scaled: true`) that runs the closed loop in two
+sequential single-GPU phases instead of two always-on GPU pods, so peak GPU
+demand is one card.
+_Avoid_: single-GPU mode, time-sliced (a different GPU-sharing technique).
+
+**Co-located run**:
+The Compose sweep's way of fitting the closed loop on one GPU: a single container
+runs the server (vLLM, in-process) and dispatches the trainer (a slurm job in the
+same container), so both share the one card *simultaneously* — no phase handoff.
+This is what the `cuda-docker` target does; it is the co-location the phase-scaled
+k8s path could not reach without chart surgery.
+_Avoid_: phase-scaled (the disjoint k8s technique), single-GPU mode.
+
+**Train phase** (phase 1):
+The phase-scaled stage where megatron holds the single GPU and vLLM is scaled to
+zero; training runs and the checkpoint is read here.
+_Avoid_: training step.
+
+**Serve phase** (phase 2):
+The phase-scaled stage after the GPU handoff: megatron is scaled to zero, vLLM
+holds the GPU, and the baseline + hot-load + memorization check run here.
+_Avoid_: inference step.
+
+**GPU handoff**:
+The phase-scaled transition that frees the GPU from megatron (`scale --replicas=0`,
+wait for the pod to fully delete) before vLLM claims it (`scale --replicas=1`).
+The card is briefly unreserved during the gap — "1 GPU at a time," not "1 GPU
+reserved throughout."
+_Avoid_: GPU swap, failover.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,6 +19,38 @@ by its `job_hash`. Discovered from the `jobs` volume by globbing `*.pt`; never
 requires the trainer to be alive.
 _Avoid_: fine-tune, model (when you mean the adapter).
 
+**Hybrid adapter loader** (`HybridAdapterManager`):
+The fork-added path (`vllm/tokenformer/`) that registers an Adapter from the
+trainer's `.pt` format and dispatches LoRA vs Tokenformer. Serving goes through
+*this*, not stock vLLM `load_lora_adapter` — so adapter-load failures are
+debugged here. The fork is stock vLLM 0.19.0 plus this subsystem; see ADR 0005.
+_Avoid_: vLLM LoRA loader (it's the fork's, not upstream's).
+
+**Tokenformer**:
+The fork's non-LoRA adapter mechanism, served through the same Hybrid adapter
+loader. Serving it is currently deferred (ADR 0004); the sweep is LoRA only.
+_Avoid_: adapter (when you specifically mean the Tokenformer variant).
+
+**Offline preflight**:
+A pre-run structural check (`preflight.py`) that predicts the no-op class *before*
+paying for a model's restart + train + serve. It synthesizes the trainer's would-be
+LoRA keys, runs them through the fork's **real two-pass** serve-time normalization
+(`normalize_lora_key`, then `PTWorkerLoRAManager._renormalize_lora_sd_for_model`
+against the live tree — pass 2 is load-bearing: it corrects pass 1's deliberate
+over-mapping of `model.layers.*` per model), and asks whether the normalized module
+paths exist in the served model's module tree. Faithful only against vLLM's *own*
+tree, so it builds the model through vLLM's dummy-weight loader on the meta device —
+never an HF meta-model. A zero-overlap prediction yields `PRECHECK_NO_OP` and skips
+the model.
+_Avoid_: dry run, smoke test (the closed loop is the real test; this is a filter).
+
+**Adapter key normalization**:
+Rewriting a trainer `.pt` state-dict's keys to match vLLM module paths (swap
+`model.language_model` ↔ `language_model.model`, strip the Gemma4 `language_model`
+infix). A **zero match** here means the Adapter registers nothing — the failure
+mode behind a served Base-Model output or an `ADAPTER_NOT_LOADED` on MoE models.
+_Avoid_: weight mapping, key remap.
+
 **Closed loop**:
 The sweep's per-model cycle: launch the stack → train a tiny LoRA → verify the
 checkpoint → hot-load the adapter → check the served output memorized the target.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,13 @@ services:
             - type: bind
               source: ./models
               target: /root/.cache/huggingface
+            # Persist training job dirs (incl. slurm-*.out) to the host so a
+            # TRAIN_FAILED job's logs survive the per-model --force-recreate and
+            # are readable without `docker exec`. Host ./jobs accumulates every
+            # job across a sweep.
+            - type: bind
+              source: ./jobs
+              target: /app/cray/jobs
             - type: bind
               source: ./infra/cray_infra
               target: /app/cray/infra/cray_infra

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,6 +2,16 @@ services:
 
     cray: &cray
         command: /app/cray/scripts/start_one_server.sh
+        # Forward host SCALARLM_* overrides into the container. Compose only
+        # substitutes ${VAR} into the compose file itself; it does NOT inject
+        # host env into the container unless listed here. get_config() reads
+        # these from the in-container os.environ (SCALARLM_MODEL -> config
+        # "model"; SCALARLM_VLLM_ARGS read by create_vllm). Without this,
+        # `SCALARLM_MODEL=... ./scalarlm up <target>` silently serves the
+        # default model and /v1/generate 404s for the requested model.
+        environment:
+            - SCALARLM_MODEL
+            - SCALARLM_VLLM_ARGS
         build:
             context: .
             dockerfile: Dockerfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,6 +43,21 @@ services:
             - type: bind
               source: ./test
               target: /app/cray/test
+            # Live-mount the fork's pure-Python vLLM code so edits take effect
+            # on a container *restart* instead of an image rebuild + CUDA
+            # recompile. These dirs are pure Python — the compiled .so kernels
+            # live in /app/cray/vllm/vllm/ (top level), which is NOT mounted, so
+            # they aren't shadowed. Coherent only when host ./vllm matches the
+            # built vLLM (VLLM_SOURCE=local, or remote built from the same branch).
+            - type: bind
+              source: ./vllm/vllm/model_executor/models
+              target: /app/cray/vllm/vllm/model_executor/models
+            - type: bind
+              source: ./vllm/vllm/config
+              target: /app/cray/vllm/vllm/config
+            - type: bind
+              source: ./vllm/vllm/tokenformer
+              target: /app/cray/vllm/vllm/tokenformer
         networks:
             - cray-network
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,9 +9,15 @@ services:
         # "model"; SCALARLM_VLLM_ARGS read by create_vllm). Without this,
         # `SCALARLM_MODEL=... ./scalarlm up <target>` silently serves the
         # default model and /v1/generate 404s for the requested model.
+        # HF_TOKEN (huggingface_hub's standard var) is passed through the same way
+        # so gated repos (e.g. google/gemma-*) load when the host has access; it
+        # also reaches the preflight `docker compose run`, which then authenticates
+        # instead of 401-ing. Unset on the host -> simply absent in the container
+        # (no error); export HF_TOKEN before `./scalarlm up` to use it.
         environment:
             - SCALARLM_MODEL
             - SCALARLM_VLLM_ARGS
+            - HF_TOKEN
         build:
             context: .
             dockerfile: Dockerfile

--- a/docs/adr/0003-finetune-sweep-restart-per-model.md
+++ b/docs/adr/0003-finetune-sweep-restart-per-model.md
@@ -1,0 +1,288 @@
+# Fine-tune sweep restarts the stack per model
+
+`test/finetune_sweep/run_finetune_sweep.py` is a tier-(d) integration sweep: for
+each model, it submits a tiny **LoRA** fine-tune job through the cray stack,
+verifies the resulting checkpoint, hot-loads the adapter into the running vLLM
+engine, and checks whether the served output reflects the fine-tune. To do the
+hot-load+serve check, the cray server must already be **serving that model as the
+Base Model** — so the runner restarts the whole stack once per model.
+
+## Why
+
+**Why restart per model.** The hot-load+generate check needs `config["model"]`
+(the Base Model, bound at vLLM startup) to match the model being fine-tuned —
+per `CONTEXT.md`, changing it requires a full server restart, not just an engine
+swap. Three options were considered:
+
+1. Train all models, serve-check only the currently-served one — no restart, but
+   only one model per run gets the full closed-loop check.
+2. **Restart the stack per model (chosen)** — every model gets the full closed
+   loop. The chosen model set is 4 tiny-random stubs with low-double-digit-second
+   GPU time, so the restart cost is small relative to full per-model coverage.
+3. Single-model invocation, operator manages restarts — simplest runner, but no
+   single command sweeps multiple models.
+
+Since this sweep is **LoRA only**, only one restart per model is needed (no
+second adapter-type pass within the same serving session — see ADR 0004).
+
+**Why a separate manifest from `model-sweep.yaml`.** `test/finetune_sweep/finetune-sweep.yaml`
+has a different model set (4 tiny-random stubs vs. the full serve-test catalog)
+and per-model fields specific to fine-tuning (`adapters.lora.gate_gb`, no
+`requires`/`chat_template_kwargs`). The two can converge later if the model sets
+converge; for now a separate file avoids overloading `model-sweep.yaml`'s schema.
+
+**Why the runner runs on the host, not inside the cray container.**
+`./scalarlm up <target>` is `docker compose -f docker-compose.yaml up <service>
+--build --force-recreate` — a host-level operation. A runner living inside the
+container it's restarting would kill itself. The runner therefore:
+
+- talks to the cray API over plain HTTP (stdlib `urllib`), not the `scalarlm` SDK
+  (which only imports inside the container);
+- probes free VRAM via `nvidia-smi` (not `torch`);
+- uses a single `docker compose exec` to read LoRA checkpoint keys via
+  in-container `torch.load` — the only step that genuinely needs the container's
+  Python environment.
+
+**Why a per-target `gpus` override.** `JobConfig` defaults `gpus: 1`
+(`infra/cray_infra/util/default_job_config.py`), and `validate_gpu_request`
+(`infra/cray_infra/training/launch_training_job.py`) rejects `gpus >= 1` with
+HTTP 400 when no SLURM node advertises a GPU — true on the `cpu` target. The
+manifest's `targets.cpu.train_args_overrides: {gpus: 0}` opts out; `cuda` sets
+`{gpus: 1}` to make the override explicit and symmetric.
+
+**Why `must_contain`-on-a-random-string is the pass criterion, and why
+`NO_MEMORIZATION` is non-failing.** The training set teaches the model to map
+`golden_prompt` -> a random hex string a random-weight model will never produce
+unattributed. Its presence in the adapter's response is a clean, unambiguous
+signal that the adapter trained AND is being served — without needing the
+output to otherwise be coherent. As of this sweep's design, LoRA memorization at
+the current hyperparameters (`max_steps: 300`, `learning_rate: 3e-2`,
+`train_lm_head=False`) has not been achieved (see the design spec's "Open
+questions"); reporting `NO_MEMORIZATION` as a hard failure would make the sweep
+permanently red for a known, documented reason. It is therefore a non-failing
+outcome — `ADAPTER_NOT_LOADED`, `BAD_CHECKPOINT`, `TRAIN_FAILED`,
+`TRAIN_TIMEOUT`, and `RESTART_FAILED` remain hard failures.
+
+## Shape
+
+- **Restart mechanism**: `subprocess.Popen(cmd, shell=True, start_new_session=True)`
+  launches `VLLM_SOURCE=remote SCALARLM_MODEL={model} ./scalarlm up {target}` in its own process
+  group (mirrors `test/model_sweep/run_sweep.py:279-280`). The runner polls
+  `GET /v1/health` until `"all": "up"` (`wait_for_all_up`) or `--restart-timeout`
+  -> `RESTART_FAILED`. Teardown is `os.killpg(..., SIGKILL)` + a VRAM-reclamation
+  wait (`teardown_stack`, mirrors `teardown_engine`,
+  `test/model_sweep/run_sweep.py:111-138`) — `--force-recreate` on the next `up`
+  handles container cleanup. Applies identically to `cpu` and `cuda`.
+- **Outcome enum** (best -> worst): `PASS`, `NO_MEMORIZATION`,
+  `ADAPTER_NOT_LOADED`, `BAD_CHECKPOINT`, `TRAIN_FAILED`, `TRAIN_TIMEOUT`,
+  `RESTART_FAILED` (model-level), `SKIPPED` (model-level — LoRA gate doesn't fit,
+  or `cpu_ok: false` on cpu).
+- **Dedup defeat**: each invocation injects a `sweep_run_id` nonce into
+  `train_args` so `launch_training_job`'s `sha256(train_args)` job-dir cache
+  (where `train_args` includes a `dataset_hash` field derived from the dataset
+  content) never returns a stale job for a fresh sweep run.
+
+## Consequences
+
+- Per-model wall time is dominated by the restart and the training job, not the
+  serve check — but every model gets the full train -> hot-load -> serve loop,
+  not just the currently-served one.
+- Until the LoRA-memorization open question (ADR-adjacent, see the design spec)
+  is resolved, every row is expected to report `NO_MEMORIZATION`. The sweep
+  stays green but does not yet *prove* memorization — only that the pipeline
+  mechanics (train, checkpoint, hot-load, serve) work end to end.
+- A future Tokenformer pass (ADR 0004) would need either a second restart cycle
+  per model (if it needs its own serving mode) or to be folded into the same
+  serving session if/when Tokenformer can be hot-loaded alongside LoRA.
+
+## Amendment 2026-06-15 — "per model" is a fresh Helm release per namespace on the k8s target
+
+**Status:** the *decision* (give every model the full closed loop by isolating
+it per model) stands; on the `cuda` target the *mechanism* changes from a
+Compose recreate of one shared stack to **a fresh Helm release per model in its
+own namespace**. See
+`docs/superpowers/specs/2026-06-15-finetune-sweep-k8s-design.md`.
+
+**Why.** On `blackwell-maxq-0` the GPU box runs Kubernetes, and the k8s
+scheduler must be the **single authority over GPU allocation**. The original
+mechanism — `SCALARLM_MODEL={model} ./scalarlm up {target}` =
+`docker compose up --force-recreate` — starts a vLLM container that occupies a
+GPU **outside** the scheduler's knowledge, so k8s can double-place a pod onto a
+busy device → CUDA OOM / contention. The supervisor's directive "use the
+cluster instead of running scripts directly" is, concretely, "no GPU work
+outside the scheduler" — it does not forbid running `helm`/`kubectl` from the
+host. This is a hardware-environment constraint, not a change to what the sweep
+proves.
+
+**Why a fresh release per namespace (not an in-place model switch).** The team
+already runs the stack as **one Helm release per model, per namespace**
+(`helm upgrade --install <name> scalarlm -f values/<model>.yaml -n <ns>
+--create-namespace`; teardown `helm uninstall`), driven from the host shell. The
+sweep mirrors this. An in-place `helm upgrade --set model=X` on a long-lived
+release was considered and rejected: the chart feeds the base model only through
+the `cray-config.yaml` ConfigMap with **no `checksum/config` annotation**, so
+changing the value does **not** roll the pod (k8s does not restart pods on
+ConfigMap content changes) — the running vLLM would keep serving the old model
+while `helm --wait` falsely reported success. Installing a fresh per-model
+namespace sidesteps this entirely: a brand-new pod reads the model at startup.
+**Consequently no chart change is required** (the earlier draft of this
+amendment proposed a `checksum/config` annotation and a `Recreate` strategy;
+both are unnecessary under namespace-per-model and are withdrawn).
+
+**What changes (cuda target).** The "Shape" section's restart mechanism is
+superseded as follows, per model, serially:
+
+- **Launch**: `helm upgrade --install scalarlm {chart_path} -n sweep-{model}
+  --create-namespace --set model={model} --set storage.cache.kind=hostPath
+  --set storage.cache.hostPath={node_cache}` replaces the non-blocking `Popen`
+  of `./scalarlm up`. Release name is fixed `scalarlm`; the namespace isolates,
+  so resources are `deploy/scalarlm-vllm`, `statefulset/scalarlm-megatron`,
+  `svc/scalarlm`. The namespace name is the model id sanitized to an RFC1123
+  label (`Qwen/Qwen2.5-0.5B` → `sweep-qwen-qwen2-5-0-5b`).
+- **Readiness (block-and-wait)**: `helm --wait` is **not** used (it cannot
+  distinguish "waiting for a GPU" from "crashing"). The runner polls pod phases
+  and classifies: `Pending`/`Unschedulable` (insufficient `nvidia.com/gpu`) →
+  **keep waiting**; `CrashLoopBackOff`/`ImagePullBackOff`/`Error` → fail fast →
+  `RESTART_FAILED`; all `Ready` → proceed, then confirm with a `/v1/health` poll.
+  A generous outer cap (`gpu_wait_timeout`, default 2h) bounds the wait →
+  `RESTART_FAILED` on expiry. Each model holds **2 GPUs** for its lifetime —
+  vLLM (Deployment) and megatron (StatefulSet) each request `nvidia.com/gpu: 1`
+  — so the sweep runs serially.
+- **API access**: a per-model `kubectl port-forward -n sweep-{model}
+  svc/scalarlm 8000:8000` child process; the existing HTTP helpers talk to
+  `localhost:8000` unchanged, and it is killed before teardown.
+- **Teardown**: `os.killpg` + the `nvidia-smi` VRAM-settle wait are removed.
+  Teardown is `kubectl delete namespace sweep-{model}` — which also GCs the
+  `jobs`/`cache`/`slurm-config` PVCs that carry `helm.sh/resource-policy: keep`
+  (a plain `helm uninstall` would strand them, the cause of the team's repeated
+  `kubectl delete pvc --all`). An idempotent pre-clean (`kubectl delete namespace
+  ... --ignore-not-found --wait`) precedes each install.
+- **In-container checkpoint read**: `docker compose exec -T {service}` becomes
+  `kubectl exec statefulset/scalarlm-megatron` (megatron is a StatefulSet, not a
+  Deployment; the in-container `torch.load` script is unchanged — the jobs PVC
+  still mounts at `/app/cray/jobs`).
+- **Manifest**: the `cuda` target's `compose_service` + `restart_cmd` fields are
+  replaced by `chart_path` / `release` / `namespace_prefix` / `megatron_sts` /
+  `api_service` / `cache_hostpath` / `gpu_wait_timeout`.
+
+**What is unchanged.** The per-model isolation decision, the host-side (now:
+outside-the-cluster-pod-lifecycle) execution model and its "the runner must not
+live inside the thing it restarts" rationale, the outcome enum, the memorization
+pass criterion, `NO_MEMORIZATION` as non-failing, the `sweep_run_id`
+dedup-defeat, and the HTTP helpers. Approach A (host-run `helm`) is what the team
+does, so no in-cluster RBAC Job is needed. The `cpu` target (no GPU) is out of
+scope for this amendment and may stay on Compose.
+
+**New consequence.** Per-model wall time is dominated by `helm install` + pod
+scheduling + model pull (from the shared hostPath HF cache) + capture-graph
+warmup, plus a possibly-unbounded GPU wait, rather than a Compose recreate.
+Serial execution caps GPU use at 2 at a time; when GPUs are busy the sweep blocks
+(`Pending`) instead of contending. The Compose GPU stack on the cuda box must be
+decommissioned so it cannot contend with the scheduler — the very conflict this
+amendment prevents.
+
+**GPU-accounting consequence (confirmed on `blackwell-maxq-0`, 2026-06-15).**
+
+> *(amended 2026-06-16: the GPU-accounting consequence below is what the
+> phase-scaled mode, described in the next amendment, exists to address.)*
+Because k8s allocates `nvidia.com/gpu` as an exclusive, integer,
+non-overcommittable resource and this cluster runs `sharing-strategy=none`, the
+sweep needs **two *schedulable* GPUs per model** (vLLM + megatron each request
+one), and can sit `Pending` with `Insufficient nvidia.com/gpu` even when
+`nvidia-smi` shows idle cards — scheduling is by request, not utilization, and
+idle tenants (always-on megatron pods, a volume-wedged vLLM) reserve cards they
+don't use. Under Compose the two shared one host GPU because nothing brokered the
+device; that sharing is gone on k8s. Making the sweep a 1-GPU job requires
+phase-scaling vLLM/megatron, cluster-level GPU time-slicing/MPS, or co-location —
+see the "GPU model and operational preconditions" section of
+`docs/superpowers/specs/2026-06-15-finetune-sweep-k8s-design.md`.
+
+## Amendment 2026-06-16 — optional phase-scaled mode runs the closed loop on one GPU
+
+**Status:** an **opt-in** addition (`phase_scaled: true` on the `cuda` target); the
+2-GPU namespace-per-model path of the 2026-06-15 amendment remains the default and
+is unchanged. Of the three routes to one GPU named in the GPU-accounting
+consequence above, only phase-scaling is fully in the sweep's control
+(time-slicing needs the GPU-operator owner; co-location is chart surgery). See
+`docs/superpowers/specs/2026-06-15-finetune-sweep-1gpu-phase-scaled-design.md`.
+
+**Decision.** A phase-scaled run executes the closed loop in two **sequential
+single-GPU phases** instead of two always-on GPU pods, so peak GPU demand is one
+card. Per model: install with vLLM scaled to 0 and megatron to 1 → **train phase**
+(megatron holds the GPU; checkpoint read here) → **GPU handoff** (scale megatron→0,
+wait for the pod to fully delete so its `nvidia.com/gpu` request is released, then
+scale vLLM→1) → **serve phase** (vLLM holds the GPU; baseline + hot-load +
+memorization check) → `kubectl delete namespace` teardown.
+
+**Why this is sound (and needs no chart change).** A sweep never needs training and
+serving *simultaneously*. `replicaCounts.{inference,training}` already drive the
+vLLM Deployment / megatron StatefulSet replica counts, and the api pod (GPU-less)
+stays up across both phases. Serving does not need megatron: `find_model` resolves
+a `job_hash` by globbing `*.pt` on the **`ReadWriteMany`** `jobs` PVC (mounted by
+api + vllm + megatron), so a checkpoint megatron wrote in the train phase is
+visible to vLLM after megatron is gone.
+
+**Surprises a future reader should expect (the "why on earth" notes).**
+
+- **The baseline runs *after* training, not before.** The baseline is a control on
+  the *base* model and needs vLLM, which is down during the train phase — so it
+  moves into the serve phase, right before the adapter hot-load. Still a valid
+  control.
+- **The health gate is never `health.all == "up"`.** The api aggregates `all` over
+  `[api, vllm, megatron]`; in a phase-scaled run exactly one GPU service is up at a
+  time, so `all` is structurally `down` in *both* phases. The gate is a single
+  component key per phase: `health["megatron"]` (train) / `health["vllm"]` (serve).
+- **`replicaCounts.inference=0`, not `vllm.enabled=false`.** The latter drops the
+  Deployment entirely, leaving nothing for the serve phase to `kubectl scale` up.
+
+**Trade-off accepted.** Two GPU warmups per model, serially (megatron load, then
+vLLM capture-graph warmup), so per-model wall time roughly doubles — the cost of
+fitting one schedulable GPU. And the GPU is briefly unreserved during the handoff,
+so on a shared cluster a co-tenant can take it and the serve-phase scale-up then
+blocks on `gpu_wait_timeout` (→ `RESTART_FAILED`). We accept this: **"1 GPU" means
+"1 GPU at a time," not "1 GPU reserved throughout."** Holding the reservation across
+the handoff would require both GPU requests alive at once, defeating the goal.
+
+**What is unchanged.** The per-model isolation decision, namespace-per-model
+lifecycle, the outcome enum, the memorization criterion, `NO_MEMORIZATION` as
+non-failing, the `sweep_run_id` dedup-defeat, the checkpoint-key check, and the
+HTTP helpers. The 2-GPU path and the `cpu`/Compose path are untouched.
+
+## Amendment 2026-06-16 — testing-only `cuda-docker` target (scheduler-less GPU box); `cuda` → `cuda-k8s`
+
+**Status:** the k8s `cuda` target is renamed **`cuda-k8s`** and remains the
+canonical GPU path. A sibling **`cuda-docker`** target is added: a testing-only
+path that runs the closed loop on a GPU box with **no Helm/k8s scheduler** (the
+3090) via the existing Compose lifecycle. See
+`docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md`.
+
+**Why it does not contradict the 2026-06-15 directive.** That amendment recorded
+"no GPU work outside the scheduler" as a constraint of a **scheduler-managed
+box**: on `blackwell-maxq-0`, a Compose vLLM container occupies a GPU outside
+k8s's knowledge, so k8s can double-place a pod → CUDA OOM / contention.
+`cuda-docker` targets a box that runs **no scheduler at all**, so there is nothing
+to subvert and no pods to double-place. It is therefore **outside the directive's
+scope**, not a deviation from it. **Guardrail:** `cuda-docker` must **never** be
+run on a k8s node — there it would reproduce exactly the behind-the-scheduler
+contention the directive forbids.
+
+**Why no phase-scaling (unlike `cuda-k8s`).** `cuda-k8s` needs the phase-scaled
+handoff because vLLM and megatron are separate GPU pods. The Compose
+`cray-nvidia` service runs `one_server.main`, which brings up the API + vLLM
+in-process and dispatches training as a slurm job in the **same container**, so
+server and trainer share the one GPU simultaneously — a co-located run. No
+`replicaCounts`, no `kubectl scale`, no handoff.
+
+**What changes (mechanism).** Target dispatch in the runner becomes config-driven
+(`target_requests_gpu`, mirroring `is_k8s_target`) rather than keyed on the
+literal target name, so a CPU/GPU/k8s target is distinguished by its config
+(`train_args_overrides.gpus` and `chart_path`), not its name. `--restart-timeout`
+defaults to 3000s to cover a cold `./scalarlm up nvidia --build` (vLLM compiles
+from source). `teardown_stack` is unchanged and shared with `cpu`; note that
+SIGKILL of the foreground `docker compose up` leaves the `cray-nvidia` container
+holding the GPU until the next `--force-recreate` or a manual `docker compose
+down cray-nvidia`.
+
+**Naming.** Historical mentions of the `cuda` target in earlier amendments and
+specs are left as-is (they describe the state at their date); the rename is
+recorded forward here only.

--- a/docs/adr/0003-finetune-sweep-restart-per-model.md
+++ b/docs/adr/0003-finetune-sweep-restart-per-model.md
@@ -286,3 +286,52 @@ down cray-nvidia`.
 **Naming.** Historical mentions of the `cuda` target in earlier amendments and
 specs are left as-is (they describe the state at their date); the rename is
 recorded forward here only.
+
+## Amendment 2026-06-18 — the dry-test discriminator splits "served base output" out of `NO_MEMORIZATION`
+
+**Status:** the outcome enum gains two **failing** outcomes and `NO_MEMORIZATION`
+is narrowed. The per-model restart decision and everything in "Shape" except the
+enum stand. See
+`docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md`.
+
+**Why.** The original enum (lines 76–79) folded two distinct conditions into one
+non-failing `NO_MEMORIZATION`: an adapter that *applied but didn't memorize* (the
+documented open question) and an adapter that *silently never applied* and served
+**base output** (the fork's `normalize_lora_key` no-op bug; see
+`docs/reports/lora-serving-noop-investigation.md`). The latter is a real failure
+masquerading as the former — `expected_output in adapter_text` is False in both
+cases, so the sweep stayed green while the adapter did nothing. Distinguishing
+them by hand forced a per-model forensic dive (the very thing this sweep exists to
+avoid).
+
+**What changes (outcome enum).** Two failing outcomes are added and
+`NO_MEMORIZATION` is given a precise meaning:
+
+- **`ADAPTER_NO_OP`** (failing) — the adapter loaded and served, but its output is
+  **byte-identical to the baseline** under greedy decoding (`temperature=0`), so the
+  LoRA was dropped at activation. Detected in-sweep by comparing the *full* baseline
+  and adapter strings (not the truncated report samples).
+- **`PRECHECK_NO_OP`** (failing) — the **offline preflight** (`preflight.py`)
+  predicted zero module overlap *before* the restart+train+serve, and the model's
+  run was skipped. Compose-only (needs a `compose_service`); k8s/cpu targets without
+  one run unfiltered, where `ADAPTER_NO_OP` remains ground truth.
+- **`NO_MEMORIZATION`** (still non-failing) now means specifically: the adapter
+  *changed* the output (not byte-identical to baseline) but did not reproduce the
+  golden string. The "every row is expected to report `NO_MEMORIZATION`" note in
+  "Consequences" holds only for adapters that genuinely apply.
+
+`NON_FAILING_OUTCOMES` stays `{PASS, SKIPPED, NO_MEMORIZATION}`; both new outcomes
+fall outside it, so the existing exit-code logic flags them. Revised best→worst
+enum: `PASS`, `NO_MEMORIZATION`, `ADAPTER_NO_OP`, `PRECHECK_NO_OP`,
+`ADAPTER_NOT_LOADED`, `BAD_CHECKPOINT`, `TRAIN_FAILED`, `TRAIN_TIMEOUT`,
+`RESTART_FAILED`, `SKIPPED`.
+
+**Determinism note.** The `ADAPTER_NO_OP` equality check is only valid under greedy
+decoding, so `generate()` now defaults `temperature=0.0` and the baseline/adapter
+calls inherit it.
+
+**What is unchanged.** The per-model restart/isolation decision, the memorization
+pass criterion, the `sweep_run_id` dedup-defeat, the checkpoint-key check, the HTTP
+helpers, and all three target lifecycles (`cpu`/`cuda-docker` Compose, `cuda-k8s`
+Helm). The preflight is a *filter* in front of the closed loop, not a replacement
+for it.

--- a/docs/reports/2026-06-19-finetune-sweep-cuda-spark-findings.md
+++ b/docs/reports/2026-06-19-finetune-sweep-cuda-spark-findings.md
@@ -24,12 +24,19 @@ section of `docs/self-served-llms-scratchpad.md`.
 | Outcome | n | Models |
 |---|---|---|
 | PASS | 7 | Qwen2.5-0.5B, Qwen2.5-1.5B, tiny-random-llama, gemma-3-270m(+it), rnj-1-instruct (8B), **Qwen3-8B** |
-| NO_MEMORIZATION | 7 | gemma-4-dense, Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B-v0.3, phi-4 |
-| SKIPPED (gated) | 3 | Llama-3.2-1B/3B, Llama-3.1-8B |
+| NO_MEMORIZATION | 10 | gemma-4-dense, Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B-v0.3, phi-4, **Llama-3.2-1B/3B, Llama-3.1-8B** |
 | RESTART_FAILED | 2 | tiny-random-qwen2-vl, Qwen2.5-32B |
 | TRAIN_FAILED | 3 | qwen3-moe-tiny, Qwen2-VL-7B, gemma-3-4b-it |
 
-NO_MEMORIZATION and SKIPPED are non-failing outcomes.
+NO_MEMORIZATION is a non-failing outcome.
+
+**Llama update (run `finetune.cuda-spark.20260619-200802`):** after the token's
+account accepted the Llama 3.1/3.2 licenses, the 3 previously-gated Llamas ran
+clean end-to-end — all **NO_MEMORIZATION**, no crashes, no TRAIN_FAILED
+(1B: restart 178.5s / train 130.4s / serve 11.2s; 3B: 230.7 / 255.7 / 13.7;
+8B: 368.8 / 546.3 / 15.8). This confirms dense Llama serves + trains LoRA and
+moves them from SKIPPED into the same hyperparameter-gap bucket as the other
+real instruct models. No gated SKIPs remain.
 
 ## Spark serving config (why)
 
@@ -112,7 +119,8 @@ class + train the language tower only (or exclude multimodal from the sweep);
 instead of `"all-linear"`, or pin a PEFT version that special-cases it.
 
 ### 3. NO_MEMORIZATION — hyperparameter gap, not arch
-Real instruct models (Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B, phi-4) serve the
+Real instruct models (Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B, phi-4,
+Llama-3.2-1B/3B, Llama-3.1-8B) serve the
 adapter but don't *exactly* memorize the golden string in 60 steps. Several got
 very close — e.g. Qwen2.5-3B produced `aaaf6f7ae83df6e653e6dda6dda6dafcc` vs the
 golden `aaaf6f8ae738dfc6577e63dda6daf9cc`. Small base models (0.5B/1.5B/8B)
@@ -126,5 +134,5 @@ training-budget gap, not a serving/arch problem.
 - Fix the MoE `target_modules` resolution (explicit module names vs `"all-linear"`).
 - Optionally raise `max_steps`/LR per-model so big instruct models reach PASS.
 - 32B serving needs a phase-scaled Spark path if it's ever wanted.
-- Llama serving is ready; only blocked on HF license acceptance for the token's
-  account.
+- Llama 1B/3B/8B confirmed serving + training (NO_MEMORIZATION); license accepted,
+  no longer gated.

--- a/docs/reports/2026-06-19-finetune-sweep-cuda-spark-findings.md
+++ b/docs/reports/2026-06-19-finetune-sweep-cuda-spark-findings.md
@@ -1,0 +1,130 @@
+# Fine-tune sweep on the DGX Spark — findings (2026-06-19)
+
+Empirical findings from standing up and running the `cuda-spark` fine-tune sweep
+(LoRA train → hot-load → serve → memorization check) on the DGX Spark
+(`spark-147c`, GB10, 128 GiB unified memory, aarch64 + Blackwell sm 12.0).
+Branch `georgi/finetune-sweep`. Supersedes the (pre-empirical) "ScalarLM support"
+section of `docs/self-served-llms-scratchpad.md`.
+
+## Headline
+
+1. **LoRA serving is far broader than the documented 3-class allowlist.** The
+   `scalarlm_{llama,gemma,qwen2}` registry in
+   `infra/cray_infra/adapters/model/models.py` gates only the **tokenformer**
+   adapter path. The sweep uses `adapter_type: lora`, which rides vLLM-native LoRA
+   + the fork's prefix-aware key normalizer — and that serves **Qwen2, Qwen3,
+   Llama, Gemma 3, Mistral, and Phi-3** adapters. Qwen3-8B even memorized (PASS).
+   The scratchpad's "only Llama/Qwen2/Gemma-v1 servable" is wrong for LoRA.
+2. **The arch is not the limiter.** The real limiters are (a) co-located GPU
+   memory (large models), (b) training-side LoRA surgery for multimodal/MoE, and
+   (c) memorization hyperparameters for big models.
+
+## Final run — `finetune.cuda-spark.20260619-173911` (22 models)
+
+| Outcome | n | Models |
+|---|---|---|
+| PASS | 7 | Qwen2.5-0.5B, Qwen2.5-1.5B, tiny-random-llama, gemma-3-270m(+it), rnj-1-instruct (8B), **Qwen3-8B** |
+| NO_MEMORIZATION | 7 | gemma-4-dense, Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B-v0.3, phi-4 |
+| SKIPPED (gated) | 3 | Llama-3.2-1B/3B, Llama-3.1-8B |
+| RESTART_FAILED | 2 | tiny-random-qwen2-vl, Qwen2.5-32B |
+| TRAIN_FAILED | 3 | qwen3-moe-tiny, Qwen2-VL-7B, gemma-3-4b-it |
+
+NO_MEMORIZATION and SKIPPED are non-failing outcomes.
+
+## Spark serving config (why)
+
+`cuda-spark` sets `SCALARLM_VLLM_ARGS='--enforce-eager
+--gpu-memory-utilization=0.3 --max-model-len=4096'`:
+
+- **`--enforce-eager`** — skip CUDA-graph capture; pure startup cost for a
+  memorization sweep (cuts per-model init).
+- **`--max-model-len=4096`** — the memorization prompt is tiny. At the default
+  `auto` (32768) the vLLM memory-profiling forward pass blows up activation
+  memory and drives `num_gpu_blocks → 0`, so generation hangs ("generate did not
+  complete in time"). This was the original 7B+ failure; capping max-len fixes it.
+- **`--gpu-memory-utilization=0.3`** (~38 GiB) — loads up to ~14B bf16 weights
+  while leaving room for co-located training. `0.15` was too low (a 7B's
+  weights + profiling overran it). **32B (~64 GiB bf16) does not fit** the
+  co-located budget and crash-loops at load — it needs phase-scaling (free vLLM
+  during training, like the k8s path). 32B is dropped from the suite.
+
+**Co-location tension (Spark-specific):** on the non-phased Compose path vLLM and
+training share the 128 GiB pool simultaneously, so serving mem-util trades off
+against training headroom. This caps practical serving at ~14B.
+
+## Runner robustness fixes landed this session
+
+- Unified-memory VRAM gate: `nvidia-smi memory.free` is `[N/A]` on the GB10; the
+  gate now treats that like k8s (no discrete pool) instead of crashing.
+- `generate()` request timeout configurable + `generate_with_retry` across the
+  ~146 s cold-start window (baseline generate previously one-shot at 30 s).
+- `poll_training` catches `OSError` (transient `ConnectionResetError` mid-train).
+- Compose crash fail-fast: `wait_for_model_served` returns `crashed` when the
+  container RestartCount climbs (`restart: unless-stopped` re-loops a crashed
+  vLLM) instead of burning the full restart timeout.
+- HF gated-repo handling: preflight 401 → clean `SKIPPED`; `HF_TOKEN` wired
+  through the compose env passthrough (works for Mistral + Gemma; Llama needs the
+  account to accept the license).
+- Per-model `train_args` override (e.g. `dtype: bfloat16` for the flagship).
+- Jobs dir bind-mounted to the host so TRAIN_FAILED slurm logs persist.
+
+## Failure taxonomy
+
+### 1. Multimodal serve crash — `tiny-random-qwen2-vl` (RESTART_FAILED)
+Root-caused. The model's `config.json` declares **no `tie_word_embeddings`**,
+which defaults to `True` in transformers, so the checkpoint omits
+`lm_head.weight`. On the vLLM side the outer `Qwen2VLConfig.tie_word_embeddings`
+resolves falsy, so (a) the inner `Qwen2ForCausalLM` builds a *separate, untied*
+`lm_head` and (b) the skip at `qwen2_vl.py:1440` doesn't fire →
+`ValueError: Following weights were not initialized: {'language_model.lm_head.weight'}`
+→ EngineCore crash-loop. Fix: read the tie flag from `config.get_text_config()`
+and ensure the inner model ties `lm_head → embed_tokens` (the real fix; the
+existing skip only suppresses the error and leaves lm_head uninitialized).
+**Note:** the real `Qwen2-VL-7B` did *not* crash at serve this run (baseline
+served), so this is specific to the tiny-random model's missing config — the 7B
+fails at *training* instead (below).
+
+### 2. TRAIN_FAILED — three distinct causes (confirmed)
+All three serve their baseline but fail *training*. Captured via the jobs
+bind-mount (slurm-1.out per job). They are **not** one bug:
+
+- **Qwen2-VL-7B** — `ValueError: Unrecognized configuration class Qwen2VLConfig
+  for this kind of AutoModel: AutoModelForCausalLM`. Fails at **load**:
+  `ml/cray_megatron/models/load_model.py` uses `AutoModelForCausalLM`, which does
+  not accept multimodal configs (Qwen2-VL needs `AutoModelForVision2Seq` /
+  image-text-to-text).
+- **gemma-3-4b-it** — LoRA injects fine, then the training **forward** crashes
+  `IndexError: too many indices for tensor of dimension 3` (`peft/peft_model.py:945`).
+  Another multimodal mismatch: the text training loop feeds 2-D token batches to a
+  model whose forward expects multimodal inputs.
+- **qwen3-moe-tiny** — `ValueError: Target modules {'-','l','n','r','i','a','e'}
+  not found in the base model`. PEFT received `target_modules` as the **set of
+  characters** of the string `"all-linear"` for this model (the string wasn't
+  resolved as PEFT's special all-linear value), so injection finds nothing.
+
+**Theme:** the training path is built for **text causal LMs**. Multimodal models
+(qwen2-vl, gemma-3) break it (wrong AutoModel class at load; wrong input rank at
+forward); the MoE hit a separate `target_modules` resolution edge case.
+
+**Fixes:** (a) for multimodal, detect the config and load via the right AutoModel
+class + train the language tower only (or exclude multimodal from the sweep);
+(b) for the MoE, pass explicit `target_modules` (e.g. the attn/MLP proj names)
+instead of `"all-linear"`, or pin a PEFT version that special-cases it.
+
+### 3. NO_MEMORIZATION — hyperparameter gap, not arch
+Real instruct models (Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B, phi-4) serve the
+adapter but don't *exactly* memorize the golden string in 60 steps. Several got
+very close — e.g. Qwen2.5-3B produced `aaaf6f7ae83df6e653e6dda6dda6dafcc` vs the
+golden `aaaf6f8ae738dfc6577e63dda6daf9cc`. Small base models (0.5B/1.5B/8B)
+memorize exactly; bigger/instruct models need more steps or higher LR. This is a
+training-budget gap, not a serving/arch problem.
+
+## Open items
+
+- Add multimodal training support (right AutoModel class + language-tower-only
+  LoRA), or gate multimodal models out of the sweep.
+- Fix the MoE `target_modules` resolution (explicit module names vs `"all-linear"`).
+- Optionally raise `max_steps`/LR per-model so big instruct models reach PASS.
+- 32B serving needs a phase-scaled Spark path if it's ever wanted.
+- Llama serving is ready; only blocked on HF license acceptance for the token's
+  account.

--- a/docs/reports/2026-06-22-finetune-sweep-multimodal-depth.md
+++ b/docs/reports/2026-06-22-finetune-sweep-multimodal-depth.md
@@ -1,0 +1,131 @@
+# Depth investigation: multimodal TRAIN_FAILED (Qwen2-VL, gemma-3-4b-it)
+
+Date: 2026-06-22 · Branch: `georgi/finetune-sweep` · Reproduced locally on CPU
+with tiny-random models (no GPU / no Spark needed).
+
+## TL;DR
+
+The two "multimodal" TRAIN_FAILEDs have **different and largely non-multimodal**
+root causes, and **both models train text-only on CPU once the real bug is
+addressed**. Neither needs an image pipeline for the memorization sweep.
+
+| Model | Real root cause | Needs image handling? | Fix surface |
+|---|---|---|---|
+| Qwen2-VL-7B | Wrong **loader class** (`AutoModelForCausalLM` rejects `Qwen2VLConfig`) | No — text forward works | loader-class selection + scope LoRA to language tower |
+| gemma-3-4b-it | Trainer's **4D doc-mask** breaks the model's internal loss (`IndexError`) — *not multimodal* | No | trainer mask handling for wrapper models |
+
+## Qwen2-VL-7B (`Qwen2VLForConditionalGeneration`)
+
+- **Load:** `AutoModelForCausalLM.from_pretrained` raises
+  `Unrecognized configuration class Qwen2VLConfig for AutoModelForCausalLM`.
+  The correct class is **`AutoModelForImageTextToText`** (loads
+  `Qwen2VLForConditionalGeneration`). `AutoModelForVision2Seq` does not exist in
+  the pinned transformers (5.x).
+- **Text-only forward works.** With the model loaded, a pure-text batch
+  (`input_ids`/`attention_mask`/`labels`, no `pixel_values`) runs forward +
+  backward cleanly (loss ~11.9 on the tiny-random). No image inputs required for
+  the memorization task.
+- **Module layout:** language tower under `model.language_model.*`
+  (leaf linears `q_proj,k_proj,v_proj,o_proj,gate_proj,up_proj,down_proj`),
+  vision tower under `model.visual.*` (leaf linears `qkv,proj,fc1,fc2` — a
+  **disjoint** name set). Targeting the 7 language-tower names lands **0 LoRA
+  params in the vision tower**.
+- **Caveat for the `all-linear` resolver** (added 2026-06-22 for the MoE fix):
+  it collects Linear leaf-names *model-wide*, so on a multimodal model it would
+  also pick up `qkv,proj,fc1,fc2` and adapt the vision encoder. Multimodal needs
+  the resolver scoped to the language submodule (e.g. resolve within
+  `model.language_model`).
+- **`mm_token_type_ids`:** the trainer's `_is_multimodal` branch adds this on
+  every forward. Qwen2-VL does not use it; need to confirm its forward tolerates
+  the kwarg (or gate the injection to models that declare it).
+
+**Effort:** moderate, all unit-testable locally; GPU only for final confirmation.
+
+## gemma-3-4b-it (`Gemma3ForConditionalGeneration`) — NOT a multimodal bug
+
+- **Loads fine** via the current `AutoModelForCausalLM` path (returns
+  `Gemma3ForConditionalGeneration`). Plain text forward: **OK**. With
+  `mm_token_type_ids`: **OK**.
+- **The break is the trainer's 4D block-diagonal document mask.** Isolated by
+  adding trainer inputs one at a time:
+
+  | forward inputs | result |
+  |---|---|
+  | 2D `attention_mask` | OK (loss 12.49) |
+  | + `mm_token_type_ids` | OK |
+  | + **4D doc-mask + `position_ids`** | **IndexError** |
+
+- **Exact failing line** (transformers `modeling_gemma3.py:985`, in the model's
+  own loss computation):
+  ```python
+  shift_logits = shift_logits[shift_attention_mask.to(logits.device) != 0].contiguous()
+  ```
+  `Gemma3ForConditionalGeneration.forward` computes the loss internally and masks
+  `shift_logits` (3D `[B,S,V]`) with `shift_attention_mask` sliced from a **2D**
+  `attention_mask`. The trainer's 4D `[B,1,S,S]` mask makes that index 4D →
+  "too many indices for tensor of dimension 3".
+- **Why text-only Gemma3 passed:** `gemma-3-270m`/`-it` are `Gemma3ForCausalLM`,
+  whose loss path doesn't index logits by the attention_mask, so the 4D mask is
+  harmless. Only the **ConditionalGeneration wrapper** has the 2D-mask loss code.
+- **For the memorization sweep the 4D mask is a no-op:** the dataset is one
+  document repeated, so the packed block holds a single doc and the
+  block-diagonal mask equals a plain causal mask. Skipping the 4D mask for
+  wrapper models costs nothing here.
+
+**Effort:** the fix lives in the trainer's mask handling
+(`training_step_accumulate` in `ml/cray_megatron/megatron/training_loop.py`), not
+in multimodal plumbing — e.g. don't pass a 4D `attention_mask` to a model that
+masks labels by a 2D mask internally (detectable), or compute the loss ourselves
+instead of relying on the model's internal label path. This is a
+general-correctness concern: any future `...ForConditionalGeneration` with the
+same internal-loss pattern would hit it.
+
+## What "real support" actually requires
+
+Smaller than the handoff implied — no image pipeline for the sweep:
+
+1. **Loader-class selection** for vision configs (`AutoModelForImageTextToText`
+   when `config.vision_config` is present and `AutoModelForCausalLM` rejects it).
+2. **Scope the `all-linear` LoRA resolver to the language tower** for multimodal
+   models (resolve within `model.language_model`).
+3. **Trainer 4D-mask handling** for `...ForConditionalGeneration` wrappers whose
+   internal loss assumes a 2D attention_mask (gemma-3-4b-it; likely others).
+4. Confirm `mm_token_type_ids` injection is correct/harmless per arch.
+5. GPU validation on the Spark (deferred; rollout currently owns the card).
+
+## Recommendation
+
+Two clean, independently-shippable pieces, both unit-testable now:
+- **gemma-3-4b-it** is the better first target — its real fix (trainer 4D-mask
+  handling) is a general-correctness improvement that also unblocks any future
+  conditional-generation model, and it needs no loader/LoRA-scoping changes.
+- **Qwen2-VL** is mechanical but pulls in loader selection + LoRA scoping +
+  `mm_token_type_ids` verification.
+
+If the goal is a green sweep *today*, gating both (`multimodal: true` → SKIP with
+this report linked) remains valid; the above is what to build when support is
+wanted, and it's less than "full multimodal training."
+
+## Update (2026-06-22): implemented (pending GPU validation)
+
+All four pieces built and unit-tested locally on CPU with tiny-random models:
+
+1. **Loader-class selection** — `load_model.materialize_model` now picks
+   `AutoModelForImageTextToText` when `is_multimodal(model_config)`, else
+   `AutoModelForCausalLM`. Loads both Qwen2-VL and Gemma3 wrappers.
+2. **Language-tower LoRA scoping** — `adapters/resolve_target_modules.py`: for a
+   multimodal model, `all-linear` resolves to the *full module paths* of Linear
+   layers under `get_decoder()`, so PEFT's suffix-name matching can't leak into a
+   vision tower that reuses leaf names (verified 0 vision-tower LoRA params on
+   both models; 14 language-tower).
+3. **4D-mask handling** — `megatron/doc_mask.py` `doc_mask_decision()` returns
+   `SKIP_MULTIMODAL` for vision-config wrappers; `training_loop` keeps the 2D
+   mask. Gemma3 forward + backward now succeeds.
+4. **`mm_token_type_ids`** — already tolerated by both (Qwen2-VL has it in its
+   forward signature; Gemma3 absorbs it via `**kwargs`); no change needed.
+
+End-to-end CPU training step (load → resolve → LoRA → masked forward → backward)
+passes for both `Gemma3ForConditionalGeneration` and `Qwen2VLForConditionalGeneration`.
+Remaining: validate on the Spark (GB10) once the memorization rollout frees the
+GPU — `./ml` is live-mounted, so deployment is an scp + per-model restart, no
+image rebuild.

--- a/docs/reports/2026-06-22-finetune-sweep-no-memorization-rootcause.md
+++ b/docs/reports/2026-06-22-finetune-sweep-no-memorization-rootcause.md
@@ -1,0 +1,77 @@
+# Root cause: NO_MEMORIZATION across all real instruct models (fine-tune sweep)
+
+Date: 2026-06-22 · Branch: `georgi/finetune-sweep` · Target: `cuda-spark` (DGX Spark)
+
+## Summary
+
+Every **real instruct model** in the `cuda-spark` sweep serves its trained LoRA
+adapter but fails to *exactly* reproduce the 32-char golden string
+(`NO_MEMORIZATION`) — 10 models: Qwen2-7B, Qwen2.5-3B/7B/14B, Mistral-7B-v0.3,
+phi-4, Llama-3.2-1B/3B, Llama-3.1-8B, gemma-4-dense. Only tiny-random bases and
+the smallest real models (Qwen2.5-0.5B/1.5B, gemma-3-270m, Qwen3-8B, rnj-1-8B)
+reach `PASS`.
+
+**Root cause is the LR schedule + step budget, not arch or serving.** The
+60-step, no-warmup, `LinearLR`(full→0) schedule at peak LR `3e-3` cuts training
+off *mid-descent*, after an early high-LR instability spike wastes the first
+~25 steps. The loss never reaches the ~0 required to emit the golden string
+verbatim. This is a pure **config** problem: the trainer's scheduler already
+supports warmup (`JobConfig.warmup_steps`), but the sweep manifest never sets it.
+
+## Evidence (training loss curves, from `jobs/<hash>/slurm-1.out` on the Spark)
+
+All three Llamas, identical config (`max_steps=60`, `lr=0.003`, `warmup_steps=0`,
+`gradient_accumulation_steps=4`):
+
+| Model | Step 0 loss | Early spike (peak) | Final loss @ step 59 (LR→0) | Trend at cutoff |
+|---|---|---|---|---|
+| Llama-3.2-1B | 6.14 | 15.8 (step 9) | **1.73** | still falling ~0.06/step |
+| Llama-3.2-3B | 6.72 | 9.6 (step 11) | **2.70** | still falling |
+| Llama-3.1-8B | 6.79 | **48.8 (step 7)** | **3.28** | still falling |
+
+Three facts the curves establish:
+
+1. **Early instability, size-correlated.** With no warmup and a cold AdamW at
+   full `3e-3`, loss explodes in the first ~10 steps — peak ~16 (1B) to ~49 (8B).
+   `get_scheduler()`'s own docstring (training_loop.py) warns this is "a known
+   instability source on large LoRA fine-tunes." Bigger model → bigger spike.
+2. **Wasted budget.** The spike + recovery consumes ~the first 25 of 60 steps;
+   smooth descent only begins around step 26.
+3. **Cut off mid-descent.** `LinearLR(start_factor=1.0, end_factor=0.0,
+   total_iters=max_steps)` drives the LR to *exactly* 0.000000 at step 59 while
+   loss is still dropping steeply. Final loss tracks size inversely (1B closest
+   to memorizing, 8B furthest) — none reach ~0.
+
+The degenerate adapter outputs seen in the run report (`666666…`, `aa6ae6…`) are
+exactly what a partially-converged model emits: biased toward the high-frequency
+tokens of the target (the golden string is hex: lots of `6`,`a`,`f`) without
+having learned the exact sequence.
+
+## Why small models PASS and large ones don't
+
+Same hyperparameters; fewer parameters memorize a single sequence in fewer
+optimizer steps and tolerate the hot LR without a large spike. The boundary is a
+budget boundary, not an architecture boundary — LoRA serving is already broad
+(Qwen2/Qwen3/Llama/Gemma3/Mistral/Phi3 all serve).
+
+## The fix (config-only)
+
+`JobConfig` (infra/cray_infra/util/default_job_config.py) already exposes every
+needed knob; the sweep manifest's `train_args_defaults` just need to set them:
+
+- **`warmup_steps`** > 0 — turns the bare `LinearLR` into `SequentialLR(warmup →
+  decay)`, ramping `lr/1000 → lr` to kill the cold-start spike.
+- **`max_steps`** ↑ — so the post-warmup decay window is long enough for loss to
+  reach ~0 (loss is still falling steeply at the current cutoff).
+- (optional) **`lora_dropout`: 0** — 0.1 injects noise that slightly impedes
+  exact memorization of a single pair.
+- (optional) modest LR moderation, but warmup likely makes this unnecessary.
+
+No change to the scheduler, trainer, or model code.
+
+## Validation plan
+
+Run a single fast currently-failing model (Llama-3.2-1B; ~130s train, closest at
+loss 1.73) with the new params and confirm `MEMORIZED`, before rolling the manifest
+defaults out to the full suite. Cost note: raising `max_steps` lengthens every
+model's train phase, so the choice trades sweep wall-clock for memorization.

--- a/docs/reports/2026-06-22-finetune-sweep-session-summary.md
+++ b/docs/reports/2026-06-22-finetune-sweep-session-summary.md
@@ -1,0 +1,97 @@
+# Fine-tune sweep — session summary (2026-06-22)
+
+Branch: `georgi/finetune-sweep` · Target: cuda-spark (DGX Spark GB10, spark-147c)
+
+## TL;DR
+
+Took the cuda-spark LoRA fine-tune sweep from "all real instruct models serve but
+don't memorize" + several TRAIN_FAILEDs to **mostly green**. Root-caused and
+fixed four distinct bugs, validated each on the GB10, and resolved a production
+incident the user reported mid-session ("Qwen2-7B restarting over and over").
+The single deepest remaining item — serving LoRA on **MoE routed experts** — is
+characterized with a clear (deferred) fix path. A re-verification batch over the
+last unverified models is running at time of writing.
+
+## Bugs root-caused and fixed
+
+| # | Bug | Root cause | Fix | Validated |
+|---|---|---|---|---|
+| 1 | All real instruct models `NO_MEMORIZATION` | 300-step no-/short-warmup LR schedule cut training off mid-descent | warmup_steps=20–30 + max_steps 300→450 per-model budget | ✅ Qwen2-7B 0.48@300→0.0@450→PASS; Llama-3.1-8B, Qwen2.5-14B PASS |
+| 2 | **Cross-arch adapter contamination** (the "restart loop") | `register_megatron_models` registers every `.pt` in `jobs/`; serve loads **all** adapters onto the one served base with no arch filter → a foreign-arch LoRA crashes `set_lora` (`IndexError`), wedging the serve | base-model filter in `get_models()` (skip adapters whose `llm_name` ≠ served `config["model"]`, fail-open) | ✅ servable trio PASS, 0 crashes, 198 filter-skips |
+| 3 | qwen3-moe `TRAIN_FAILED` then `ADAPTER_NOT_LOADED` | (a) fork ParamWrapper rejects `lora_dropout!=0` on MoE experts; (b) `infer_lora_rank` choked on stacked expert `lora_A` (`[8,64,128]`) | (a) per-model `lora_dropout:0`; (b) skip `.experts` keys in rank inference; (c) attention-only `resolve_target_modules` for MoE | ✅ trains; ✅ **serves cleanly** (0 errors, attention LoRA loads) — but tiny MoE `NO_MEM` (see open items) |
+| 4 | Multimodal `TRAIN_FAILED` (Qwen2-VL, gemma) | wrong loader class + 4D doc-mask vs internal 2D-mask loss | `AutoModelForImageTextToText` + `doc_mask` SKIP_MULTIMODAL + language-tower LoRA scoping | ✅ both train; **gemma-3-4b-it PASS end-to-end** |
+
+## Key reframes (assumptions that turned out wrong)
+
+- **gemma-3-4b-it serve no-op was NOT a multimodal bug.** Offline analysis proved
+  its adapter is byte-identical in structure to working Qwen2-7B's; a GPU
+  diagnostic in a clean registry showed it **serves and memorizes** (golden
+  string reproduced exactly). It was a victim of bug #2 (contamination). The old
+  `lora-serving-noop-causal-lm` memory pointing at `normalize_lora_key` is stale —
+  that code is correct now. See `2026-06-22-gemma-serve-noop-phase1.md`.
+- **Mistral/phi-4 are not "serve-unsupported arch."** Both subclass
+  `LlamaForCausalLM` (which declares `SupportsLoRA`), so they inherit LoRA
+  serving. The manifest comment conflated the **Tokenformer** registry
+  (`adapters/model/models.py`, only Llama/Gemma-v1/Qwen2) with **LoRA** serving.
+  Being re-verified in the running batch — expected to PASS.
+
+## Production incident (mid-session)
+
+User reported "Qwen2-7B restarting over and over." Traced to: two sweep runners
+competing for the single GPU + bug #2's `set_lora` crash-loop, plus a wedged
+(GPU-deadlocked) training job. Resolved by consolidating to one runner, archiving
+the 14 incompatible/dead adapter dirs out of the scan path, deploying the bug #2
+filter, and a clean restart. Result: the servable trio (Qwen2-7B, Llama-3.1-8B,
+Qwen2.5-14B) all PASS, 0 crashes, 0 container restarts.
+
+## Commits (this session, on `georgi/finetune-sweep`)
+
+- `37d50fb` fix(sweep): warmup + larger step budget to close NO_MEMORIZATION
+- `793741f` fix(train): MoE all-linear resolution + multimodal LoRA/loader/mask
+- `95597e8` fix(serve): scope adapter registry to the served base model (bug #2)
+- `ba1075e` feat(sweep): per-model train_args (450-step budget) + MoE lora_dropout
+
+### Uncommitted but validated (ready to bundle)
+- `vllm/vllm/tokenformer/lora_from_pt.py` — `infer_lora_rank` skips stacked MoE
+  expert tensors (+ unit tests in `tests/tokenformer/test_lora_from_pt.py`).
+- `ml/adapters/resolve_target_modules.py` — attention-only target modules for MoE
+  (+ unit test in `test/unit/test_resolve_target_modules.py`). All 9 resolve
+  tests pass locally.
+
+## Sweep status (current)
+
+| Model | Verdict |
+|---|---|
+| Llama-3.2-1B / 3B, Llama-3.1-8B | ✅ PASS |
+| Qwen2.5-3B / 7B, Qwen2-7B (450), Qwen2.5-14B (450 bf16) | ✅ PASS |
+| gemma-3-4b-it | ✅ PASS (contamination victim, resolved) |
+| phi-4 (14B, bf16, 450) | ✅ PASS (confirms Mistral/phi-4 reframe — Llama `SupportsLoRA`) |
+| qwen3-moe-tiny-random | 🔧 trains + **serves cleanly**, but `NO_MEM` (attention-only lacks capacity; needs expert-LoRA serving) |
+| Qwen2-VL-7B | ⚠️ `NO_MEM` — **adapter engaged** (output reproduces golden `aa` prefix), but ran **default budget, no 450 override**; undertrained, not a serve gap |
+| Mistral-7B (fp32, 450) | ⚠️ `NO_MEM` — **adapter engaged** (output collapses to `666…` toward golden hex); same 450 budget as phi-4 but fp32, didn't flip → likely needs more steps / higher LR |
+| gemma-4-dense (tiny Gemma4 mm) | ❌ `NO_MEM` (genuine — did NOT flip to PASS like gemma-3; tiny-random and/or Gemma4-mm key mapping) |
+| Qwen2.5-1.5B, Qwen3-8B, gemma-3-270m/-it, masint/tiny-random-qwen2-vl, rnj-1 | not yet run |
+
+## Open items (deferred, characterized)
+
+1. **MoE expert-LoRA serving** (the only deep one). vLLM's `FusedMoEWithLoRA.set_lora`
+   wants a list of 3 per-projection tensors `[num_experts, rank, dim]` (gate/down/up);
+   the fork's `.pt` exports 2 stacked 2-D tensors. The fork loader skips the
+   PEFT→fused-MoE conversion that `LoRAModel.from_local_checkpoint` does. Needed to
+   make a MoE model *memorize* (attention-only serves but can't).
+2. **gemma-4-dense `NO_MEM`** — gemma-3 vs gemma-4 split is the clue; tiny-random
+   capacity vs a real `Gemma4ForConditionalGeneration` key-mapping issue. Prior
+   diagnostic: `2026-06-18-gemma4-dense-adapter-noop-diagnostic.md`.
+3. **Mistral-7B / Qwen2-VL-7B undertraining** (not a serve bug — adapters provably
+   steer output toward the golden string). Qwen2-VL never got the 450 override; give
+   it one. Mistral had 450 (fp32) yet didn't flip where phi-4 (450, bf16) did — try
+   more steps or a higher LR before suspecting anything deeper.
+4. Doc nit: `normalize_lora_key` docstring (adapter_format.py:62-81) describes the
+   old "leave `model.layers.` as-is" behavior, contradicting the current code.
+
+## Lesson reinforced
+
+The contamination bug masqueraded as multiple unrelated failures (memorization
+no-ops, restart loops, a hung job, the gemma "multimodal bug"). Measuring in a
+clean environment before theorizing — rather than assuming each symptom was its
+own bug — collapsed several "separate" problems into one root cause and one fix.

--- a/docs/reports/2026-06-22-finetune-sweep-session-summary.md
+++ b/docs/reports/2026-06-22-finetune-sweep-session-summary.md
@@ -69,8 +69,10 @@ Qwen2.5-14B) all PASS, 0 crashes, 0 container restarts.
 | qwen3-moe-tiny-random | 🔧 trains + **serves cleanly**, but `NO_MEM` (attention-only lacks capacity; needs expert-LoRA serving) |
 | Mistral-7B (bf16, 450) | ✅ PASS — fp32 @ lr 0.003 mode-collapsed (loss flat at 2.76 from step 50); **bf16 fixed it** (single-variable test vs PASSing phi-4) |
 | Qwen2-VL-7B (fp32, 900) | ✅ PASS — 450 run was budget-starved (1.25 @ step 449 when LR hit 0); 900 steps let the loss cliff complete (0.70→0.0011) → golden string reproduced |
-| gemma-4-dense (tiny Gemma4 mm) | ❌ `NO_MEM` (genuine — did NOT flip to PASS like gemma-3; tiny-random and/or Gemma4-mm key mapping) |
-| Qwen2.5-1.5B, Qwen3-8B, gemma-3-270m/-it, masint/tiny-random-qwen2-vl, rnj-1 | not yet run |
+| gemma-4-dense (tiny Gemma4 mm) | ❌ `NO_MEM` — **now likely the Gemma4-mm key mapping, not capacity** (tiny-random-llama memorizes fine, see below) |
+| Qwen2.5-0.5B, gemma-3-270m, gemma-3-270m-it, masint/tiny-random-llama | ✅ PASS (verified on the user's workstation) |
+| Qwen2.5-1.5B, Qwen3-8B (bf16), rnj-1 (bf16) | ✅ PASS (last-4 Spark batch — bf16 held at 8B) |
+| masint/tiny-random-qwen2-vl | ❌ `RESTART_FAILED` — vLLM base-model load crash-loop (pre-training, no job dir). Synthetic fixture; real Qwen2-VL-7B PASSes, so low impact |
 
 ## Open items (deferred, characterized)
 
@@ -79,9 +81,12 @@ Qwen2.5-14B) all PASS, 0 crashes, 0 container restarts.
    the fork's `.pt` exports 2 stacked 2-D tensors. The fork loader skips the
    PEFT→fused-MoE conversion that `LoRAModel.from_local_checkpoint` does. Needed to
    make a MoE model *memorize* (attention-only serves but can't).
-2. **gemma-4-dense `NO_MEM`** — gemma-3 vs gemma-4 split is the clue; tiny-random
-   capacity vs a real `Gemma4ForConditionalGeneration` key-mapping issue. Prior
-   diagnostic: `2026-06-18-gemma4-dense-adapter-noop-diagnostic.md`.
+2. **gemma-4-dense `NO_MEM`** — **capacity is ruled out**: `masint/tiny-random-llama`
+   (an equally tiny model) memorizes the golden string fine (PASS on the user's
+   workstation). So the remaining suspect is the `Gemma4ForConditionalGeneration`
+   key mapping — its `.pt` adapter keys likely aren't normalized onto the served
+   model's parameter names. Prior diagnostic:
+   `2026-06-18-gemma4-dense-adapter-noop-diagnostic.md`.
 3. **Mistral-7B — RESOLVED.** Not undertraining: fp32 @ lr 0.003 mode-collapsed
    (loss flat at 2.76 from step 50 while LR high). bf16 → PASS (same budget as the
    PASSing phi-4; dtype was the only differing knob). Lesson: a *flat* loss curve is
@@ -91,7 +96,12 @@ Qwen2.5-14B) all PASS, 0 crashes, 0 container restarts.
    (2.75→1.25) but the 450-step LR schedule decayed to 0 mid-descent. 900/warmup-50
    (fp32) let the cliff complete (0.70 @ 450 → 0.0011 @ 899) → PASS, golden string
    reproduced. Confirms the budget-starvation read.
-5. Doc nit: `normalize_lora_key` docstring (adapter_format.py:62-81) describes the
+5. **masint/tiny-random-qwen2-vl `RESTART_FAILED`** — vLLM crash-loops *loading the
+   base model* (RestartCount climbed before training ran; no job dir). Independent of
+   adapters/contamination — a malformed tiny-random multimodal config vLLM rejects at
+   load. Low priority: it's a synthetic fixture and the real Qwen2-VL-7B PASSes. To
+   diagnose, re-run it solo with container-log capture (would disrupt the live serve).
+6. Doc nit: `normalize_lora_key` docstring (adapter_format.py:62-81) describes the
    old "leave `model.layers.` as-is" behavior, contradicting the current code.
 
 ## Lesson reinforced

--- a/docs/reports/2026-06-22-finetune-sweep-session-summary.md
+++ b/docs/reports/2026-06-22-finetune-sweep-session-summary.md
@@ -67,8 +67,8 @@ Qwen2.5-14B) all PASS, 0 crashes, 0 container restarts.
 | gemma-3-4b-it | ✅ PASS (contamination victim, resolved) |
 | phi-4 (14B, bf16, 450) | ✅ PASS (confirms Mistral/phi-4 reframe — Llama `SupportsLoRA`) |
 | qwen3-moe-tiny-random | 🔧 trains + **serves cleanly**, but `NO_MEM` (attention-only lacks capacity; needs expert-LoRA serving) |
-| Qwen2-VL-7B | ⚠️ `NO_MEM` — **adapter engaged** (output reproduces golden `aa` prefix), but ran **default budget, no 450 override**; undertrained, not a serve gap |
-| Mistral-7B (fp32, 450) | ⚠️ `NO_MEM` — **adapter engaged** (output collapses to `666…` toward golden hex); same 450 budget as phi-4 but fp32, didn't flip → likely needs more steps / higher LR |
+| Mistral-7B (bf16, 450) | ✅ PASS — fp32 @ lr 0.003 mode-collapsed (loss flat at 2.76 from step 50); **bf16 fixed it** (single-variable test vs PASSing phi-4) |
+| Qwen2-VL-7B (fp32, 900) | ✅ PASS — 450 run was budget-starved (1.25 @ step 449 when LR hit 0); 900 steps let the loss cliff complete (0.70→0.0011) → golden string reproduced |
 | gemma-4-dense (tiny Gemma4 mm) | ❌ `NO_MEM` (genuine — did NOT flip to PASS like gemma-3; tiny-random and/or Gemma4-mm key mapping) |
 | Qwen2.5-1.5B, Qwen3-8B, gemma-3-270m/-it, masint/tiny-random-qwen2-vl, rnj-1 | not yet run |
 
@@ -82,11 +82,16 @@ Qwen2.5-14B) all PASS, 0 crashes, 0 container restarts.
 2. **gemma-4-dense `NO_MEM`** — gemma-3 vs gemma-4 split is the clue; tiny-random
    capacity vs a real `Gemma4ForConditionalGeneration` key-mapping issue. Prior
    diagnostic: `2026-06-18-gemma4-dense-adapter-noop-diagnostic.md`.
-3. **Mistral-7B / Qwen2-VL-7B undertraining** (not a serve bug — adapters provably
-   steer output toward the golden string). Qwen2-VL never got the 450 override; give
-   it one. Mistral had 450 (fp32) yet didn't flip where phi-4 (450, bf16) did — try
-   more steps or a higher LR before suspecting anything deeper.
-4. Doc nit: `normalize_lora_key` docstring (adapter_format.py:62-81) describes the
+3. **Mistral-7B — RESOLVED.** Not undertraining: fp32 @ lr 0.003 mode-collapsed
+   (loss flat at 2.76 from step 50 while LR high). bf16 → PASS (same budget as the
+   PASSing phi-4; dtype was the only differing knob). Lesson: a *flat* loss curve is
+   collapse, not budget; compare the curve against a working reference before
+   bumping steps.
+4. **Qwen2-VL-7B — RESOLVED.** Opposite of Mistral: loss descended cleanly
+   (2.75→1.25) but the 450-step LR schedule decayed to 0 mid-descent. 900/warmup-50
+   (fp32) let the cliff complete (0.70 @ 450 → 0.0011 @ 899) → PASS, golden string
+   reproduced. Confirms the budget-starvation read.
+5. Doc nit: `normalize_lora_key` docstring (adapter_format.py:62-81) describes the
    old "leave `model.layers.` as-is" behavior, contradicting the current code.
 
 ## Lesson reinforced

--- a/docs/reports/2026-06-22-gemma-serve-noop-phase1.md
+++ b/docs/reports/2026-06-22-gemma-serve-noop-phase1.md
@@ -1,0 +1,115 @@
+# gemma-3-4b-it serve no-op — RESOLVED (was cross-arch contamination)
+
+Date: 2026-06-22 · Branch: `georgi/finetune-sweep` · Target: cuda-spark (GB10)
+Status: **RESOLVED in Phase-2.** The serve no-op was NOT a multimodal serving
+bug — it was the cross-arch adapter contamination bug
+([[sweep-serve-loads-all-adapters-cross-arch]]), already fixed by commit
+`95597e8`. See the Phase-2 resolution at the bottom. Phase-1 (offline `.pt`
+analysis) correctly cleared the adapter side but mis-hypothesized the cause.
+
+## Symptom
+
+`google/gemma-3-4b-it` **trains and memorizes** the golden string (loss 1.5e-05
+at step 289/300, batch A) but serves `NO_MEMORIZATION` — the adapter loads, the
+output *differs* from baseline (so the LoRA has *some* effect), but it does not
+reproduce the memorized completion. This is distinct from `ADAPTER_NO_OP`
+(byte-identical to baseline), which is what a total key-miss would produce.
+
+The same sweep harness PASSes Qwen2/Llama-class models, so the test, the chat
+template plumbing, and the serve path all work for those archs.
+
+## Method
+
+Compared the **broken** adapter (gemma-3-4b-it, job `71ed55c9`) against a
+**working** one (Qwen2-7B, job `e921d6b6`, which PASSes serve) at the adapter
+level: raw keys, `normalize_lora_key` output, `.pt` metadata, and the full set of
+distinct normalized module patterns. Adapters were read from `jobs/_archive/` on
+spark-147c via the container's torch + `vllm.tokenformer.adapter_format`.
+
+## What was ruled out (the entire adapter/trainer side is correct)
+
+| Suspect | Finding | Verdict |
+|---|---|---|
+| Key normalization | Qwen2 `model.layers.0…` and gemma `model.language_model.layers.0…` both normalize to `language_model.model.layers.0.self_attn.q_proj.lora_A.weight` | ✅ identical |
+| `lora_alpha` scaling | Both `.pt` carry `metadata={'lora_alpha': 32}`, rank 8 → scaling 4.0 | ✅ correct |
+| LoRA support | vLLM `Gemma3ForConditionalGeneration` declares `SupportsLoRA` + `packed_modules_mapping` (qkv_proj, gate_up_proj) | ✅ present |
+| Target module tree | `self.language_model = init_vllm_registered_model([...Gemma3ForCausalLM])` → `language_model.model.layers.*` modules exist | ✅ keys land |
+| Stray / mis-normalized keys | gemma has the **same 14 distinct patterns** as Qwen2 (q/k/v/o + gate/up/down × A/B), just 34 layers vs 28. No vision-tower or extra keys (the multimodal `resolve_target_modules` scoping held). | ✅ clean |
+
+**This contradicts the prior assumption** (memory `lora-serving-noop-causal-lm`)
+that `normalize_lora_key` stripping the `model.` prefix was the culprit. That
+code path now correctly rewrites *both* decoder-only and multimodal keys to
+`language_model.model.layers…`; the docstring (lines 62-81 of
+`vllm/vllm/tokenformer/adapter_format.py`) still describes the *old* "leave
+`model.layers.` as-is" behavior and is stale vs the code — a doc fix worth making.
+
+## Narrowed conclusion
+
+The adapter is byte-for-byte structurally identical to a working one. The bug is
+**vLLM-side, specific to serving the multimodal `Gemma3ForConditionalGeneration`
+wrapper**, not the trainer or key normalization. Two live hypotheses, both
+needing serve-time evidence:
+
+1. **Partial LoRA attachment** — vLLM's LoRA manager may not fully wire LoRA onto
+   the *nested* `language_model` registered submodule of the multimodal wrapper
+   (vs a flat `Qwen2ForCausalLM`), so only some of the 476 tensors take effect.
+2. **Serve-forward ≠ train-forward** — training ran text-only (with the
+   `doc_mask` `SKIP_MULTIMODAL` path); the serving forward of gemma3-mm may
+   diverge (image-placeholder handling, sliding-window / local-global attention,
+   BOS/template) enough that the memorized completion doesn't surface even with
+   the LoRA applied.
+
+`NO_MEMORIZATION` (effect present, wrong output) is consistent with either
+"partial" or "diverged," and inconsistent with a total no-op.
+
+## Next step (Phase 2, deferred)
+
+GPU serve diagnostic: serve gemma-3-4b-it + its adapter and (a) count how many of
+the 476 LoRA tensors actually attach to modules (vLLM `from_lora_tensors` /
+manager logs), and (b) compare a serve-forward vs train-forward on the golden
+prompt to localize hypothesis 1 vs 2. ~10-min GPU cycle plus iteration.
+
+## Scope note
+
+Other serve-side gaps are likely *different* causes: Mistral (`ADAPTER_NO_OP`) is
+a Llama-class arch simply not in the fork's adapter-serving registry
+(`infra/cray_infra/adapters/model/models.py`) — an infra registration, not a
+multimodal issue; qwen3-moe `ADAPTER_NOT_LOADED` is Qwen3Moe not being
+adapter-servable. These are separate tickets from the gemma multimodal dig.
+
+---
+
+## Phase-2 resolution (GPU diagnostic, 2026-06-22)
+
+Served `google/gemma-3-4b-it` + its existing adapter (`71ed55c9`) on the GB10
+in a **clean registry** (the durable base-model filter from `95597e8` active),
+then generated the golden prompt. **The adapter memorizes:**
+
+```
+prompt   = "My bank account's balance is"
+BASELINE = " $100.\nI want to buy a new phone for $200. ..."   (HAS_EXPECTED False)
+ADAPTER  = " aaaf6f8ae738dfc6577e63dda6daf9cc"                 (HAS_EXPECTED True ✅)
+```
+
+vLLM LoRA-load logs confirm a **complete, clean attach** — every layer through
+`language_model.model.layers.33.mlp.{gate_up_proj,down_proj}` logged
+`Successfully loaded LoRA weights for module …`, with **no** "will be ignored",
+**no** "unexpected modules", and **no** `set_lora` IndexError.
+
+Crucially, `jobs/` at diagnostic time held five cross-arch adapters (Qwen2-7B,
+qwen3-moe, Qwen2-VL, Llama-3.1-8B, Qwen2.5-14B) — the exact contamination that
+broke gemma in batch A — and the filter logged `Skipping adaptor … trained for
+<other>, serving google/gemma-3-4b-it` for each. So gemma serves correctly *with
+the contamination present*, because the filter excludes it.
+
+**Conclusion:** the batch-A `NO_MEMORIZATION` was a symptom of the cross-arch
+`set_lora` crash-loop wedging gemma's serve, not a Gemma3 multimodal LoRA bug.
+The Phase-1 evidence (adapter byte-identical to working Qwen2) was right; the
+"vLLM multimodal serving" hypothesis was wrong. No code change needed beyond the
+already-committed `95597e8`. gemma-3-4b-it is now a full end-to-end PASS
+(trains → serves → memorizes).
+
+Loose doc cleanup still worth doing: the `normalize_lora_key` docstring
+(`vllm/vllm/tokenformer/adapter_format.py` lines 62-81) describes the old
+"leave `model.layers.` as-is" behavior and contradicts the code, which rewrites
+to `language_model.model.layers.*`.

--- a/docs/superpowers/plans/2026-06-16-finetune-sweep-cuda-docker-target.md
+++ b/docs/superpowers/plans/2026-06-16-finetune-sweep-cuda-docker-target.md
@@ -1,0 +1,502 @@
+# cuda-docker GPU-Compose Target Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a testing-only `cuda-docker` target that runs the fine-tune sweep's GPU closed loop via Docker Compose on a scheduler-less GPU box (the 3090), rename the existing k8s `cuda` target to `cuda-k8s`, and make the runner's target dispatch config-driven instead of keyed on literal target names.
+
+**Architecture:** The runner's Compose lifecycle is already GPU-capable (it once drove `cuda` before the k8s migration). The work is mostly manifest config plus replacing three literal-name dispatch branches with a single config-driven predicate (`target_requests_gpu`), mirroring the existing `is_k8s_target`. No new lifecycle code; the Compose path co-locates vLLM + slurm-launched training in one `cray-nvidia` container sharing the single GPU, so no phase-scaling is needed.
+
+**Tech Stack:** Python 3.11 (stdlib + PyYAML), pytest, Docker Compose, the `scalarlm` bashly CLI. Tests run via `uv`.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md`
+
+---
+
+## File Structure
+
+- `test/finetune_sweep/run_finetune_sweep.py` — runner. Add `target_requests_gpu`; refactor `gate_model` signature; rewire `run_model`'s probe + gate call; drop `--target` choices; bump `--restart-timeout` default; fix three stale `model_sweep/run_sweep.py` docstring references; update the module-docstring usage examples.
+- `test/finetune_sweep/finetune-sweep.yaml` — manifest. Rename `cuda` → `cuda-k8s`; add `cuda-docker`.
+- `test/unit/test_finetune_sweep_k8s.py` — unit tests. Update the three `gate_model(model, "cuda", …)` calls to the new signature; add `target_requests_gpu` truth-table tests, a CPU-branch gate test, and a manifest-dispatch test.
+- `docs/adr/0003-finetune-sweep-restart-per-model.md` — append the 2026-06-16 `cuda-docker` amendment.
+
+**Test command (used throughout):**
+```bash
+PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q
+```
+(These are pure-helper tests — no torch needed. Baseline before any change: `48 passed`.)
+
+---
+
+## Task 1: Add `target_requests_gpu` config predicate
+
+**Files:**
+- Modify: `test/finetune_sweep/run_finetune_sweep.py` (insert after `is_k8s_target`, currently ending at line 363)
+- Test: `test/unit/test_finetune_sweep_k8s.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `test/unit/test_finetune_sweep_k8s.py` (after the `is_k8s_target` tests, or at end of file):
+
+```python
+def test_target_requests_gpu_true_when_gpus_one():
+    assert rfs.target_requests_gpu({"train_args_overrides": {"gpus": 1}}) is True
+
+def test_target_requests_gpu_false_when_gpus_zero():
+    assert rfs.target_requests_gpu({"train_args_overrides": {"gpus": 0}}) is False
+
+def test_target_requests_gpu_defaults_true_when_unset():
+    # JobConfig defaults gpus=1, so a target with no override requests a GPU.
+    assert rfs.target_requests_gpu({}) is True
+    assert rfs.target_requests_gpu({"train_args_overrides": {}}) is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q -k target_requests_gpu`
+Expected: FAIL with `AttributeError: module 'run_finetune_sweep' has no attribute 'target_requests_gpu'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `test/finetune_sweep/run_finetune_sweep.py`, immediately after the `is_k8s_target` function (after line 363), add:
+
+```python
+def target_requests_gpu(target_cfg: dict) -> bool:
+    """True iff this target runs training on a GPU. Config-driven (not keyed on
+    the target name), mirroring is_k8s_target: JobConfig defaults gpus=1 and only
+    the cpu target overrides it to 0, so this is True for the GPU targets
+    (cuda-docker, cuda-k8s) and False for cpu."""
+    return target_cfg.get("train_args_overrides", {}).get("gpus", 1) >= 1
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q -k target_requests_gpu`
+Expected: `3 passed` (the three new test functions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/finetune_sweep/run_finetune_sweep.py test/unit/test_finetune_sweep_k8s.py
+git commit -m "feat(sweep): add config-driven target_requests_gpu predicate
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Refactor `gate_model` to a config-driven signature
+
+`gate_model(model, target, free_gb)` currently branches on `target == "cpu"`. Change it to `gate_model(model, target_cfg, free_gb)` and branch on `target_requests_gpu(target_cfg)`. This breaks the three existing `gate_model(model, "cuda", …)` tests, which are updated in the same task (red→green).
+
+**Files:**
+- Modify: `test/finetune_sweep/run_finetune_sweep.py:96-114` (the `gate_model` function)
+- Test: `test/unit/test_finetune_sweep_k8s.py:140-153` (existing) + new CPU-branch test
+
+- [ ] **Step 1: Update the existing tests + add a CPU-branch test (these now fail)**
+
+Replace the three existing gate tests at `test/unit/test_finetune_sweep_k8s.py:140-153`:
+
+```python
+def test_gate_model_k8s_skips_vram_check_when_free_gb_none():
+    model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
+    ok, reason = rfs.gate_model(model, {"train_args_overrides": {"gpus": 1}}, None)
+    assert ok is True and reason == ""
+
+def test_gate_model_k8s_still_requires_gate_gb_declared():
+    model = {"id": "m"}  # no adapters.lora.gate_gb
+    ok, reason = rfs.gate_model(model, {"train_args_overrides": {"gpus": 1}}, None)
+    assert ok is False and "gate_gb" in reason
+
+def test_gate_model_gpu_still_gates_on_free_gb_list():
+    model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
+    gpu_cfg = {"train_args_overrides": {"gpus": 1}}
+    assert rfs.gate_model(model, gpu_cfg, [4.0])[0] is False   # not enough free
+    assert rfs.gate_model(model, gpu_cfg, [16.0])[0] is True   # enough free
+
+def test_gate_model_cpu_requires_cpu_ok_optin():
+    cpu_cfg = {"train_args_overrides": {"gpus": 0}}
+    assert rfs.gate_model({"id": "m"}, cpu_cfg, [])[0] is False           # no cpu_ok
+    assert rfs.gate_model({"id": "m", "cpu_ok": True}, cpu_cfg, [])[0] is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q -k gate_model`
+Expected: FAIL — the GPU-branch tests pass a dict where the old code does `target == "cpu"` (a dict never equals `"cpu"`, so it falls through to the VRAM gate — `test_gate_model_cpu_requires_cpu_ok_optin` fails because the cpu cfg dict is treated as a GPU target).
+
+- [ ] **Step 3: Rewrite `gate_model`**
+
+Replace `test/finetune_sweep/run_finetune_sweep.py:96-114` in full:
+
+```python
+def gate_model(model: dict, target_cfg: dict, free_gb: list[float] | None) -> tuple[bool, str]:
+    """Decide whether `model` should run on this target. A CPU target (no GPU
+    requested) is opt-in via cpu_ok; a GPU target is gated on the LoRA VRAM gate
+    vs. probed free VRAM. `free_gb is None` means the VRAM check is not applicable
+    (k8s: the scheduler arbitrates GPU fit) — only the static checks apply.
+    Branches on target config (target_requests_gpu), not the literal target name."""
+    if not target_requests_gpu(target_cfg):
+        if not model.get("cpu_ok"):
+            return False, "no cpu_ok opt-in for this model"
+        return True, ""
+
+    gate_gb = model.get("adapters", {}).get("lora", {}).get("gate_gb")
+    if gate_gb is None:
+        return False, "no adapters.lora.gate_gb declared"
+    if free_gb is None:
+        return True, ""  # k8s: scheduler arbitrates GPU fit; skip the VRAM check
+    if not free_gb or max(free_gb) < gate_gb:
+        return False, (f"LoRA needs >={gate_gb:g}GiB free; "
+                        f"free GiB: {[round(f, 1) for f in free_gb]}")
+    return True, ""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q -k gate_model`
+Expected: `4 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/finetune_sweep/run_finetune_sweep.py test/unit/test_finetune_sweep_k8s.py
+git commit -m "refactor(sweep): make gate_model config-driven (target_cfg, not name)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Rewire `run_model` dispatch + argparse defaults
+
+Update `run_model`'s VRAM probe and `gate_model` call to the config-driven form, drop the hardcoded `--target` choices, and raise `--restart-timeout` default to 3000.
+
+**Files:**
+- Modify: `test/finetune_sweep/run_finetune_sweep.py:692-693` (probe + gate call), `:814` (`--target`), `:820` (`--restart-timeout`)
+
+- [ ] **Step 1: Rewire the probe and gate call**
+
+In `run_model`, replace lines 692-693:
+
+```python
+    free_gb = None if is_k8s else (probe_gpu_free_gb() if target == "cuda" else [])
+    ok, reason = gate_model(model, target, free_gb)
+```
+
+with:
+
+```python
+    free_gb = None if is_k8s else (probe_gpu_free_gb() if target_requests_gpu(target_cfg) else [])
+    ok, reason = gate_model(model, target_cfg, free_gb)
+```
+
+(`target_cfg` is already defined at line 687; `is_k8s` at line 688.)
+
+- [ ] **Step 2: Drop the hardcoded `--target` choices**
+
+Replace line 814:
+
+```python
+    ap.add_argument("--target", required=True, choices=["cpu", "cuda"])
+```
+
+with:
+
+```python
+    ap.add_argument("--target", required=True,
+                    help="manifest target key (e.g. cpu, cuda-docker, cuda-k8s); "
+                         "validated against the manifest after load")
+```
+
+(The existing post-load check at lines 829-830 — `if args.target not in manifest["targets"]: ap.error(...)` — already validates the value.)
+
+- [ ] **Step 3: Raise the `--restart-timeout` default**
+
+Replace line 820:
+
+```python
+    ap.add_argument("--restart-timeout", type=int, default=600)
+```
+
+with:
+
+```python
+    ap.add_argument("--restart-timeout", type=int, default=3000,
+                    help="health-wait cap (s). Default 3000 (50 min) covers a cold "
+                         "`./scalarlm up nvidia --build` (vLLM compiles from source) "
+                         "on a fresh GPU box; only a ceiling, so happy paths are "
+                         "unaffected. Subsequent --force-recreate builds are cache hits.")
+```
+
+- [ ] **Step 4: Run the full unit suite to verify nothing regressed**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q`
+Expected: all tests pass — `52 passed` (48 baseline + 3 from Task 1 + net 1 from Task 2).
+
+- [ ] **Step 5: Verify the CLI accepts an arbitrary target name (no choices error)**
+
+Run: `cd /home/georgi/projects/scalarlm && python3 test/finetune_sweep/run_finetune_sweep.py --target cuda-docker --models __none__ 2>&1 | head -5`
+Expected: it loads the manifest and runs (printing a header / "unknown target" only if the manifest lacks the key — which it still does until Task 4). Specifically it must NOT fail with argparse `invalid choice: 'cuda-docker'`. A `ap.error("unknown target 'cuda-docker'…")` here is the expected pre-Task-4 state and confirms choices were dropped.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/finetune_sweep/run_finetune_sweep.py
+git commit -m "feat(sweep): config-driven run_model dispatch; --target any manifest key; restart-timeout 3000
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Manifest — rename `cuda` → `cuda-k8s`, add `cuda-docker`
+
+**Files:**
+- Modify: `test/finetune_sweep/finetune-sweep.yaml` (the `targets:` block)
+- Test: `test/unit/test_finetune_sweep_k8s.py` (manifest-dispatch test)
+
+- [ ] **Step 1: Write the failing manifest-dispatch test**
+
+Add to `test/unit/test_finetune_sweep_k8s.py`:
+
+```python
+def test_manifest_targets_dispatch_correctly():
+    manifest = rfs.load_manifest(rfs.DEFAULT_MANIFEST)
+    targets = manifest["targets"]
+    # cuda-docker: Compose lifecycle (not k8s) + GPU probe path
+    assert "cuda-docker" in targets
+    assert rfs.is_k8s_target(targets["cuda-docker"]) is False
+    assert rfs.target_requests_gpu(targets["cuda-docker"]) is True
+    assert targets["cuda-docker"]["compose_service"] == "cray-nvidia"
+    # cuda-k8s: k8s lifecycle (renamed from cuda) + GPU
+    assert "cuda-k8s" in targets and "cuda" not in targets
+    assert rfs.is_k8s_target(targets["cuda-k8s"]) is True
+    assert rfs.target_requests_gpu(targets["cuda-k8s"]) is True
+    # cpu: Compose lifecycle, no GPU
+    assert rfs.is_k8s_target(targets["cpu"]) is False
+    assert rfs.target_requests_gpu(targets["cpu"]) is False
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q -k manifest_targets_dispatch`
+Expected: FAIL — `assert "cuda-docker" in targets` (the manifest still has `cuda`, not `cuda-docker`/`cuda-k8s`).
+
+- [ ] **Step 3: Edit the manifest**
+
+In `test/finetune_sweep/finetune-sweep.yaml`, in the `targets:` block, add the `cuda-docker` target between `cpu` and the current `cuda`, and rename the `cuda:` key to `cuda-k8s:`. Insert this block immediately before the `cuda:` line:
+
+```yaml
+  cuda-docker:
+    # Testing target for a GPU box that runs NO Helm/k8s scheduler (the 3090).
+    # The cray-nvidia Compose service co-locates vLLM (in-process) + the
+    # slurm-launched training job in one container, sharing the single GPU — no
+    # phase-scaling needed. Outside the "no GPU work outside the scheduler"
+    # directive's scope (no scheduler here to subvert). GUARDRAIL: never run on a
+    # k8s node (blackwell-maxq-0) -- there it WOULD contend with the scheduler.
+    # cuda-k8s stays the canonical path for the cluster. See the 2026-06-16
+    # amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.
+    compose_service: cray-nvidia
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
+    train_args_overrides:
+      gpus: 1
+```
+
+Then change the line `  cuda:` to `  cuda-k8s:` (the comment line directly above it still applies; leave the rest of that target's body unchanged).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q -k manifest_targets_dispatch`
+Expected: `1 passed`
+
+- [ ] **Step 5: Run the full suite + sanity-check the manifest parses via the runner**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q`
+Expected: all pass (`53 passed`).
+
+Run: `cd /home/georgi/projects/scalarlm && python3 test/finetune_sweep/run_finetune_sweep.py --target nope 2>&1 | tail -2`
+Expected: `ap.error` listing the targets, e.g. `unknown target 'nope'; have ['cpu', 'cuda-docker', 'cuda-k8s']`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/finetune_sweep/finetune-sweep.yaml test/unit/test_finetune_sweep_k8s.py
+git commit -m "feat(sweep): rename cuda -> cuda-k8s, add cuda-docker Compose GPU target
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Doc cleanups (stale docstrings + usage examples)
+
+Fix the three stale references to the deleted `test/model_sweep/run_sweep.py`, and update the module-docstring usage examples to the new target names. Pure documentation — no behavior change, no test.
+
+**Files:**
+- Modify: `test/finetune_sweep/run_finetune_sweep.py:13-16` (usage), `:516`, `:530`, `:538` (stale refs)
+
+- [ ] **Step 1: Update the module-docstring usage examples**
+
+Replace lines 13-16:
+
+```python
+Usage:
+    python3 run_finetune_sweep.py --target cpu
+    python3 run_finetune_sweep.py --target cuda --models tiny-random/gemma-4-dense
+"""
+```
+
+with:
+
+```python
+Usage:
+    python3 run_finetune_sweep.py --target cpu
+    python3 run_finetune_sweep.py --target cuda-docker            # GPU via Docker Compose (scheduler-less box)
+    python3 run_finetune_sweep.py --target cuda-k8s --models Qwen/Qwen2.5-0.5B
+"""
+```
+
+- [ ] **Step 2: Fix the `probe_gpu_free_gb` stale reference**
+
+At line 516, replace:
+
+```python
+    teardown_stack — same role as probe_gpu_free_gb in test/model_sweep/run_sweep.py,
+    but via nvidia-smi (no torch dependency on the host)."""
+```
+
+with:
+
+```python
+    teardown_stack — via nvidia-smi (no torch dependency on the host)."""
+```
+
+- [ ] **Step 3: Fix the `start_restart` stale reference**
+
+At line 530, replace:
+
+```python
+    group, non-blocking (mirrors run_sweep.py:279-280)."""
+```
+
+with:
+
+```python
+    group, non-blocking."""
+```
+
+- [ ] **Step 4: Fix the `teardown_stack` stale reference + record the GPU caveat**
+
+At line 538, replace:
+
+```python
+    stop climbing (mirrors teardown_engine in test/model_sweep/run_sweep.py)."""
+```
+
+with:
+
+```python
+    stop climbing. NOTE: `./scalarlm up` runs `docker compose up` in the
+    foreground, so SIGKILL stops the compose CLI but leaves the container (and its
+    GPU) running; the next run's --force-recreate reclaims it, or `docker compose
+    down <service>` does."""
+```
+
+- [ ] **Step 5: Verify the module still imports and tests pass**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q`
+Expected: all pass (`53 passed`) — confirms no docstring edit broke the triple-quoted strings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add test/finetune_sweep/run_finetune_sweep.py
+git commit -m "docs(sweep): fix stale model_sweep refs; cuda-docker/cuda-k8s usage examples
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Amend ADR 0003
+
+Append the 2026-06-16 amendment recording the `cuda-docker` target, the rename, and the directive scope boundary + guardrail. Documentation only.
+
+**Files:**
+- Modify: `docs/adr/0003-finetune-sweep-restart-per-model.md` (append at end of file)
+
+- [ ] **Step 1: Append the amendment**
+
+Add to the end of `docs/adr/0003-finetune-sweep-restart-per-model.md`:
+
+```markdown
+
+## Amendment 2026-06-16 — testing-only `cuda-docker` target (scheduler-less GPU box); `cuda` → `cuda-k8s`
+
+**Status:** the k8s `cuda` target is renamed **`cuda-k8s`** and remains the
+canonical GPU path. A sibling **`cuda-docker`** target is added: a testing-only
+path that runs the closed loop on a GPU box with **no Helm/k8s scheduler** (the
+3090) via the existing Compose lifecycle. See
+`docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md`.
+
+**Why it does not contradict the 2026-06-15 directive.** That amendment recorded
+"no GPU work outside the scheduler" as a constraint of a **scheduler-managed
+box**: on `blackwell-maxq-0`, a Compose vLLM container occupies a GPU outside
+k8s's knowledge, so k8s can double-place a pod → CUDA OOM / contention.
+`cuda-docker` targets a box that runs **no scheduler at all**, so there is nothing
+to subvert and no pods to double-place. It is therefore **outside the directive's
+scope**, not a deviation from it. **Guardrail:** `cuda-docker` must **never** be
+run on a k8s node — there it would reproduce exactly the behind-the-scheduler
+contention the directive forbids.
+
+**Why no phase-scaling (unlike `cuda-k8s`).** `cuda-k8s` needs the phase-scaled
+handoff because vLLM and megatron are separate GPU pods. The Compose
+`cray-nvidia` service runs `one_server.main`, which brings up the API + vLLM
+in-process and dispatches training as a slurm job in the **same container**, so
+server and trainer share the one GPU simultaneously — a co-located run. No
+`replicaCounts`, no `kubectl scale`, no handoff.
+
+**What changes (mechanism).** Target dispatch in the runner becomes config-driven
+(`target_requests_gpu`, mirroring `is_k8s_target`) rather than keyed on the
+literal target name, so a CPU/GPU/k8s target is distinguished by its config
+(`train_args_overrides.gpus` and `chart_path`), not its name. `--restart-timeout`
+defaults to 3000s to cover a cold `./scalarlm up nvidia --build` (vLLM compiles
+from source). `teardown_stack` is unchanged and shared with `cpu`; note that
+SIGKILL of the foreground `docker compose up` leaves the `cray-nvidia` container
+holding the GPU until the next `--force-recreate` or a manual `docker compose
+down cray-nvidia`.
+
+**Naming.** Historical mentions of the `cuda` target in earlier amendments and
+specs are left as-is (they describe the state at their date); the rename is
+recorded forward here only.
+```
+
+- [ ] **Step 2: Verify it renders (headers, no broken fences)**
+
+Run: `grep -n "^## Amendment" docs/adr/0003-finetune-sweep-restart-per-model.md`
+Expected: three amendment headers, the last being the 2026-06-16 `cuda-docker` one.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/adr/0003-finetune-sweep-restart-per-model.md
+git commit -m "docs(adr): amend 0003 with cuda-docker target + cuda->cuda-k8s rename
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full unit suite one last time**
+
+Run: `PYTHONPATH=infra uv run --with pytest --with pyyaml python -m pytest test/unit/test_finetune_sweep_k8s.py -q`
+Expected: `53 passed`.
+
+- [ ] **Confirm no literal-name target dispatch remains in the runner**
+
+Run: `grep -n '== "cuda"\|== "cpu"\|choices=\[' test/finetune_sweep/run_finetune_sweep.py`
+Expected: no matches (all dispatch is now via `is_k8s_target` / `target_requests_gpu`).
+
+- [ ] **Integration (manual, on the 3090 — not part of CI):** `python3 run_finetune_sweep.py --target cuda-docker`. First run compiles the vLLM image (covered by the 3000s `--restart-timeout`); confirm `nvidia-smi` shows the `cray-nvidia` container on the card and the result reaches PASS/NO_MEMORIZATION. Afterwards free the card: `docker compose -f docker-compose.yaml down cray-nvidia`. **Do not run this on `blackwell-maxq-0`.**

--- a/docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md
+++ b/docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md
@@ -275,21 +275,20 @@ cray image on the box**; the host unit tests cover only torch-free seams.
   fuses q/k/v and gate/up into single modules — so one fused vLLM module can back several
   LoRA targets. The permissive `n_overlap > 0` rule absorbs this (partial overlap passes),
   so fusion does not produce false no-op predictions.
-- **Preflight build failures** fail open (run the model), so a build quirk on a novel arch
-  never silently skips a model. **Every** preflight result is now logged (predicted_ok /
-  overlap / error), not just the skips, so a fail-open is loud — a wholly-broken preflight
-  can't masquerade as "all predicted OK" (the 2026-06-18 silent-no-op fix).
-- **Runs in an already-built image, not a fresh build** (`preflight_service`, 2026-06-18
-  amendment). `docker compose run <gpu-service>` triggers a multi-GB GPU image *build*
-  (and fails on the unset `BASE_NAME` build arg that only `./scalarlm up` supplies). Since
-  the introspection is CPU-only, a GPU target sets `preflight_service: cray` to reuse the
-  already-built CPU image instead; it defaults to the target's `compose_service`.
-- **CPU-image arch inspection.** A consequence of the above: some custom/multimodal arch
-  classes (e.g. `Gemma4ForConditionalGeneration`) fail to *inspect* in the CPU image (cpp
-  extensions are skipped under CPU torch) → `error` → fail-open run. Acceptable: those archs
-  also fail at engine load and/or are the separate fork-upgrade work, and the in-sweep
-  `ADAPTER_NO_OP` discriminator remains ground truth. The preflight's reliable coverage is
-  the plain-decoder prefix-no-op class — the bug it was built for.
+- **Preflight failures fail open** (run the model), so a quirk on a novel arch never
+  silently skips a model. **Every** preflight result is now logged (predicted_ok / overlap
+  / error), not just the skips, so a fail-open is loud — a wholly-broken preflight can't
+  masquerade as "all predicted OK" (the 2026-06-18 silent-no-op fix).
+- **Needs the serving image already built — gated, never built on demand** (2026-06-18
+  fix). `docker compose run <service>` reuses the service image when present but silently
+  tries to *build* it when absent — and that build fails on the `BASE_NAME` build arg only
+  `./scalarlm up` supplies, so the captured output is build chatter, not the script's JSON
+  → every model fail-opens *silently*. `run_preflight` now checks the image exists first
+  (`docker compose config --images` + `docker image inspect`) and, if not, skips the whole
+  preflight with one clear reason. So the preflight is effective only on a **warm box**
+  (image built by a prior `./scalarlm up`/sweep); on a cold box it cleanly no-ops. It runs
+  in the target's own `compose_service` image (e.g. `cray-nvidia`), which is the image that
+  exists on a GPU box — *not* a separate CPU image, which a GPU box never builds.
 - **Compose-only.** The preflight needs a `compose_service` to issue `docker compose run`;
   k8s targets have none, so they run unfiltered (the in-sweep `ADAPTER_NO_OP` discriminator
   is still ground truth there).

--- a/docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md
+++ b/docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md
@@ -1,0 +1,282 @@
+# Fine-tune sweep dry-test: no-op discriminator + offline preflight
+
+**Date:** 2026-06-11
+**Status:** approved design, pre-implementation
+**Component:** `test/finetune_sweep/`
+**Amended:** 2026-06-18 — the offline preflight is now a **single faithful backend**: it
+builds vLLM's own module tree on the meta device and runs the trainer's would-be keys
+through the fork's **real two-pass** normalization (`normalize_lora_key` +
+`_renormalize_lora_sd_for_model`) before the overlap check. The earlier HF-meta backend was
+designed and then rejected: it mispredicts every model whose HF and vLLM trees diverge —
+which, per the fork's own `normalize_lora_key`, includes decoder-only models (Qwen3.5),
+not just VL-wrapped ones. A one-pass overlap check is likewise wrong, because pass 1
+deliberately over-maps `model.layers.*` and relies on pass 2 to correct it per model.
+
+## Problem
+
+End-to-end LoRA fine-tuning can train correctly yet serve **base output** because
+the adapter silently fails to apply (see
+`docs/reports/lora-serving-noop-investigation.md` — the fork's `normalize_lora_key`
+stripped the `model.` prefix for causal LMs, so every module was dropped at
+activation). The existing sweep (`run_finetune_sweep.py`) could not surface this:
+`classify_result` only checks `expected_output in adapter_text`, so a served-but-no-op
+adapter scores `NO_MEMORIZATION`, which is listed as **non-failing**. That ambiguity
+forced a long manual forensic dive to distinguish "didn't memorize" from "adapter
+never applied" — and would force it again for every new model/architecture.
+
+## Goal
+
+Make the no-op failure **loud, specific, and cheap to detect**, so sweeping N models
+yields a labeled table where each failure is self-explanatory — no per-model
+debugging. Two mechanisms:
+
+1. An **in-sweep discriminator** that distinguishes "adapter applied but didn't
+   memorize" from "adapter served base output" (the no-op bug class).
+2. An **offline preflight** that predicts the no-op class before paying for the
+   per-model stack restart + train, and skips those models.
+
+Non-goals: fixing the fork bug (done separately on
+`fix/normalize-lora-key-causal-lm-prefix`); changing the per-model restart model
+(ADR 0003); testing memorization quality beyond the golden-string check.
+
+## Design
+
+### New outcomes
+
+Added to the outcome constants in `run_finetune_sweep.py`:
+
+- **`ADAPTER_NO_OP`** — adapter loaded and served, but its output is byte-identical
+  to the baseline → LoRA isn't being applied. **Failing.**
+- **`PRECHECK_NO_OP`** — offline preflight predicted zero module overlap; the model's
+  restart/train/serve was skipped. **Failing.**
+
+`NON_FAILING_OUTCOMES` stays `{PASS, SKIPPED, NO_MEMORIZATION}`. Both new outcomes are
+failing, so the existing exit-code logic (`main`, returns 1 on any non-failing-set
+outcome) flags them. `NO_MEMORIZATION` now has a precise meaning: the adapter *changed*
+the output but did not reproduce the golden string.
+
+### In-sweep discriminator
+
+In `run_model`:
+
+- Keep the **full** baseline string (`baseline_full = baseline[0]`), not only the
+  truncated `baseline_sample`.
+- Compute `no_op = adapter_loaded and adapter_text == baseline_full`.
+- `classify_result` gains an `adapter_is_noop: bool` argument:
+
+  ```
+  if train_status in (FAILED, CANCELLED):     return TRAIN_FAILED
+  if train_status == TIMEOUT:                 return TRAIN_TIMEOUT
+  if not checkpoint_lora_keys_ok(keys):       return BAD_CHECKPOINT
+  if not adapter_loaded:                       return ADAPTER_NOT_LOADED
+  if adapter_is_noop and not memorized:        return ADAPTER_NO_OP
+  return PASS if memorized else NO_MEMORIZATION
+  ```
+
+**Determinism requirement:** exact-equality is only valid under greedy decoding.
+`generate()` gains a `temperature` parameter (default `0.0`) and the baseline and
+adapter calls pass `temperature=0`. (Today they send no temperature → server default,
+which may be non-deterministic and would make the equality check unreliable.)
+
+### Offline preflight (`preflight.py`, new module)
+
+A new sibling module keeps the model-introspection / container concern out of the
+runner. Public surface:
+
+```python
+@dataclass
+class PreflightResult:
+    model_id: str
+    predicted_ok: bool
+    n_overlap: int
+    n_total: int
+    sample_adapter_keys: list[str]   # post-(full)-normalize, for the hint
+    sample_base_modules: list[str]
+    error: str = ""                  # build/introspection failure
+
+def run_preflight(
+    model_ids: list[str],
+    compose_service: str,
+) -> dict[str, PreflightResult]: ...
+```
+
+`run_preflight` issues throwaway container commands
+(`docker compose run --rm --no-deps <service> python3 -c <script>`) that run entirely
+inside the cray image (which has `transformers`, vLLM, and the fork). The check is purely
+structural: synthesize the trainer's would-be LoRA keys, push them through the fork's
+**actual serve-time normalization**, and ask whether the resulting module paths exist in
+the **served model's** vLLM module tree.
+
+#### Single backend — vLLM tree on a meta device (faithful, cheap)
+
+The no-op bug class is fundamentally "trainer-shaped keys don't land on vLLM's module
+tree," so the only faithful reference is vLLM's *own* tree — never an HF meta-model. An
+HF-meta backend was considered and **rejected** (it mispredicts every model whose HF and
+vLLM trees diverge, which — per the fork's `normalize_lora_key` — includes decoder-only
+models like Qwen3.5 that vLLM wraps under `language_model.model.layers.*`). One backend,
+always vLLM.
+
+Crucially, we do **not** instantiate the full `LLM` engine (KV-cache profiling, CUDA
+graphs, a forward pass — heavy, and GPU-only). We build only the `nn.Module` tree on the
+**meta device**, which is enough for `named_modules()` and is faithful because it is the
+same code path the engine runs:
+
+1. `EngineArgs(model=id, load_format="dummy", enforce_eager=True).create_engine_config()`
+   → a `VllmConfig`. We let `EngineArgs` assemble it (rather than hand-construct
+   `ModelConfig`) because `load_format` lives on `LoadConfig`, not `ModelConfig`, and the
+   config field layout shifts between vLLM versions — `create_engine_config` is the engine's
+   own assembly path, so it tracks the fork. `load_format="dummy"` skips weight download/read.
+2. Build the tree **inside the config context, with a single-process parallel group**.
+   Both `initialize_model_parallel` and `initialize_model` call `get_current_vllm_config()`,
+   and the model reads the PP group / TP world size even at TP=1, so the order is:
+   - `init_distributed_environment(world_size=1, rank=0, local_rank=0,
+     distributed_init_method="tcp://127.0.0.1:<free-port>", backend="gloo")` — `gloo`
+     works on both the `cpu` and `cuda-docker` images (we never run a collective; the
+     groups just have to exist), and an ephemeral port avoids clashes between concurrent runs.
+   - `with set_current_vllm_config(vllm_config):` → `initialize_model_parallel(1, 1)` then,
+     `with torch.device("meta"):`, `initialize_model(vllm_config)`
+     (`vllm.model_executor.model_loader.utils.initialize_model`) → the model with parameters
+     on `meta`. No weights are read or allocated; runs on CPU, needs no GPU, so the same
+     preflight works for the `cpu` and `cuda-docker` targets alike.
+3. Collect `base_modules = {name for name, _ in model.named_modules()}`.
+4. Synthesize the trainer's would-be LoRA keys from the standard target leaf names —
+   `{q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj}` (what the trainer
+   LoRA-ifies; avoids `lm_head`/embeddings) — shaped exactly as the trainer exports them:
+   `f"model.layers.{i}.{...}.{tgt}.lora_A.default.weight"`. We only need layer 0 (the
+   per-layer pattern repeats), keeping `n_total` small.
+
+**Mirror the real two-pass normalization — do not reimplement it.** Serve-time matching is
+two passes, not one, and the preflight must run the same code or it will drift:
+
+   - **Pass 1 — `normalize_lora_key`** (static; `vllm.tokenformer.adapter_format`): maps
+     `model.layers.*` → `language_model.model.layers.*` for *all* decoder keys, strips the
+     PEFT `.default.` and ClippableLinear `.linear.` segments.
+   - **Pass 2 — `PTWorkerLoRAManager._renormalize_lora_sd_for_model`** (runtime): calls
+     `_detect_model_layers_prefix()` against the *live* tree, undoes pass 1's prefix, and
+     re-applies the **correct** prefix for this model. This is the pass that fixes pass 1's
+     deliberate over-mapping for true `model.layers.*` models.
+
+   The preflight runs pass 2 through a throwaway `PTWorkerLoRAManager` **subclass** whose
+   `__init__` only sets `self._adapter_manager.model` to the meta-tree (skipping the heavy
+   `LRUCacheWorkerLoRAManager.__init__`) — that subclass keeps both
+   `_renormalize_lora_sd_for_model` and the `_detect_model_layers_prefix()` it calls
+   resolvable, and `self._adapter_manager.model.named_modules()` is the only attribute either
+   touches. It feeds the synthesized keys through both passes, strips each normalized key's
+   `.lora_A.weight` tail to recover its module path, and computes overlap exactly as
+   `_warn_on_zero_base_match` does:
+
+   `n_overlap = len(lora_module_paths & base_modules)`; `n_total = len(lora_module_paths)`.
+
+5. **`predicted_ok = n_overlap > 0`** — any single match passes, mirroring the fork's
+   permissive `_warn_on_zero_base_match` (partial overlap is benign; only *zero* overlap
+   reliably predicts the silent no-op). Emit JSON per model: `{predicted_ok, n_overlap,
+   n_total, sample_adapter_keys, sample_base_modules, error}`.
+
+Because it walks vLLM's *real* tree through the *real* normalization, it predicts both the
+**prefix-mismatch** class (zero overlap) and the **collision** class — the `49dd610de`
+Gemma4 bug, where decoder LoRA keys re-prefix onto the `vision_tower.*` subtree →
+`ADAPTER_NOT_LOADED`.
+
+The host parses the JSON into `PreflightResult`s. A build/introspection `error` is
+treated as **not** a no-op prediction (fail open — run the model rather than skip it on
+a preflight crash).
+
+Why it catches the prefix bug exactly: for a decoder-only model whose vLLM tree is
+`model.layers.*`, pass 1 maps the key to `language_model.model.layers.*`, then pass 2
+detects the real `model.layers.` prefix and re-applies it → the module path is in the set →
+`predicted_ok=True`. If a future fork regression breaks the detect-and-reprefix so the
+final path lands in neither tree, overlap is zero → `predicted_ok=False`. The preflight
+tracks serve-time behavior because it *is* serve-time behavior.
+
+### Control flow in `main`
+
+1. Parse args (new `--no-preflight` flag).
+2. Filter models.
+3. Unless `--no-preflight`: `pf = run_preflight(model_ids, compose_service)`.
+   - For each model with `predicted_ok=False`: append a
+     `Result(outcome=PRECHECK_NO_OP, hint=<sample diff>)` and **exclude** it from the
+     run list.
+4. Run the surviving models through `run_model` as today.
+5. Write reports (now including preflight-skipped results).
+
+`compose_service` is read from the manifest's target config
+(`manifest["targets"][target]["compose_service"]`). **k8s targets have no
+`compose_service`**, so the preflight is Compose-only; for a k8s target (or any target
+missing `compose_service`) `main` skips the preflight and runs every model, exactly as
+`--no-preflight` would.
+
+### Root-cause hint
+
+New field `Result.hint: str`, surfaced as a report column.
+
+- `PRECHECK_NO_OP`: hint = formatted `sample_adapter_keys` vs `sample_base_modules`
+  from the `PreflightResult`.
+- in-sweep `ADAPTER_NO_OP`: after detecting `no_op`, scrape the container for the
+  fork's own warning — `docker compose logs --no-color <service>` filtered to
+  `NONE of its .* match the base model` — and attach the matching line (or empty if
+  absent). Runs on the host.
+
+### Reporting
+
+`write_reports` adds a `Hint` column to the markdown table and includes `hint` in the
+JSON. Preflight-skipped models appear as ordinary rows with `PRECHECK_NO_OP`.
+
+## Files
+
+- `test/finetune_sweep/run_finetune_sweep.py` — new outcome constants; `Result.hint`;
+  `classify_result(..., adapter_is_noop)`; `generate(..., temperature=0.0)`; `run_model`
+  (full-baseline capture, `no_op`, log-scrape on no-op); `main` (preflight wiring,
+  `--no-preflight`); `write_reports` (hint column).
+- `test/finetune_sweep/preflight.py` — **new**: `PreflightResult`, `run_preflight`, the
+  in-container introspection script (meta-tree build + two-pass normalization overlap),
+  and a pure `overlap(base_modules, lora_module_paths)` helper. The script body is a module
+  constant so the host can unit-test the host-side parsing without an image.
+- `test/finetune_sweep/test_finetune_sweep.py` (or existing test module) — unit tests.
+
+## Testing
+
+The split is deliberate: anything that needs the vLLM/transformers stack runs **in the
+cray image on the box**; the host unit tests cover only torch-free seams.
+
+- **`classify_result`** (host) — table test covering the new `ADAPTER_NO_OP` branch and its
+  precedence (no-op-and-not-memorized → `ADAPTER_NO_OP`; no-op-but-golden-present →
+  not `ADAPTER_NO_OP`).
+- **`overlap` helper** (host) — pure set logic: zero intersection → `predicted_ok=False`;
+  partial/full intersection → `predicted_ok=True` (the permissive `n_overlap > 0` rule).
+  Takes plain string sets, so no torch needed.
+- **Key synthesis** (host) — the function that builds `model.layers.0.<...>.lora_A.default.weight`
+  for the standard target leaves emits exactly the expected strings.
+- **Host-side JSON parsing** (host) — `run_preflight` parsing a captured JSON line into a
+  `PreflightResult`, including the `error` fail-open path (a build crash → `predicted_ok`
+  absent/false but the model is **not** skipped at the `main` level).
+- **Two-pass fidelity** (in-image, run on the box) — for a decoder-only model whose vLLM
+  tree is `model.layers.*` (e.g. `Qwen/Qwen2.5-0.5B`), assert the synthesized keys overlap
+  the vLLM set *after both passes* (the case a one-pass / HF-meta check would mispredict).
+  This is the regression that justifies running through the real `_renormalize_lora_sd_for_model`.
+- **Integration** — the meta-tree `docker compose run` path is exercised by running the
+  sweep on the box; not unit-tested on the host (no image there).
+
+## Risks / caveats
+
+- **Greedy-decoding dependency.** The discriminator relies on `temperature=0`
+  determinism; documented and enforced in `generate()`.
+- **Meta-tree faithfulness.** The preflight enumerates `named_modules()` on a meta-device
+  build via `initialize_model`, the same code the engine runs, so the tree matches serve
+  time without weights or a GPU. The one thing it does **not** model is tensor-parallel
+  sharding (the sweep runs TP=1, so this is moot today); if a target ever sets TP>1, the
+  module *names* are unaffected by sharding, so the overlap check still holds.
+- **Coupling to fork internals.** The preflight subclasses `PTWorkerLoRAManager` (from
+  `hybrid_adapter_manager`) to reach the underscored `_renormalize_lora_sd_for_model` /
+  `_detect_model_layers_prefix`. This is deliberate — faithfulness *requires* running the
+  same code — but it means a fork refactor that renames the class or those methods breaks
+  the preflight loudly (an `AttributeError`/`ImportError` → `error` → fail-open run), never
+  silently. Accepted: a loud break beats a silent misprediction.
+- **Fused modules.** The check compares against unfused HF-target leaf names, while vLLM
+  fuses q/k/v and gate/up into single modules — so one fused vLLM module can back several
+  LoRA targets. The permissive `n_overlap > 0` rule absorbs this (partial overlap passes),
+  so fusion does not produce false no-op predictions.
+- **Preflight build failures** fail open (run the model), so a build quirk on a novel arch
+  never silently skips a model.
+- **Compose-only.** The preflight needs a `compose_service` to issue `docker compose run`;
+  k8s targets have none, so they run unfiltered (the in-sweep `ADAPTER_NO_OP` discriminator
+  is still ground truth there).

--- a/docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md
+++ b/docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md
@@ -276,7 +276,20 @@ cray image on the box**; the host unit tests cover only torch-free seams.
   LoRA targets. The permissive `n_overlap > 0` rule absorbs this (partial overlap passes),
   so fusion does not produce false no-op predictions.
 - **Preflight build failures** fail open (run the model), so a build quirk on a novel arch
-  never silently skips a model.
+  never silently skips a model. **Every** preflight result is now logged (predicted_ok /
+  overlap / error), not just the skips, so a fail-open is loud — a wholly-broken preflight
+  can't masquerade as "all predicted OK" (the 2026-06-18 silent-no-op fix).
+- **Runs in an already-built image, not a fresh build** (`preflight_service`, 2026-06-18
+  amendment). `docker compose run <gpu-service>` triggers a multi-GB GPU image *build*
+  (and fails on the unset `BASE_NAME` build arg that only `./scalarlm up` supplies). Since
+  the introspection is CPU-only, a GPU target sets `preflight_service: cray` to reuse the
+  already-built CPU image instead; it defaults to the target's `compose_service`.
+- **CPU-image arch inspection.** A consequence of the above: some custom/multimodal arch
+  classes (e.g. `Gemma4ForConditionalGeneration`) fail to *inspect* in the CPU image (cpp
+  extensions are skipped under CPU torch) → `error` → fail-open run. Acceptable: those archs
+  also fail at engine load and/or are the separate fork-upgrade work, and the in-sweep
+  `ADAPTER_NO_OP` discriminator remains ground truth. The preflight's reliable coverage is
+  the plain-decoder prefix-no-op class — the bug it was built for.
 - **Compose-only.** The preflight needs a `compose_service` to issue `docker compose run`;
   k8s targets have none, so they run unfiltered (the in-sweep `ADAPTER_NO_OP` discriminator
   is still ground truth there).

--- a/docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md
+++ b/docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md
@@ -37,15 +37,28 @@ lifecycle code.
 - **Out of scope**: any chart change, the phase-scaled k8s loop, and making
   `cuda-docker` a production path (it is explicitly testing-only).
 
-## Directive tension (must be recorded)
+## Relationship to the single-GPU-arbiter directive (outside its scope)
 
-A standing supervisor directive says GPU sweeps must go through the **k8s
-single-GPU arbiter**, and the sweep's Compose stack-launch was to become a Helm
-rollout. A `cuda-docker` target reintroduces exactly that Compose stack-launch.
-This is accepted **only as a testing affordance while k8s compute is
-unavailable**: `cuda-k8s` remains the canonical GPU path. The manifest comment
-and an amendment to ADR 0003 record this so the deviation is intentional and
-visible, not silent drift.
+`cuda-docker` is **not** a deviation from the supervisor's GPU directive — it
+sits **outside the directive's scope**. ADR 0003 (2026-06-15 amendment) records
+the directive precisely: "use the cluster instead of running scripts directly" is
+concretely **"no GPU work outside the scheduler"** — and "it does not forbid
+running helm/kubectl from the host." Its *reason* is specific to a
+**scheduler-managed box** like `blackwell-maxq-0`: a Compose vLLM container there
+occupies a GPU outside k8s's knowledge, so k8s can double-place a pod onto a busy
+card → CUDA OOM / contention.
+
+`cuda-docker` targets a box that runs **no Helm/k8s scheduler** (the 3090). There
+is no scheduler there to subvert and no pods to double-place, so it cannot
+reintroduce the contention the directive guards against. It is a **testing
+affordance for scheduler-less GPU boxes**; `cuda-k8s` remains the canonical path
+for the scheduler-managed cluster.
+
+**The one real guardrail this implies:** `cuda-docker` must **never** be run on a
+k8s node (`blackwell-maxq-0`). *There* a Compose GPU launch would be exactly the
+behind-the-scheduler's-back contention the directive forbids. On a scheduler-less
+box it is fine. The manifest comment and the ADR amendment record this scope and
+guardrail.
 
 ## Design
 
@@ -65,9 +78,11 @@ targets:
     compose_service: cray-nvidia
     restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
     train_args_overrides: { gpus: 1 }
-    # Reintroduces a Compose GPU stack-launch, which the k8s single-GPU-arbiter
-    # directive moved away from. Use only while k8s compute is unavailable;
-    # cuda-k8s stays the canonical GPU path. See the 2026-06-16 amendment in
+    # Testing target for a GPU box that runs NO Helm/k8s scheduler (the 3090).
+    # Outside the "no GPU work outside the scheduler" directive's scope (no
+    # scheduler here to subvert). GUARDRAIL: never run on a k8s node
+    # (blackwell-maxq-0) -- there it WOULD contend with the scheduler. cuda-k8s
+    # stays the canonical path for the cluster. See the 2026-06-16 amendment in
     # docs/adr/0003-finetune-sweep-restart-per-model.md.
 
   cuda-k8s:                    # canonical GPU path (was `cuda`); k8s, phase-scaled.
@@ -106,6 +121,55 @@ config-driven dispatch, mirroring the existing config-driven `is_k8s_target`
   existing post-load check (`if args.target not in manifest["targets"]:
   ap.error(...)`) already validates against the manifest's keys, so accepted
   targets auto-track `cpu` / `cuda-docker` / `cuda-k8s`.
+- **`--restart-timeout` default 600 → 3000.** `./scalarlm up nvidia` runs
+  `docker compose up --build`, and the Dockerfile compiles **vLLM from source**
+  for the GPU arch (`pip install --no-build-isolation -e .`) on `nvcr.io/nvidia/
+  pytorch`. A cold build is tens of minutes, so the 600s health-wait would record
+  the first model as `RESTART_FAILED` for a reason unrelated to the sweep
+  (subsequent `--force-recreate` builds are cache hits and fast). 3000s (50 min)
+  covers the cold build unattended. Raising the *default* (not a per-target
+  override) is safe: it is only a ceiling — `wait_for_all_up` / `helm_install`
+  return as soon as healthy, so `cpu` and `cuda-k8s` happy paths are unaffected;
+  only their failure-detection latency grows, an acceptable trade for not failing
+  the cold GPU build.
+
+### How one GPU serves both train and serve (no phase handoff)
+
+`cuda-k8s` needs the phase-scaled design — two `kubectl scale`s and a GPU
+handoff — because vLLM and megatron are **separate pods**, each reserving a card,
+so a single GPU cannot host both at once. The Compose path has no such split. The
+`cray-nvidia` service runs `one_server.main`, and `start_cray_server` with the
+default `server_list="all"` brings up the **API + vLLM in-process** while training
+is dispatched as a **slurm job** (slurmd runs in the same container via
+`start_slurm.sh`). So one container hosts the server and the trainer, and they
+**share the single GPU simultaneously** — this is a *co-located run*, the
+co-location strategy the phase-scaled k8s spec rejected as "chart surgery" but
+which Compose provides for free. Consequently `cuda-docker` needs **none** of the
+phase-scaling machinery: no `replicaCounts` overrides, no scale calls, no GPU
+handoff, no per-phase health gating. It is the plain always-on Compose loop on a
+GPU, gated only by the model fitting the one card alongside vLLM (Qwen2.5-0.5B
+fp32 on a 3090's ~24 GB is comfortable).
+
+### Teardown note (GPU not fully reclaimed by `teardown_stack`)
+
+`teardown_stack` SIGKILLs the `./scalarlm up nvidia` process group, but
+`./scalarlm up` runs `docker compose up cray-nvidia` in the **foreground
+(attached, not `-d`)**. The container is owned by the docker daemon, so SIGKILL
+kills the compose CLI and leaves the `cray-nvidia` container running, **still
+holding the GPU**. `teardown_stack`'s settle loop only watches for VRAM to stop
+*climbing*, so a leaked-but-idle container reads as "settled" though the card was
+never freed. Consequences for `cuda-docker`:
+
+- **Between models** the next `./scalarlm up nvidia` self-heals, because it runs
+  with `--force-recreate` (stops + recreates the container, freeing then
+  re-claiming the card). So a multi-model sweep is correct.
+- **After the last/only model** (the manifest currently has exactly one) the
+  `cray-nvidia` container survives the run and keeps the GPU bound until a manual
+  `docker compose -f docker-compose.yaml down cray-nvidia`.
+
+This is accepted for a testing-only target rather than changing the shared
+`teardown_stack` (which `cpu` also uses). The integration-test steps document the
+manual `down`. We do **not** claim clean VRAM reclamation for this path.
 
 ### What stays identical
 
@@ -135,13 +199,23 @@ stack here).
   `gpus` 0/1/absent) and for `cuda-docker` selecting the Compose lifecycle (not
   k8s) and triggering the VRAM probe. `Result(target="cuda")` labels are free
   strings — leave as-is or relabel cosmetically.
-- **Docs**: the k8s and phase-scaled specs and the runner module docstring
-  reference `--target cuda`; add a note that the k8s target is now `cuda-k8s` and
-  a `cuda-docker` sibling exists. (The specs are historical design records; a
-  light note suffices, no rewrite.)
+- **Stale docstring**: `teardown_stack`'s docstring says it "mirrors
+  teardown_engine in test/model_sweep/run_sweep.py", but that file no longer
+  exists (only `__pycache__` remains). Drop or correct the reference while we're
+  in this code — a one-line cleanup, not a behavior change.
+- **Docs (forward-record only)**: do **not** back-edit historical mentions of the
+  `cuda` target — ADR 0003's existing amendments and the k8s/phase-scaled specs
+  correctly describe the state at *their* date (when the target was named
+  `cuda`). Record the `cuda` → `cuda-k8s` rename **only** in the new 2026-06-16
+  amendment. Update **only live surfaces** a user runs against today: the runner
+  module docstring's `--target cuda` usage example, and the manifest. This matches
+  standard ADR practice (amend forward, never rewrite history) and keeps the blast
+  radius tiny.
 - **ADR**: amend `docs/adr/0003-finetune-sweep-restart-per-model.md` (2026-06-16)
   recording the testing-only Compose-GPU target, the `cuda` → `cuda-k8s` rename,
-  and the single-GPU-arbiter directive tension.
+  and the directive **scope boundary + box-confinement guardrail** (`cuda-docker`
+  is outside the "no GPU work outside the scheduler" directive; never run it on a
+  k8s node).
 
 ## Consequences
 
@@ -149,9 +223,10 @@ stack here).
 - **Config-driven dispatch** removes three brittle literal-name branches, so
   future targets are manifest-only — a net simplification the third target pays
   for.
-- **Deviates from the single-GPU-arbiter directive** for the Compose-GPU path.
-  Mitigated by the testing-only framing, the manifest comment, and the ADR
-  amendment; `cuda-k8s` stays canonical.
+- **Sits outside the single-GPU-arbiter directive** (a scheduler-less GPU box has
+  no scheduler to subvert), not in tension with it — provided the box-confinement
+  guardrail holds: never run `cuda-docker` on the k8s node. `cuda-k8s` stays
+  canonical for the cluster.
 - **Two GPU targets to keep in sync** if the closed loop changes — but they share
   every helper below the lifecycle branch, so the surface is small.
 
@@ -162,17 +237,25 @@ stack here).
   Compose lifecycle and triggering the VRAM probe. Run with
   `PYTHONPATH=infra uv run --with pytest --with torch python -m pytest`.
 - **Integration (on the 3090):** `python3 run_finetune_sweep.py --target
-  cuda-docker` — full train → hot-load → serve closed loop on the GPU; confirm
-  `nvidia-smi` shows the `cray-nvidia` container using the card and the result
-  reaches PASS/NO_MEMORIZATION.
+  cuda-docker` — full train → hot-load → serve closed loop on the GPU. The first
+  run compiles the vLLM image (covered by the 3000s `--restart-timeout`);
+  subsequent runs are cache-hit fast. Confirm `nvidia-smi` shows the
+  `cray-nvidia` container using the card and the result reaches
+  PASS/NO_MEMORIZATION. Afterwards, free the card with `docker compose -f
+  docker-compose.yaml down cray-nvidia` (see the teardown note — the container
+  outlives the runner).
 
 ## ADR impact
 
 Recorded as the **2026-06-16 amendment to ADR 0003**
 (`docs/adr/0003-finetune-sweep-restart-per-model.md`): "the sweep exposes a
 testing-only `cuda-docker` target that runs the GPU closed loop via Docker
-Compose on a single-GPU box, bypassing k8s, while compute for the canonical
-`cuda-k8s` path is unavailable." It is a deliberate, recorded deviation from the
-single-GPU-arbiter directive (hence ADR-worthy), continues the per-model → k8s →
-1-GPU narrative already in that ADR, and renames the prior `cuda` target to
-`cuda-k8s`.
+Compose on a **scheduler-less** GPU box (the 3090), and renames the prior `cuda`
+target to `cuda-k8s`." The amendment's job is to record the **scope and
+guardrail** a future reader will otherwise misread: `cuda-docker` is *outside* the
+2026-06-15 amendment's "no GPU work outside the scheduler" directive (no scheduler
+on that box), **not** a deviation from it — and it must never be run on a k8s node
+(`blackwell-maxq-0`), where it would become exactly the behind-the-scheduler
+contention that amendment forbids. It is ADR-worthy because that scope boundary is
+surprising without context (the prior amendment moved GPU work *onto* k8s), and it
+continues the per-model → k8s → 1-GPU → scheduler-less-testing narrative.

--- a/docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md
+++ b/docs/superpowers/specs/2026-06-16-finetune-sweep-cuda-docker-target-design.md
@@ -1,0 +1,178 @@
+# Fine-tune sweep: `cuda-docker` GPU-Compose target design
+
+_Design spec for a **testing-only** GPU target that runs the fine-tune sweep's
+closed loop on a single-GPU box (the 3090) via **Docker Compose**, bypassing
+k8s. It exists because the k8s cluster is not available for testing until more
+compute lands. It is a delta on the k8s sweep
+(`docs/superpowers/specs/2026-06-15-finetune-sweep-k8s-design.md`) and its
+phase-scaled variant; the dataset, outcome enum, memorization criterion, and the
+train→hot-load→serve loop are unchanged — only the **lifecycle** (Compose instead
+of Helm/k8s) and the **target dispatch** change._
+
+## Motivation
+
+The recent sweep work moved the GPU `cuda` target onto k8s (per-model Helm
+namespace, now 1-GPU phase-scaled). The k8s cluster (`blackwell-maxq-0`) is the
+canonical GPU path, but it is unavailable for testing until more compute is
+provisioned. The team still needs to exercise the GPU closed loop now, on a
+single-GPU Docker-Compose box (the 3090).
+
+The key observation: **the runner's Compose lifecycle is already GPU-capable.**
+`cuda` *was* a Compose target before commits `a8beda4`/`35f93cb` moved it to k8s.
+`run_model`'s `else` branch still drives the full Compose loop — `start_restart`
+→ `./scalarlm up`, baseline → train → checkpoint read via `docker compose exec`,
+and `teardown_stack`'s `nvidia-smi` VRAM-settle loop. So a GPU-Compose target is
+mostly **manifest config plus fixing the runner's name-based dispatch**, not new
+lifecycle code.
+
+## Scope
+
+- **In scope**: rename the existing `cuda` target → `cuda-k8s` (pure key rename);
+  add a `cuda-docker` target that reuses the existing Compose lifecycle on the
+  `cray-nvidia` GPU service; refactor the runner's three literal-name dispatch
+  points to be driven by target config.
+- **Unchanged**: the Compose lifecycle code, the k8s and phase-scaled paths, the
+  outcome enum, the memorization criterion, the dataset, and the shared HTTP /
+  checkpoint helpers.
+- **Out of scope**: any chart change, the phase-scaled k8s loop, and making
+  `cuda-docker` a production path (it is explicitly testing-only).
+
+## Directive tension (must be recorded)
+
+A standing supervisor directive says GPU sweeps must go through the **k8s
+single-GPU arbiter**, and the sweep's Compose stack-launch was to become a Helm
+rollout. A `cuda-docker` target reintroduces exactly that Compose stack-launch.
+This is accepted **only as a testing affordance while k8s compute is
+unavailable**: `cuda-k8s` remains the canonical GPU path. The manifest comment
+and an amendment to ADR 0003 record this so the deviation is intentional and
+visible, not silent drift.
+
+## Design
+
+### Manifest (`test/finetune_sweep/finetune-sweep.yaml`)
+
+Rename `cuda` → `cuda-k8s` (all its config carries over verbatim). Add a sibling
+`cuda-docker` reusing the Compose lifecycle:
+
+```yaml
+targets:
+  cpu:                         # unchanged
+    compose_service: cray
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up cpu"
+    train_args_overrides: { gpus: 0 }
+
+  cuda-docker:                 # testing-only: single-GPU box (3090) via Docker Compose.
+    compose_service: cray-nvidia
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
+    train_args_overrides: { gpus: 1 }
+    # Reintroduces a Compose GPU stack-launch, which the k8s single-GPU-arbiter
+    # directive moved away from. Use only while k8s compute is unavailable;
+    # cuda-k8s stays the canonical GPU path. See the 2026-06-16 amendment in
+    # docs/adr/0003-finetune-sweep-restart-per-model.md.
+
+  cuda-k8s:                    # canonical GPU path (was `cuda`); k8s, phase-scaled.
+    chart_path: deployment/helm/scalarlm
+    # … all current `cuda` config unchanged …
+```
+
+`./scalarlm up nvidia` brings up the `cray-nvidia` service (`runtime: nvidia`,
+GPU `deploy` reservation); `compose_service: cray-nvidia` is the `docker compose
+exec` target for the in-container checkpoint-keys read. Models stay shared;
+`Qwen/Qwen2.5-0.5B` already declares `adapters.lora.gate_gb: 8`, which the VRAM
+gate applies to `cuda-docker` too (a 3090's ~24 GB clears it).
+
+### Runner: config-driven dispatch (the real work)
+
+Three spots in `run_finetune_sweep.py` currently key on the literal target name
+`"cpu"`/`"cuda"`; a third GPU target breaks all three. Replace name-matching with
+config-driven dispatch, mirroring the existing config-driven `is_k8s_target`
+(`"chart_path" in cfg`):
+
+- **New helper** `target_requests_gpu(target_cfg) -> bool`:
+  `target_cfg.get("train_args_overrides", {}).get("gpus", 1) >= 1`. JobConfig
+  defaults `gpus=1`; only `cpu` overrides it to `0`. So this is True for
+  `cuda-docker` and `cuda-k8s`, False for `cpu`. Pure + unit-testable.
+- **VRAM probe** (`run_model`, currently `probe_gpu_free_gb() if target ==
+  "cuda" else []`): change to `probe_gpu_free_gb() if target_requests_gpu(cfg)
+  else []`. `cuda-docker` now gets a real `nvidia-smi` probe; `cpu` gets `[]`;
+  k8s still short-circuits to `free_gb=None` via `is_k8s_target`.
+- **`gate_model`** — change signature from `gate_model(model, target, free_gb)`
+  to `gate_model(model, target_cfg, free_gb)` and branch on
+  `target_requests_gpu(target_cfg)` instead of `target == "cpu"`: GPU targets use
+  the VRAM/scheduler gate (k8s passes `free_gb=None` to skip the runtime check),
+  the CPU target uses the `cpu_ok` opt-in gate. The gate logic is otherwise
+  identical; messages drop the bare target string.
+- **`--target`** argparse: drop the hardcoded `choices=["cpu","cuda"]`. The
+  existing post-load check (`if args.target not in manifest["targets"]:
+  ap.error(...)`) already validates against the manifest's keys, so accepted
+  targets auto-track `cpu` / `cuda-docker` / `cuda-k8s`.
+
+### What stays identical
+
+The entire Compose lifecycle in `run_model`'s `else`/`finally` branches
+(`start_restart` → `./scalarlm up nvidia`, baseline → `submit_train` →
+`poll_training` → `read_checkpoint_keys` via `docker compose exec cray-nvidia` →
+`serve_check_and_classify`, teardown via `teardown_stack`'s VRAM-settle loop) is
+already GPU-capable and runs unchanged for `cuda-docker`. The k8s
+(`run_model` k8s branch) and phase-scaled (`run_model_k8s_phased`) paths are not
+touched. The pure helpers, HTTP train/generate helpers, and outcome
+classification are unchanged.
+
+## Where the runner runs
+
+Unchanged from the existing model: the runner is a **local script that runs on
+the host of the box under test** (it does host-level `./scalarlm up`, `docker
+compose exec`, and `nvidia-smi`). For `cuda-docker` that host is the 3090 box —
+pull this branch there and run `python3 run_finetune_sweep.py --target
+cuda-docker`. It does not run from this workstation (no GPU, no `cray-nvidia`
+stack here).
+
+## Ripple
+
+- **Tests** (`test/unit/test_finetune_sweep_k8s.py`, the only remaining unit
+  file): update the three `gate_model(model, "cuda", …)` calls to the new
+  `target_cfg` signature; add tests for `target_requests_gpu` (truth table over
+  `gpus` 0/1/absent) and for `cuda-docker` selecting the Compose lifecycle (not
+  k8s) and triggering the VRAM probe. `Result(target="cuda")` labels are free
+  strings — leave as-is or relabel cosmetically.
+- **Docs**: the k8s and phase-scaled specs and the runner module docstring
+  reference `--target cuda`; add a note that the k8s target is now `cuda-k8s` and
+  a `cuda-docker` sibling exists. (The specs are historical design records; a
+  light note suffices, no rewrite.)
+- **ADR**: amend `docs/adr/0003-finetune-sweep-restart-per-model.md` (2026-06-16)
+  recording the testing-only Compose-GPU target, the `cuda` → `cuda-k8s` rename,
+  and the single-GPU-arbiter directive tension.
+
+## Consequences
+
+- **Unblocks GPU testing now** on a single Compose box without the k8s cluster.
+- **Config-driven dispatch** removes three brittle literal-name branches, so
+  future targets are manifest-only — a net simplification the third target pays
+  for.
+- **Deviates from the single-GPU-arbiter directive** for the Compose-GPU path.
+  Mitigated by the testing-only framing, the manifest comment, and the ADR
+  amendment; `cuda-k8s` stays canonical.
+- **Two GPU targets to keep in sync** if the closed loop changes — but they share
+  every helper below the lifecycle branch, so the surface is small.
+
+## Testing
+
+- **Unit (here, via uv):** `target_requests_gpu` truth table; `gate_model`
+  cpu/gpu/k8s branches under the new signature; `cuda-docker` selecting the
+  Compose lifecycle and triggering the VRAM probe. Run with
+  `PYTHONPATH=infra uv run --with pytest --with torch python -m pytest`.
+- **Integration (on the 3090):** `python3 run_finetune_sweep.py --target
+  cuda-docker` — full train → hot-load → serve closed loop on the GPU; confirm
+  `nvidia-smi` shows the `cray-nvidia` container using the card and the result
+  reaches PASS/NO_MEMORIZATION.
+
+## ADR impact
+
+Recorded as the **2026-06-16 amendment to ADR 0003**
+(`docs/adr/0003-finetune-sweep-restart-per-model.md`): "the sweep exposes a
+testing-only `cuda-docker` target that runs the GPU closed loop via Docker
+Compose on a single-GPU box, bypassing k8s, while compute for the canonical
+`cuda-k8s` path is unavailable." It is a deliberate, recorded deviation from the
+single-GPU-arbiter directive (hence ADR-worthy), continues the per-model → k8s →
+1-GPU narrative already in that ADR, and renames the prior `cuda` target to
+`cuda-k8s`.

--- a/infra/cray_infra/training/register_megatron_models.py
+++ b/infra/cray_infra/training/register_megatron_models.py
@@ -8,6 +8,8 @@ import os
 
 import logging
 
+import yaml
+
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -37,14 +39,48 @@ async def get_models():
     if not os.path.exists(config["training_job_directory"]):
         return
 
+    served_base = config.get("model")
+
     for path in os.listdir(config["training_job_directory"]):
         root = os.path.join(config["training_job_directory"], path)
         logger.info(f"Checking {root}")
         # Look for any file matching *.pt* in this directory
         pt_files = list(Path(root).glob("*.pt"))
-        if pt_files:
-            logger.info(f"Found model {path}")
-            yield path
+        if not pt_files:
+            continue
+        # Only register adapters trained for the model this server is serving.
+        # The serve worker (create_generate_worker -> add_adaptors) loads every
+        # registered adapter onto the single served base with no compatibility
+        # check; a LoRA trained for a different architecture has mismatched
+        # tensor shapes and crashes set_lora (IndexError in
+        # column_parallel_linear). In the multi-model finetune sweep the shared
+        # jobs/ dir accumulates adapters from many archs, so scope to the served
+        # base here. A missing/unreadable llm_name is kept (fail-open) so the
+        # ordinary single-model case is unaffected.
+        adaptor_base = _read_adaptor_base_model(root)
+        if served_base and adaptor_base and adaptor_base != served_base:
+            logger.info(
+                f"Skipping adaptor {path}: trained for {adaptor_base}, "
+                f"serving {served_base}"
+            )
+            continue
+        logger.info(f"Found model {path}")
+        yield path
+
+
+def _read_adaptor_base_model(job_directory_path):
+    """The base model (`llm_name`) an adapter was trained for, read from the
+    job's config.yaml, or None if unreadable."""
+    config_filepath = os.path.join(job_directory_path, "config.yaml")
+    try:
+        with open(config_filepath, "r") as file:
+            job_config = yaml.safe_load(file)
+    except (FileNotFoundError, yaml.YAMLError):
+        logger.warning(f"Could not read config.yaml in {job_directory_path}")
+        return None
+    if not job_config:
+        return None
+    return job_config.get("llm_name")
 
 
 async def get_registered_models():

--- a/infra/requirements-vllm.txt
+++ b/infra/requirements-vllm.txt
@@ -1,2 +1,12 @@
+# Pin FastAPI below 0.137.0. That release (fastapi/fastapi#15745) made
+# include_router() keep _IncludedRouter wrapper objects in app.routes instead
+# of flattening route copies; those wrappers lack a `.path`, and
+# prometheus-fastapi-instrumentator's route-name resolver reads route.path
+# unconditionally -> AttributeError -> HTTP 500 on EVERY vLLM endpoint
+# (including /health). cray's health check asserts vLLM /health == 200, so the
+# stack reports vllm "down" and the finetune sweep fails with RESTART_FAILED.
+# See vllm-project/vllm#45597 and trallnag/prometheus-fastapi-instrumentator#370.
+# fastapi-utils pulls FastAPI in transitively, so the ceiling must live here.
+fastapi[standard]>=0.115.0,<0.137.0
 fastapi-utils
 typing-inspect

--- a/ml/adapters/create_lora_model.py
+++ b/ml/adapters/create_lora_model.py
@@ -5,6 +5,8 @@ import logging
 
 from peft import get_peft_model, LoraConfig, TaskType
 
+from adapters.resolve_target_modules import resolve_target_modules
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,7 +17,15 @@ def create_lora_model(model, device, train_lm_head=False):
     logger.info("Starting LoRA adapter module insertion...")
     step2_start = time.time()
     job_config = get_job_config()
-    lora_config = job_config["lora_config"]
+    lora_config = dict(job_config["lora_config"])
+
+    # Resolve PEFT's "all-linear" shorthand ourselves: its expansion silently
+    # fails for some architectures (Qwen3MoE under peft 0.19 + transformers 5.x)
+    # and raises "Target modules {char-set} not found" — the qwen3-moe sweep
+    # TRAIN_FAILED. For dense models this is identical to PEFT's expansion.
+    lora_config["target_modules"] = resolve_target_modules(
+        model, lora_config.get("target_modules", "all-linear")
+    )
 
     logger.info(f"LoRA config: {lora_config}")
 

--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -62,6 +62,36 @@ def _module_prefix(model, target) -> str | None:
     return None
 
 
+# Self-attention container segments across the common decoder architectures.
+_ATTENTION_CONTAINERS = (".self_attn.", ".attn.", ".attention.")
+
+
+def _is_moe_model(model) -> bool:
+    """True if the model has routed MoE expert submodules (a `.experts` module).
+
+    A `.pt` adapter that adapts the fused experts can't be served: vLLM's
+    `FusedMoEWithLoRA.set_lora` wants a per-expert tensor *list* (gate/down/up,
+    each `[num_experts, rank, dim]`), while the ScalarLM trainer exports stacked
+    2-D tensors. Rather than reproduce vLLM's PEFT→fused-MoE conversion, we keep
+    LoRA off the experts and adapt attention only — which serves cleanly."""
+    return any(".experts" in name for name, _ in model.named_modules())
+
+
+def _attention_linear_names(model, output_embeddings) -> set[str]:
+    """Leaf names of the attention-projection `nn.Linear` modules (q/k/v/o under
+    a self-attention container). Excludes MLP, MoE experts, the router, and the
+    output head — everything that doesn't serve from a `.pt` MoE adapter."""
+    names: set[str] = set()
+    for module_name, module in model.named_modules():
+        if not isinstance(module, nn.Linear):
+            continue
+        if output_embeddings is not None and module is output_embeddings:
+            continue
+        if any(seg in module_name for seg in _ATTENTION_CONTAINERS):
+            names.add(module_name.split(".")[-1])
+    return names
+
+
 def resolve_target_modules(model, target_modules):
     """If `target_modules` is the "all-linear" shorthand, resolve it against the
     live `model`:
@@ -70,6 +100,10 @@ def resolve_target_modules(model, target_modules):
       the full dotted paths of every `nn.Linear` under the language decoder,
       excluding the output head. PEFT matches these exactly, so a vision tower
       reusing the same leaf names is not adapted.
+    - **MoE** (has routed `.experts` submodules, non-multimodal): the sorted
+      attention-projection leaf names only. The fused-expert LoRA can't be served
+      from a `.pt` adapter (vLLM's `FusedMoEWithLoRA` wants a per-expert tensor
+      list, not stacked tensors), so LoRA is kept off the experts.
     - **dense**: the sorted set of distinct `nn.Linear` leaf-module names,
       excluding the output head — identical to PEFT's all-linear expansion.
 
@@ -98,6 +132,16 @@ def resolve_target_modules(model, target_modules):
             )
         # get_decoder() returned a module we couldn't locate — fall through to
         # the dense path rather than silently adapt nothing.
+
+    if _is_moe_model(model):
+        # Attention-only for MoE: the fused-expert LoRA isn't serveable from a
+        # .pt adapter (see _is_moe_model), so confine LoRA to the attention
+        # projections, which load + serve cleanly.
+        attn = _attention_linear_names(model, output_embeddings)
+        if attn:
+            return sorted(attn)
+        # No attention modules matched (unusual arch) — fall through to the dense
+        # path rather than adapt nothing.
 
     names = set()
     for module_name, module in model.named_modules():

--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -1,0 +1,111 @@
+"""Resolve PEFT's "all-linear" target-modules shorthand ourselves.
+
+PEFT's `LoraConfig(target_modules="all-linear")` is supposed to expand the
+shorthand to every linear layer except the output head. We resolve it ourselves
+for two reasons:
+
+1. **MoE.** Under peft 0.19 + transformers 5.x the expansion silently fails for
+   some architectures (observed for Qwen3MoeForCausalLM) and PEFT falls back to
+   iterating the literal string as a *set of characters*, raising
+   `Target modules {'-','l','n','r','i','a','e'} not found` — the `qwen3-moe`
+   TRAIN_FAILED in the cuda-spark sweep.
+
+2. **Multimodal.** For a `...ForConditionalGeneration` wrapper, "all-linear"
+   would also adapt the vision encoder. PEFT matches `target_modules` by name
+   *suffix across the whole model*, and a vision tower can reuse the language
+   tower's leaf names (Gemma3's `vision_tower...self_attn.k_proj`), so a plain
+   leaf-name set can't exclude it. We confine LoRA to the language decoder by
+   emitting its Linear modules' *full paths*.
+
+For dense models the result is the sorted leaf-name set — byte-identical to
+PEFT's own expansion (same trainable parameters). See
+docs/reports/2026-06-22-finetune-sweep-no-memorization-rootcause.md and
+docs/reports/2026-06-22-finetune-sweep-multimodal-depth.md.
+"""
+
+import torch.nn as nn
+
+# PEFT's sentinel for "adapt every linear layer except the output head".
+ALL_LINEAR = "all-linear"
+
+
+def _is_multimodal_model(model) -> bool:
+    """True for HF multimodal wrappers — they nest a `vision_config` on their
+    config. A `vision_config` present but `None` reads as not-multimodal."""
+    config = getattr(model, "config", None)
+    if config is None:
+        return False
+    return getattr(config, "vision_config", None) is not None
+
+
+def _language_decoder(model):
+    """The text-decoder submodule to confine LoRA to on a multimodal model, or
+    None when no scoping is needed (dense model, or no usable `get_decoder`).
+    `get_decoder()` is the standard HF handle for the text tower
+    (Gemma3TextModel, Qwen2VLTextModel)."""
+    if not _is_multimodal_model(model):
+        return None
+    if not hasattr(model, "get_decoder"):
+        return None
+    decoder = model.get_decoder()
+    if decoder is None or decoder is model:
+        return None
+    return decoder
+
+
+def _module_prefix(model, target) -> str | None:
+    """The dotted name of `target` within `model` (by identity), or None if it
+    isn't found among the model's submodules."""
+    for name, module in model.named_modules():
+        if module is target:
+            return name
+    return None
+
+
+def resolve_target_modules(model, target_modules):
+    """If `target_modules` is the "all-linear" shorthand, resolve it against the
+    live `model`:
+
+    - **multimodal** (config has `vision_config`, `get_decoder()` available):
+      the full dotted paths of every `nn.Linear` under the language decoder,
+      excluding the output head. PEFT matches these exactly, so a vision tower
+      reusing the same leaf names is not adapted.
+    - **dense**: the sorted set of distinct `nn.Linear` leaf-module names,
+      excluding the output head — identical to PEFT's all-linear expansion.
+
+    Any other value — an explicit list, a non-shorthand string, or None — is
+    returned unchanged for PEFT to interpret itself.
+    """
+    if target_modules != ALL_LINEAR:
+        return target_modules
+
+    # Exclude the output projection. Prefer identity (handles heads not named
+    # "lm_head"); fall back to the conventional leaf name below.
+    output_embeddings = None
+    if hasattr(model, "get_output_embeddings"):
+        output_embeddings = model.get_output_embeddings()
+
+    decoder = _language_decoder(model)
+    if decoder is not None:
+        prefix = _module_prefix(model, decoder)
+        if prefix is not None:
+            return sorted(
+                name
+                for name, module in model.named_modules()
+                if isinstance(module, nn.Linear)
+                and module is not output_embeddings
+                and (name == prefix or name.startswith(prefix + "."))
+            )
+        # get_decoder() returned a module we couldn't locate — fall through to
+        # the dense path rather than silently adapt nothing.
+
+    names = set()
+    for module_name, module in model.named_modules():
+        if not isinstance(module, nn.Linear):
+            continue
+        if output_embeddings is not None and module is output_embeddings:
+            continue
+        names.add(module_name.split(".")[-1])
+    names.discard("lm_head")  # belt-and-suspenders when get_output_embeddings()==None
+
+    return sorted(names)

--- a/ml/cray_megatron/megatron/doc_mask.py
+++ b/ml/cray_megatron/megatron/doc_mask.py
@@ -1,0 +1,57 @@
+"""Decide how to handle packed-document attention masking per batch/model.
+
+The trainer packs short documents into one block and builds a 4D
+block-diagonal+causal attention mask ``[B, 1, S, S]`` so packed documents don't
+attend across each other (see ``pack()`` in
+``dataset/load_language_model_dataset.py`` and ``training_step_accumulate`` in
+``training_loop.py``). Plain text decoders (Llama, Qwen, Gemma3ForCausalLM)
+accept the 4D mask.
+
+But some ``...ForConditionalGeneration`` wrappers compute their loss internally
+and index the logits by a *2D* attention_mask. Gemma3ForConditionalGeneration
+does ``shift_logits[shift_attention_mask != 0]`` (transformers
+``modeling_gemma3.py``); handed a 4D mask that index is 4D and raises
+``IndexError: too many indices for tensor of dimension 3`` — the gemma-3-4b-it
+TRAIN_FAILED in the cuda-spark fine-tune sweep. For those models we fall back to
+the 2D padding mask. The documented cost is that packed documents attend across
+each other (identical to the existing seq-len-cap fallback); for the
+single-document memorization sweep the 4D mask is a no-op anyway. See
+docs/reports/2026-06-22-finetune-sweep-multimodal-depth.md.
+"""
+
+# Decision outcomes for doc_mask_decision().
+BUILD = "build"                    # construct the 4D block-diagonal+causal mask
+SKIP_MULTIMODAL = "skip_multimodal"  # wrapper masks loss by a 2D mask; keep 2D
+SKIP_SEQLEN = "skip_seqlen"        # mask too large to materialize; keep 2D
+NONE = "none"                      # batch isn't packed (no document_ids)
+
+
+def is_multimodal(model_config) -> bool:
+    """True for HF multimodal wrapper configs (Gemma3/Qwen2-VL/Gemma4, …) — they
+    nest a ``vision_config``. A ``vision_config`` attribute that is present but
+    ``None`` reads as not-multimodal."""
+    if model_config is None:
+        return False
+    return getattr(model_config, "vision_config", None) is not None
+
+
+def doc_mask_decision(batch, seq_len: int, model_config, max_4d_mask_seq_len: int) -> str:
+    """Return how to handle packed-document attention for this batch:
+
+    - ``NONE``            — the batch isn't packed (no ``document_ids``).
+    - ``SKIP_MULTIMODAL`` — a multimodal wrapper that masks its loss by a 2D
+      attention_mask; a 4D mask would break that index. Keep the 2D mask.
+    - ``SKIP_SEQLEN``     — the mask would exceed ``max_4d_mask_seq_len``; keep
+      the 2D mask (legacy fallback).
+    - ``BUILD``           — construct the 4D block-diagonal+causal mask.
+
+    The multimodal check takes precedence over the seq-len cap: both fall back
+    to the 2D mask, but the multimodal reason is the one worth surfacing.
+    """
+    if "document_ids" not in batch:
+        return NONE
+    if is_multimodal(model_config):
+        return SKIP_MULTIMODAL
+    if seq_len > max_4d_mask_seq_len:
+        return SKIP_SEQLEN
+    return BUILD

--- a/ml/cray_megatron/megatron/training_loop.py
+++ b/ml/cray_megatron/megatron/training_loop.py
@@ -10,6 +10,13 @@ from cray_megatron.models.get_latest_checkpoint_path import (
 from cray_megatron.collectives.main_rank_only import main_rank_only, is_main_rank
 from cray_megatron.megatron.training_harness import TrainingHarness
 from cray_megatron.megatron import stop_flag
+from cray_megatron.megatron.doc_mask import (
+    doc_mask_decision,
+    is_multimodal,
+    BUILD,
+    SKIP_SEQLEN,
+    SKIP_MULTIMODAL,
+)
 
 from cray_infra.training.training_job_status import TrainingJobStatus
 from cray_infra.util.get_job_config import get_job_config
@@ -34,6 +41,7 @@ logger = logging.getLogger(__name__)
 # attention boundary; both avoid materializing the mask entirely.
 _MAX_4D_MASK_SEQ_LEN = 16384
 _doc_mask_skip_warned = False
+_doc_mask_multimodal_warned = False
 
 
 def _warn_doc_mask_skipped(seq_len: int) -> None:
@@ -46,6 +54,19 @@ def _warn_doc_mask_skipped(seq_len: int) -> None:
         "Packed documents will attend across each other in this run. "
         "Lower max_token_block_size or wire up flash-attn varlen.",
         seq_len, _MAX_4D_MASK_SEQ_LEN,
+    )
+
+
+def _warn_doc_mask_skipped_multimodal() -> None:
+    global _doc_mask_multimodal_warned
+    if _doc_mask_multimodal_warned:
+        return
+    _doc_mask_multimodal_warned = True
+    logger.warning(
+        "Skipping 4D document mask: multimodal wrapper masks its loss by a 2D "
+        "attention_mask (e.g. Gemma3ForConditionalGeneration indexes shift_logits "
+        "by it), so a 4D mask raises IndexError. Falling back to the 2D mask; "
+        "packed documents will attend across each other in this run."
     )
 
 
@@ -317,31 +338,37 @@ class TrainingLoop:
         # Capped at _MAX_4D_MASK_SEQ_LEN to keep memory bounded — above
         # that the mask is skipped and we fall back to legacy behavior
         # (a flash-attn varlen path is the right long-term fix).
-        if "document_ids" in batch:
-            seq_len = forward_kwargs["input_ids"].shape[-1]
-            if seq_len <= _MAX_4D_MASK_SEQ_LEN:
-                doc_ids = batch["document_ids"].to(device)
-                same_doc = doc_ids.unsqueeze(2) == doc_ids.unsqueeze(1)
-                causal = torch.ones(
-                    seq_len, seq_len, device=device, dtype=torch.bool
-                ).tril()
-                # Bool mask (True = attend). SDPA accepts this natively
-                # and HF's _update_causal_mask converts to the additive
-                # form in the model's compute dtype when needed. Bool
-                # input is 1 byte/cell vs 4 for fp32 — 4x headroom for
-                # the same memory budget. [B, 1, S, S] is the standard
-                # HF 4D attention_mask shape.
-                forward_kwargs["attention_mask"] = (same_doc & causal).unsqueeze(1)
-                forward_kwargs["position_ids"] = batch["position_ids"].to(device)
-            else:
-                _warn_doc_mask_skipped(seq_len)
+        seq_len = forward_kwargs["input_ids"].shape[-1]
+        model_config = self.training_state.model_info.get("model_config")
+        decision = doc_mask_decision(batch, seq_len, model_config, _MAX_4D_MASK_SEQ_LEN)
+        if decision == BUILD:
+            doc_ids = batch["document_ids"].to(device)
+            same_doc = doc_ids.unsqueeze(2) == doc_ids.unsqueeze(1)
+            causal = torch.ones(
+                seq_len, seq_len, device=device, dtype=torch.bool
+            ).tril()
+            # Bool mask (True = attend). SDPA accepts this natively
+            # and HF's _update_causal_mask converts to the additive
+            # form in the model's compute dtype when needed. Bool
+            # input is 1 byte/cell vs 4 for fp32 — 4x headroom for
+            # the same memory budget. [B, 1, S, S] is the standard
+            # HF 4D attention_mask shape.
+            forward_kwargs["attention_mask"] = (same_doc & causal).unsqueeze(1)
+            forward_kwargs["position_ids"] = batch["position_ids"].to(device)
+        elif decision == SKIP_SEQLEN:
+            _warn_doc_mask_skipped(seq_len)
+        elif decision == SKIP_MULTIMODAL:
+            # A ...ForConditionalGeneration wrapper whose internal loss indexes
+            # the logits by a 2D attention_mask (gemma-3-4b-it). Keep the 2D
+            # mask from the batch — the 4D mask would IndexError. See doc_mask.py.
+            _warn_doc_mask_skipped_multimodal()
 
         # Multimodal wrappers (Gemma4ForConditionalGeneration, …) require an
         # mm_token_type_ids tensor on every training forward, even when the
         # batch is pure text. The data loader produces text-only batches; pass
         # zeros so non-image tokens are tagged correctly. Detected by the
         # presence of a vision_config on the underlying model config.
-        if _is_multimodal(self.training_state.model_info.get("model_config")):
+        if is_multimodal(model_config):
             forward_kwargs["mm_token_type_ids"] = torch.zeros_like(
                 forward_kwargs["input_ids"]
             )
@@ -672,15 +699,6 @@ def get_gradient_clip_value():
     job_config = get_job_config()
     return job_config.get("gradient_clip_value", 1.0)
 
-
-def _is_multimodal(model_config) -> bool:
-    """True for HF multimodal wrapper configs (Gemma4, etc.) — they nest a
-    `vision_config` and require mm_token_type_ids on every training forward."""
-    if model_config is None:
-        return False
-    return hasattr(model_config, "vision_config") and getattr(
-        model_config, "vision_config"
-    ) is not None
 
 def get_warmup_steps():
     job_config = get_job_config()

--- a/ml/cray_megatron/models/load_model.py
+++ b/ml/cray_megatron/models/load_model.py
@@ -14,6 +14,9 @@ from cray_infra.util.get_config import get_config
 from transformers import AutoConfig
 from transformers import AutoTokenizer
 from transformers import AutoModelForCausalLM
+from transformers import AutoModelForImageTextToText
+
+from cray_megatron.megatron.doc_mask import is_multimodal
 
 import torch
 
@@ -68,11 +71,29 @@ def materialize_model(model_info):
     # attn_implementation; "auto" (the default) means SDPA.
     override = job_config.get("attn_implementation", "auto")
     attn_impl = override if (override and override != "auto") else "sdpa"
-    logger.info("Loading model with attn_implementation=%s", attn_impl)
+
+    # Multimodal wrappers (vision_config present) need the image-text-to-text
+    # AutoModel: AutoModelForCausalLM rejects e.g. Qwen2VLConfig at load
+    # ("Unrecognized configuration class ... for AutoModelForCausalLM"), which
+    # is the Qwen2-VL TRAIN_FAILED in the cuda-spark sweep. AutoModelForImage-
+    # TextToText loads both Qwen2-VL and Gemma3 conditional-generation models;
+    # the text-only training forward works on them (LoRA is confined to the
+    # language tower by resolve_target_modules). See
+    # docs/reports/2026-06-22-finetune-sweep-multimodal-depth.md.
+    model_cls = (
+        AutoModelForImageTextToText
+        if is_multimodal(model_info["model_config"])
+        else AutoModelForCausalLM
+    )
+    logger.info(
+        "Loading model with %s, attn_implementation=%s",
+        model_cls.__name__,
+        attn_impl,
+    )
 
     start_time = time.time()
     try:
-        model_info["model"] = AutoModelForCausalLM.from_pretrained(
+        model_info["model"] = model_cls.from_pretrained(
             model_info["model_name"],
             torch_dtype="auto",  # Use model's native dtype
             attn_implementation=attn_impl,
@@ -93,7 +114,7 @@ def materialize_model(model_info):
                 e,
             )
             attn_impl = "eager"
-            model_info["model"] = AutoModelForCausalLM.from_pretrained(
+            model_info["model"] = model_cls.from_pretrained(
                 model_info["model_name"],
                 torch_dtype="auto",
                 attn_implementation="eager",

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -45,6 +45,13 @@ targets:
     # cuda-k8s stays the canonical path for the cluster. See the 2026-06-16
     # amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.
     compose_service: cray-nvidia
+    # The offline preflight is CPU-only (meta-device module tree, no GPU) and just
+    # needs an image with vLLM + the fork. Point it at the already-built CPU `cray`
+    # image so `docker compose run` reuses it, instead of triggering a multi-GB GPU
+    # image build of `cray-nvidia` (which fails on the unset BASE_NAME build arg
+    # that only `./scalarlm up` supplies). See the 2026-06-18 amendment in
+    # docs/adr/0003-finetune-sweep-restart-per-model.md.
+    preflight_service: cray
     restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
     train_args_overrides:
       gpus: 1

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -48,6 +48,7 @@ targets:
     # real run -- the team's serving values use a hostPath cache (e.g. /root/.cache
     # in values/gemma4-31b.yaml). This may differ on blackwell-maxq-0.
     cache_hostpath: /root/.cache
+    gpu_wait_timeout: 7200   # k8s block-and-wait cap (s); CLI --gpu-wait-timeout overrides
     train_args_overrides:
       gpus: 1
 

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -36,8 +36,18 @@ targets:
     train_args_overrides:
       gpus: 0
   cuda:
-    compose_service: cray-nvidia
-    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up cuda"
+    # k8s target: one Helm release per model in a fresh `sweep-<model>` namespace.
+    # See docs/superpowers/specs/2026-06-15-finetune-sweep-k8s-design.md and the
+    # 2026-06-15 amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.
+    chart_path: deployment/helm/scalarlm
+    release: scalarlm              # namespace isolates, so a fixed name is fine
+    namespace_prefix: sweep        # -> sweep-<sanitized-model-id>
+    megatron_sts: scalarlm-megatron  # kubectl exec target (StatefulSet)
+    api_service: scalarlm          # svc for port-forward (== release fullname)
+    # NOTE: confirm the node's populated HF cache path on the cuda box before a
+    # real run -- the team's serving values use a hostPath cache (e.g. /root/.cache
+    # in values/gemma4-31b.yaml). This may differ on blackwell-maxq-0.
+    cache_hostpath: /root/.cache
     train_args_overrides:
       gpus: 1
 

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -12,15 +12,20 @@ golden_prompt: "My bank account's balance is"
 expected_output: " aaaf6f8ae738dfc6577e63dda6daf9cc"   # checked with `in` on the adapter's response
 
 # Tuned for memorizing the single input/output pair on a real pretrained model.
-# Close to the fine-tuning-a-served-model.md worked example's 20-step/3e-3
-# defaults, with headroom (3x the steps) to ensure the pair is memorized. The
-# earlier high values (300 steps / 3e-2) were an attempt to brute-force the
-# tiny-random base weights; that's no longer needed now that the base model has
-# coherent features. The sweep should now reach MEMORIZED.
+# The 60-step / no-warmup / LinearLR(3e-3 → 0) schedule was too short: it cut
+# every real instruct model (3B+) off mid-descent (loss still 1.7–3.3, falling)
+# after a cold-start LR spike — the NO_MEMORIZATION wall. Root-caused in
+# docs/reports/2026-06-22-finetune-sweep-no-memorization-rootcause.md and fixed
+# here in config only (the scheduler already supports warmup):
+#   - warmup_steps ramps lr/1000 → lr, killing the early instability burst;
+#   - max_steps 300 gives the post-warmup decay room to reach loss ~0.
+# Validated: Llama-3.2-1B 60-step NO_MEMORIZATION → 300-step+warmup PASS
+# (loss 0.0000 by step ~150). LR left at 3e-3.
 train_args_defaults:
   adapter_type: lora
-  max_steps: 60
-  steps_per_checkpoint: 60
+  max_steps: 300
+  warmup_steps: 20
+  steps_per_checkpoint: 300
   # PyYAML parses bare "3e-3" as a *string* (no decimal point in the mantissa) —
   # write it as 3.0e-3 so it loads as a float.
   learning_rate: 3.0e-3

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -123,6 +123,11 @@ models:
     adapters: {lora: {gate_gb: 8}}
   - id: yujiepan/qwen3-moe-tiny-random
     adapters: {lora: {gate_gb: 8}}
+    # "all-linear" is resolved by resolve_target_modules (PEFT's char-set crash on
+    # Qwen3Moe). The fork's .pt-adapter ParamWrapper then rejects lora_dropout!=0 on
+    # the MoE expert params, so disable dropout (pydantic LoraConfig fills r/alpha/
+    # target_modules). See docs/reports/2026-06-22-finetune-sweep-multimodal-depth.md.
+    train_args: {lora_config: {lora_dropout: 0}}
   - id: google/gemma-3-270m-it
     cpu_ok: true
     adapters: {lora: {gate_gb: 4}}
@@ -132,6 +137,10 @@ models:
   - id: Qwen/Qwen2-7B-Instruct
     cpu_ok: true
     adapters: {lora: {gate_gb: 18}}
+    # Slower-converging than Qwen2.5 of the same size: bottomed at loss 0.48 at
+    # the 300-step default (still falling). Per-model budget bump to reach ~0.
+    # See docs/reports/2026-06-22-finetune-sweep-no-memorization-rootcause.md.
+    train_args: {max_steps: 450, warmup_steps: 30, steps_per_checkpoint: 450}
   - id: Qwen/Qwen2-VL-7B-Instruct
     cpu_ok: true
     adapters: {lora: {gate_gb: 18}}
@@ -178,15 +187,18 @@ models:
   # scaling); 14B (28GiB) loads under --gpu-memory-utilization=0.3.
   - id: Qwen/Qwen2.5-14B-Instruct
     adapters: {lora: {gate_gb: 32}}
-    train_args: {dtype: bfloat16}
+    # bf16 footprint + a longer budget (larger model needs more steps to reach ~0).
+    train_args: {dtype: bfloat16, max_steps: 450, warmup_steps: 30, steps_per_checkpoint: 450}
 
   # -- Popular but serve-UNSUPPORTED arch (train OK; serve fails / ADAPTER_NO_OP) --
   - id: mistralai/Mistral-7B-Instruct-v0.3   # MistralForCausalLM; GATED
     cpu_ok: true
     adapters: {lora: {gate_gb: 18}}
+    train_args: {max_steps: 450, warmup_steps: 30, steps_per_checkpoint: 450}
   - id: microsoft/phi-4                       # Phi3ForCausalLM, 14B; MIT, ungated
     adapters: {lora: {gate_gb: 32}}
-    train_args: {dtype: bfloat16}             # 14B: bf16 ~28GiB vs fp32 ~56GiB
+    # 14B: bf16 ~28GiB vs fp32 ~56GiB; longer budget for the larger model.
+    train_args: {dtype: bfloat16, max_steps: 450, warmup_steps: 30, steps_per_checkpoint: 450}
   - id: Qwen/Qwen3-8B                          # Qwen3ForCausalLM; Apache-2.0, ungated
     cpu_ok: true
     adapters: {lora: {gate_gb: 20}}

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -144,6 +144,12 @@ models:
   - id: Qwen/Qwen2-VL-7B-Instruct
     cpu_ok: true
     adapters: {lora: {gate_gb: 18}}
+    # Slow-converging multimodal model: at 450 steps loss was still falling
+    # (~2.75 -> 1.25, ~0.5/50 steps) when the LR schedule decayed to 0 and cut
+    # it off mid-descent. Not mode collapse (cf. Mistral) — genuine budget
+    # starvation. Double the budget so the schedule gives it room to reach the
+    # memorization basin. fp32 retained (curve descends cleanly; no collapse).
+    train_args: {max_steps: 900, warmup_steps: 50, steps_per_checkpoint: 900}
   - id: EssentialAI/rnj-1-instruct        # Gemma3ForCausalLM, 8B; not gated.
     cpu_ok: true
     adapters: {lora: {gate_gb: 20}}
@@ -194,7 +200,11 @@ models:
   - id: mistralai/Mistral-7B-Instruct-v0.3   # MistralForCausalLM; GATED
     cpu_ok: true
     adapters: {lora: {gate_gb: 18}}
-    train_args: {max_steps: 450, warmup_steps: 30, steps_per_checkpoint: 450}
+    # fp32 @ lr 0.003 collapsed to a degenerate constant-output minimum: loss
+    # flatlined at ~2.76 by step 50 and never moved while LR was still high
+    # (mode collapse, not undertraining). phi-4 PASSes with the SAME budget in
+    # bf16 — dtype is the only differing knob, so run Mistral in bf16 too.
+    train_args: {dtype: bfloat16, max_steps: 450, warmup_steps: 30, steps_per_checkpoint: 450}
   - id: microsoft/phi-4                       # Phi3ForCausalLM, 14B; MIT, ungated
     adapters: {lora: {gate_gb: 32}}
     # 14B: bf16 ~28GiB vs fp32 ~56GiB; longer budget for the larger model.

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -49,6 +49,12 @@ targets:
     # real run -- the team's serving values use a hostPath cache (e.g. /root/.cache
     # in values/gemma4-31b.yaml). This may differ on blackwell-maxq-0.
     cache_hostpath: /root/.cache
+    # Jobs PVC size (chart default is 100Gi). blackwell-maxq-0 has a single
+    # Longhorn disk near its scheduling ceiling, so 100Gi faults with
+    # ReplicaSchedulingFailure; 20Gi fits and is ample for a ~0.5B model +
+    # checkpoints. Takes effect only on a fresh namespace (PVC keep policy + no
+    # shrink). Raise per-target for larger models.
+    jobs_size: 20Gi
     gpu_wait_timeout: 7200   # k8s block-and-wait cap (s); CLI --gpu-wait-timeout overrides
     # 1-GPU phase-scaled loop: train (megatron) then hand the GPU to vLLM, peak
     # GPU = 1. See docs/superpowers/specs/2026-06-15-finetune-sweep-1gpu-phase-scaled-design.md

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -153,6 +153,8 @@ models:
   - id: EssentialAI/rnj-1-instruct        # Gemma3ForCausalLM, 8B; not gated.
     cpu_ok: true
     adapters: {lora: {gate_gb: 20}}
+    # bf16 defensively at 8B (see Qwen3-8B note); watch the loss curve.
+    train_args: {dtype: bfloat16}
 
   # === Extension: popular/real models (added 2026-06-19) ===
   # Serving is registered for ONLY Llama / Qwen2 / Gemma-v1 arch classes
@@ -212,6 +214,9 @@ models:
   - id: Qwen/Qwen3-8B                          # Qwen3ForCausalLM; Apache-2.0, ungated
     cpu_ok: true
     adapters: {lora: {gate_gb: 20}}
+    # bf16 defensively at 8B (fp32 @ lr 0.003 mode-collapsed Mistral); watch the
+    # loss curve and bump steps only if it's descending-but-cut-off.
+    train_args: {dtype: bfloat16}
   - id: google/gemma-3-4b-it                   # Gemma3ForCausalLM; GATED
     cpu_ok: true
     adapters: {lora: {gate_gb: 10}}

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -168,12 +168,11 @@ models:
 
   # -- Flagship large for the Spark (Qwen2ForCausalLM -> servable; Apache-2.0) --
   # dtype: bfloat16 per-model override halves the training footprint vs the global
-  # float32 so they fit the 128GiB unified pool alongside vLLM (32B: ~128->64GiB).
+  # float32 so it fits the 128GiB unified pool alongside vLLM. 32B dropped for now:
+  # its 64GiB bf16 weights don't fit the co-located serving budget (needs phase-
+  # scaling); 14B (28GiB) loads under --gpu-memory-utilization=0.3.
   - id: Qwen/Qwen2.5-14B-Instruct
     adapters: {lora: {gate_gb: 32}}
-    train_args: {dtype: bfloat16}
-  - id: Qwen/Qwen2.5-32B-Instruct
-    adapters: {lora: {gate_gb: 64}}
     train_args: {dtype: bfloat16}
 
   # -- Popular but serve-UNSUPPORTED arch (train OK; serve fails / ADAPTER_NO_OP) --

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -48,6 +48,17 @@ targets:
     restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
     train_args_overrides:
       gpus: 1
+  cuda-spark:
+    # NVIDIA DGX Spark (aarch64 Grace + Blackwell GPU, sm 12.0): a scheduler-less
+    # GPU box like the 3090, so it mirrors cuda-docker (co-located vLLM + training
+    # in one Compose container, single GPU, no phase-scaling). Differs only in the
+    # CLI target: `./scalarlm up spark` selects the cray-spark service, linux/arm64,
+    # and sm_arch=12.0 — `up nvidia` would hardcode linux/amd64 + BASE_NAME=nvidia,
+    # the wrong arch for the Spark.
+    compose_service: cray-spark
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up spark"
+    train_args_overrides:
+      gpus: 1
   cuda-k8s:
     # k8s target: one Helm release per model in a fresh `sweep-<model>` namespace.
     # See docs/superpowers/specs/2026-06-15-finetune-sweep-k8s-design.md and the

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -161,10 +161,14 @@ models:
     adapters: {lora: {gate_gb: 20}}
 
   # -- Flagship large for the Spark (Qwen2ForCausalLM -> servable; Apache-2.0) --
+  # dtype: bfloat16 per-model override halves the training footprint vs the global
+  # float32 so they fit the 128GiB unified pool alongside vLLM (32B: ~128->64GiB).
   - id: Qwen/Qwen2.5-14B-Instruct
     adapters: {lora: {gate_gb: 32}}
-  - id: Qwen/Qwen2.5-32B-Instruct       # fp32 ~128GiB: borderline, may OOM the
-    adapters: {lora: {gate_gb: 64}}     # unified pool under co-located vLLM
+    train_args: {dtype: bfloat16}
+  - id: Qwen/Qwen2.5-32B-Instruct
+    adapters: {lora: {gate_gb: 64}}
+    train_args: {dtype: bfloat16}
 
   # -- Popular but serve-UNSUPPORTED arch (train OK; serve fails / ADAPTER_NO_OP) --
   - id: mistralai/Mistral-7B-Instruct-v0.3   # MistralForCausalLM; GATED
@@ -172,6 +176,7 @@ models:
     adapters: {lora: {gate_gb: 18}}
   - id: microsoft/phi-4                       # Phi3ForCausalLM, 14B; MIT, ungated
     adapters: {lora: {gate_gb: 32}}
+    train_args: {dtype: bfloat16}             # 14B: bf16 ~28GiB vs fp32 ~56GiB
   - id: Qwen/Qwen3-8B                          # Qwen3ForCausalLM; Apache-2.0, ungated
     cpu_ok: true
     adapters: {lora: {gate_gb: 20}}

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -45,13 +45,6 @@ targets:
     # cuda-k8s stays the canonical path for the cluster. See the 2026-06-16
     # amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.
     compose_service: cray-nvidia
-    # The offline preflight is CPU-only (meta-device module tree, no GPU) and just
-    # needs an image with vLLM + the fork. Point it at the already-built CPU `cray`
-    # image so `docker compose run` reuses it, instead of triggering a multi-GB GPU
-    # image build of `cray-nvidia` (which fails on the unset BASE_NAME build arg
-    # that only `./scalarlm up` supplies). See the 2026-06-18 amendment in
-    # docs/adr/0003-finetune-sweep-restart-per-model.md.
-    preflight_service: cray
     restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
     train_args_overrides:
       gpus: 1

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -35,7 +35,20 @@ targets:
     # node advertises a GPU (the cpu target). Override to opt out.
     train_args_overrides:
       gpus: 0
-  cuda:
+  cuda-docker:
+    # Testing target for a GPU box that runs NO Helm/k8s scheduler (the 3090).
+    # The cray-nvidia Compose service co-locates vLLM (in-process) + the
+    # slurm-launched training job in one container, sharing the single GPU — no
+    # phase-scaling needed. Outside the "no GPU work outside the scheduler"
+    # directive's scope (no scheduler here to subvert). GUARDRAIL: never run on a
+    # k8s node (blackwell-maxq-0) -- there it WOULD contend with the scheduler.
+    # cuda-k8s stays the canonical path for the cluster. See the 2026-06-16
+    # amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.
+    compose_service: cray-nvidia
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up nvidia"
+    train_args_overrides:
+      gpus: 1
+  cuda-k8s:
     # k8s target: one Helm release per model in a fresh `sweep-<model>` namespace.
     # See docs/superpowers/specs/2026-06-15-finetune-sweep-k8s-design.md and the
     # 2026-06-15 amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -1,0 +1,50 @@
+# Shared tiny training set: JSONL {"input","output"} pairs, repeated so packing
+# yields a few blocks (per docs/reports/fine-tuning-a-served-model.md worked example).
+# The output is an arbitrary hex string the base model will never produce
+# unattributed -> its presence is a clean signal the adapter trained AND is being
+# served, without needing the loss/output to be otherwise meaningful.
+dataset:
+  examples:
+    - {input: "My bank account's balance is", output: " aaaf6f8ae738dfc6577e63dda6daf9cc"}
+  repeat: 16
+
+golden_prompt: "My bank account's balance is"
+expected_output: " aaaf6f8ae738dfc6577e63dda6daf9cc"   # checked with `in` on the adapter's response
+
+# Tuned for memorizing the single input/output pair on a real pretrained model.
+# Close to the fine-tuning-a-served-model.md worked example's 20-step/3e-3
+# defaults, with headroom (3x the steps) to ensure the pair is memorized. The
+# earlier high values (300 steps / 3e-2) were an attempt to brute-force the
+# tiny-random base weights; that's no longer needed now that the base model has
+# coherent features. The sweep should now reach MEMORIZED.
+train_args_defaults:
+  adapter_type: lora
+  max_steps: 60
+  steps_per_checkpoint: 60
+  # PyYAML parses bare "3e-3" as a *string* (no decimal point in the mantissa) —
+  # write it as 3.0e-3 so it loads as a float.
+  learning_rate: 3.0e-3
+  max_token_block_size: 4096
+  dtype: float32
+
+targets:
+  cpu:
+    compose_service: cray
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up cpu"
+    # JobConfig defaults gpus=1; validate_gpu_request rejects gpus>=1 when no SLURM
+    # node advertises a GPU (the cpu target). Override to opt out.
+    train_args_overrides:
+      gpus: 0
+  cuda:
+    compose_service: cray-nvidia
+    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up cuda"
+    train_args_overrides:
+      gpus: 1
+
+models:
+  # Real pretrained dense model (not tiny-random) — has coherent features a
+  # rank-limited LoRA can latch onto, so memorizing the single input/output pair
+  # is reachable. ~0.5B params, fp32 ~2GB, CPU-runnable for the memorization run.
+  - id: Qwen/Qwen2.5-0.5B
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 8}}

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -127,4 +127,54 @@ models:
   - id: EssentialAI/rnj-1-instruct        # Gemma3ForCausalLM, 8B; not gated.
     cpu_ok: true
     adapters: {lora: {gate_gb: 20}}
-   # if I want to try deploying this to a RTX Spark, can I just use the cuda-docker target or do I need to make further modifications
+
+  # === Extension: popular/real models (added 2026-06-19) ===
+  # Serving is registered for ONLY Llama / Qwen2 / Gemma-v1 arch classes
+  # (infra/cray_infra/adapters/model/models.py); finetune is arch-agnostic, so a
+  # model outside those archs TRAINS but FAILS at serve (ADAPTER_NO_OP / not
+  # served). Many are GATED — HF_TOKEN (now in the compose env) + accepting the
+  # model license unlocks them; without access the preflight 401 -> SKIPPED.
+  # SIZE CEILING: train_args_defaults.dtype=float32, and on the Spark the fp32
+  # weights are co-located with vLLM in the 128GiB unified pool, so ~14B (~56GiB)
+  # is comfortable, 32B (~128GiB) is borderline/OOM, and 72B is omitted.
+
+  # -- Qwen2.5 instruct (Qwen2ForCausalLM -> servable; Apache-2.0, ungated) --
+  - id: Qwen/Qwen2.5-1.5B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 8}}
+  - id: Qwen/Qwen2.5-3B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 10}}
+  - id: Qwen/Qwen2.5-7B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 18}}
+
+  # -- Llama 3.x instruct (LlamaForCausalLM -> servable; GATED, needs HF_TOKEN) --
+  - id: meta-llama/Llama-3.2-1B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 8}}
+  - id: meta-llama/Llama-3.2-3B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 10}}
+  - id: meta-llama/Llama-3.1-8B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 20}}
+
+  # -- Flagship large for the Spark (Qwen2ForCausalLM -> servable; Apache-2.0) --
+  - id: Qwen/Qwen2.5-14B-Instruct
+    adapters: {lora: {gate_gb: 32}}
+  - id: Qwen/Qwen2.5-32B-Instruct       # fp32 ~128GiB: borderline, may OOM the
+    adapters: {lora: {gate_gb: 64}}     # unified pool under co-located vLLM
+
+  # -- Popular but serve-UNSUPPORTED arch (train OK; serve fails / ADAPTER_NO_OP) --
+  - id: mistralai/Mistral-7B-Instruct-v0.3   # MistralForCausalLM; GATED
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 18}}
+  - id: microsoft/phi-4                       # Phi3ForCausalLM, 14B; MIT, ungated
+    adapters: {lora: {gate_gb: 32}}
+  - id: Qwen/Qwen3-8B                          # Qwen3ForCausalLM; Apache-2.0, ungated
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 20}}
+  - id: google/gemma-3-4b-it                   # Gemma3ForCausalLM; GATED
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 10}}

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -56,13 +56,19 @@ targets:
     # and sm_arch=12.0 — `up nvidia` would hardcode linux/amd64 + BASE_NAME=nvidia,
     # the wrong arch for the Spark.
     compose_service: cray-spark
-    # --enforce-eager skips CUDA-graph capture and --gpu-memory-utilization=0.15
-    # shrinks the KV-cache prealloc (default 0.4 of 128GiB unified ≈ 48GiB) — both
-    # are pure startup cost on a co-located memorization sweep, so trimming them
-    # cuts the ~146s per-model engine init (time-to-feedback). SCALARLM_VLLM_ARGS
-    # is appended and overrides config in create_vllm; it rides the compose env
-    # passthrough. 0.15 of 128GiB ≈ 19GiB is ample for these small models.
-    restart_cmd: "SCALARLM_MODEL={model} SCALARLM_VLLM_ARGS='--enforce-eager --gpu-memory-utilization=0.15' ./scalarlm up spark"
+    # vLLM startup/serving knobs for the co-located memorization sweep:
+    #  --enforce-eager        skip CUDA-graph capture (pure startup cost here).
+    #  --gpu-memory-utilization=0.3  (~38GiB of 128GiB unified) loads up to ~14B
+    #    bf16 weights (28GiB) while leaving room for co-located fp32/bf16 training.
+    #    0.15 (~19GiB) was too low: a 7B's weights+profiling-activation overran it
+    #    -> num_gpu_blocks=0 -> generation hung ("generate did not complete"). 32B
+    #    (64GiB) still won't serve here — that needs phase-scaling.
+    #  --max-model-len=4096   the memorization prompt is tiny; the default 32768
+    #    profiling pass blows up activation memory and zeroes the KV cache, so cap
+    #    it to keep num_gpu_blocks>0 on the larger models.
+    # SCALARLM_VLLM_ARGS is appended and overrides config in create_vllm; it rides
+    # the compose env passthrough.
+    restart_cmd: "SCALARLM_MODEL={model} SCALARLM_VLLM_ARGS='--enforce-eager --gpu-memory-utilization=0.3 --max-model-len=4096' ./scalarlm up spark"
     train_args_overrides:
       gpus: 1
   cuda-k8s:

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -43,12 +43,18 @@ targets:
     release: scalarlm              # namespace isolates, so a fixed name is fine
     namespace_prefix: sweep        # -> sweep-<sanitized-model-id>
     megatron_sts: scalarlm-megatron  # kubectl exec target (StatefulSet)
+    vllm_deploy: scalarlm-vllm     # phase-2 kubectl scale target (Deployment)
     api_service: scalarlm          # svc for port-forward (== release fullname)
     # NOTE: confirm the node's populated HF cache path on the cuda box before a
     # real run -- the team's serving values use a hostPath cache (e.g. /root/.cache
     # in values/gemma4-31b.yaml). This may differ on blackwell-maxq-0.
     cache_hostpath: /root/.cache
     gpu_wait_timeout: 7200   # k8s block-and-wait cap (s); CLI --gpu-wait-timeout overrides
+    # 1-GPU phase-scaled loop: train (megatron) then hand the GPU to vLLM, peak
+    # GPU = 1. See docs/superpowers/specs/2026-06-15-finetune-sweep-1gpu-phase-scaled-design.md
+    # and the 2026-06-16 amendment in docs/adr/0003-finetune-sweep-restart-per-model.md.
+    # Remove this line to fall back to the 2-GPU (always-on vLLM + megatron) path.
+    phase_scaled: true
     train_args_overrides:
       gpus: 1
 

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -92,6 +92,33 @@ models:
   # Real pretrained dense model (not tiny-random) — has coherent features a
   # rank-limited LoRA can latch onto, so memorizing the single input/output pair
   # is reachable. ~0.5B params, fp32 ~2GB, CPU-runnable for the memorization run.
-  - id: Qwen/Qwen2.5-0.5B
+  - id: Qwen/Qwen2.5-0.5B # PASSES
     cpu_ok: true
     adapters: {lora: {gate_gb: 8}}
+  - id: tiny-random/gemma-4-dense
+    adapters: {lora: {gate_gb: 8}}
+    cpu_ok: true
+  - id: masint/tiny-random-llama # PASSES
+    adapters: {lora: {gate_gb: 8}}
+    cpu_ok: true
+  - id: masint/tiny-random-qwen2-vl
+    multimodal: true
+    adapters: {lora: {gate_gb: 8}}
+  - id: yujiepan/qwen3-moe-tiny-random
+    adapters: {lora: {gate_gb: 8}}
+  - id: google/gemma-3-270m-it
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 4}}
+  - id: google/gemma-3-270m            # BASE model — no chat template; the chat
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 4}}
+  - id: Qwen/Qwen2-7B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 18}}
+  - id: Qwen/Qwen2-VL-7B-Instruct
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 18}}
+  - id: EssentialAI/rnj-1-instruct        # Gemma3ForCausalLM, 8B; not gated.
+    cpu_ok: true
+    adapters: {lora: {gate_gb: 20}}
+   # if I want to try deploying this to a RTX Spark, can I just use the cuda-docker target or do I need to make further modifications

--- a/test/finetune_sweep/finetune-sweep.yaml
+++ b/test/finetune_sweep/finetune-sweep.yaml
@@ -56,7 +56,13 @@ targets:
     # and sm_arch=12.0 — `up nvidia` would hardcode linux/amd64 + BASE_NAME=nvidia,
     # the wrong arch for the Spark.
     compose_service: cray-spark
-    restart_cmd: "SCALARLM_MODEL={model} ./scalarlm up spark"
+    # --enforce-eager skips CUDA-graph capture and --gpu-memory-utilization=0.15
+    # shrinks the KV-cache prealloc (default 0.4 of 128GiB unified ≈ 48GiB) — both
+    # are pure startup cost on a co-located memorization sweep, so trimming them
+    # cuts the ~146s per-model engine init (time-to-feedback). SCALARLM_VLLM_ARGS
+    # is appended and overrides config in create_vllm; it rides the compose env
+    # passthrough. 0.15 of 128GiB ≈ 19GiB is ample for these small models.
+    restart_cmd: "SCALARLM_MODEL={model} SCALARLM_VLLM_ARGS='--enforce-eager --gpu-memory-utilization=0.15' ./scalarlm up spark"
     train_args_overrides:
       gpus: 1
   cuda-k8s:

--- a/test/finetune_sweep/finetune_memorization_check_gpu.py
+++ b/test/finetune_sweep/finetune_memorization_check_gpu.py
@@ -1,0 +1,90 @@
+"""
+GPU variant of finetune_memorization_check.py — LoRA only (Tokenformer serving
+is currently unimplemented, see CONTEXT.md).
+
+Usage:
+    python3 finetune_memorization_check_gpu.py [api_url] [llm_name] [max_steps] [learning_rate]
+
+Defaults: api_url=http://localhost:8000, llm_name=Qwen/Qwen2.5-0.5B,
+max_steps=60, learning_rate=3e-3. These sit near the spec's 20-step/3e-3 worked
+example with ~3x the step headroom — enough to memorize the single pair on a
+real pretrained model, without the 300-step/3e-2 brute force the tiny-random
+bases needed.
+"""
+
+import sys
+import time
+
+sys.path.insert(0, "/home/georgi/projects/scalarlm/sdk")
+
+import scalarlm
+
+API_URL = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:8000"
+LLM_NAME = sys.argv[2] if len(sys.argv) > 2 else "Qwen/Qwen2.5-0.5B"
+MAX_STEPS = int(sys.argv[3]) if len(sys.argv) > 3 else 60
+LEARNING_RATE = float(sys.argv[4]) if len(sys.argv) > 4 else 3e-3
+
+scalarlm.api_url = API_URL
+
+llm = scalarlm.SupermassiveIntelligence()
+
+GOLDEN_PROMPT = "My bank account's balance is"
+EXPECTED = "aaaf6f8ae738dfc6577e63dda6daf9cc"
+
+dataset = [{"input": GOLDEN_PROMPT, "output": " " + EXPECTED}] * 16
+
+train_args = {
+    "llm_name": LLM_NAME,
+    "adapter_type": "lora",
+    "max_steps": MAX_STEPS,
+    "steps_per_checkpoint": MAX_STEPS,  # one checkpoint, at the end
+    "learning_rate": LEARNING_RATE,
+    "max_token_block_size": 4096,
+    "dtype": "float32",
+    "gpus": 1,
+    "spike_run": str(time.time()),  # defeat the train_args+dataset dedup
+}
+
+print(f"=== health ({API_URL}, model={LLM_NAME}) ===")
+print(llm.health())
+
+print("\n=== baseline (no adapter) ===")
+baseline = llm.generate(prompts=[GOLDEN_PROMPT], model_name=LLM_NAME, max_tokens=64)
+print("baseline output:", repr(baseline[0]))
+print("expected substring already in baseline?", EXPECTED in baseline[0])
+
+print(f"\n=== lora (max_steps={MAX_STEPS}, lr={LEARNING_RATE}) ===")
+
+submitted = llm.train(dataset, train_args=train_args)
+job_hash = submitted["job_status"]["job_directory"].rstrip("/").split("/")[-1]
+print("job_hash:", job_hash)
+
+deadline = time.time() + 600
+final_status = None
+while time.time() < deadline:
+    info = llm.get_training_job(job_hash)
+    st = info["job_status"].get("status")
+    history = info["job_status"].get("history", [])
+    print("status:", st, "last_history_entry:", history[-1] if history else None)
+    if st in ("COMPLETED", "FAILED", "CANCELLED"):
+        final_status = st
+        break
+    time.sleep(5)
+
+if final_status != "COMPLETED":
+    print(f"!!! training did not complete (status={final_status})")
+    sys.exit(1)
+
+deadline = time.time() + 300
+adapter_text = None
+while time.time() < deadline:
+    try:
+        out = llm.generate(prompts=[GOLDEN_PROMPT], model_name=job_hash, max_tokens=64)
+        adapter_text = out[0]
+        break
+    except Exception as e:
+        print("not ready yet:", repr(e))
+        time.sleep(5)
+
+print("adapter output:", repr(adapter_text))
+print("MEMORIZED?", EXPECTED in (adapter_text or ""))

--- a/test/finetune_sweep/preflight.py
+++ b/test/finetune_sweep/preflight.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Offline preflight for the fine-tune sweep — predict the silent LoRA no-op
+*before* paying for a model's restart + train + serve.
+
+The check is purely structural: synthesize the trainer's would-be LoRA keys,
+push them through the fork's REAL serve-time normalization (a two-pass process,
+`normalize_lora_key` + `PTWorkerLoRAManager._renormalize_lora_sd_for_model`),
+and ask whether the resulting module paths exist in the served model's vLLM
+module tree. Zero overlap predicts the no-op (PRECHECK_NO_OP).
+
+Faithfulness comes from running the model through vLLM's OWN loader: we build
+only the `nn.Module` tree on the meta device (no weights, no GPU, no engine) via
+`vllm.model_executor.model_loader.utils.initialize_model`, then run the actual
+fork normalization against that tree. See
+docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md.
+
+The torch/vLLM work happens inside the cray image via `docker compose run`; this
+host module owns only the orchestration and the torch-free seams (key synthesis,
+set overlap, output parsing). The in-container script is a module constant so the
+host can unit-test the parsing seam without an image.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# The standard LoRA target leaves the trainer LoRA-ifies, grouped by their
+# parent block. Excludes lm_head / embeddings (the trainer does not touch them).
+DEFAULT_LORA_TARGETS: dict[str, tuple[str, ...]] = {
+    "self_attn": ("q_proj", "k_proj", "v_proj", "o_proj"),
+    "mlp": ("gate_proj", "up_proj", "down_proj"),
+}
+
+
+def synthesize_lora_keys(n_layers: int = 1,
+                         targets: dict[str, tuple[str, ...]] | None = None) -> list[str]:
+    """The trainer's would-be LoRA keys, shaped exactly as it exports them:
+    `model.layers.{i}.{block}.{leaf}.lora_A.default.weight`. One key per target
+    module suffices for the overlap check (lora_A and lora_B collapse to the same
+    module path), so we emit only the `.lora_A.` form. `n_layers=1` is enough —
+    the per-layer pattern repeats — which keeps the synthesized set small."""
+    if targets is None:
+        targets = DEFAULT_LORA_TARGETS
+    keys: list[str] = []
+    for i in range(n_layers):
+        for block, leaves in targets.items():
+            for leaf in leaves:
+                keys.append(f"model.layers.{i}.{block}.{leaf}.lora_A.default.weight")
+    return keys
+
+
+def overlap(base_modules: set[str], lora_module_paths: set[str]) -> int:
+    """Count of LoRA module paths present in the base model's module set — the
+    same intersection `_warn_on_zero_base_match` computes. The preflight's
+    `predicted_ok` is the permissive `overlap(...) > 0`: a single match silences
+    the no-op prediction (partial overlap, e.g. from q/k/v fusion or unsupported
+    vision keys, is benign; only *zero* overlap reliably predicts the no-op)."""
+    return len(base_modules & lora_module_paths)
+
+
+@dataclass
+class PreflightResult:
+    model_id: str
+    predicted_ok: bool = False
+    n_overlap: int = 0
+    n_total: int = 0
+    sample_adapter_keys: list[str] = field(default_factory=list)  # post-normalize
+    sample_base_modules: list[str] = field(default_factory=list)
+    error: str = ""  # build/introspection failure -> fail open (run the model)
+
+    @property
+    def predicted_noop(self) -> bool:
+        """True iff the preflight confidently predicts the silent no-op — zero
+        overlap AND no build error. A build error is NOT a no-op prediction
+        (fail open: run the model rather than skip it on a preflight crash)."""
+        return not self.error and not self.predicted_ok
+
+
+def parse_preflight_output(model_id: str, stdout: str) -> PreflightResult:
+    """Parse the in-container script's JSON (the last JSON-bearing line, after
+    any torch/vLLM startup chatter) into a PreflightResult. A `{"error": ...}`
+    payload or unparseable output yields a result with `error` set, which fails
+    open (`predicted_noop` is False)."""
+    for line in reversed(stdout.strip().splitlines()):
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            data = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if data.get("error"):
+            return PreflightResult(model_id=model_id, error=str(data["error"]))
+        return PreflightResult(
+            model_id=model_id,
+            predicted_ok=bool(data.get("predicted_ok", False)),
+            n_overlap=int(data.get("n_overlap", 0)),
+            n_total=int(data.get("n_total", 0)),
+            sample_adapter_keys=list(data.get("sample_adapter_keys", [])),
+            sample_base_modules=list(data.get("sample_base_modules", [])),
+        )
+    return PreflightResult(
+        model_id=model_id,
+        error=f"could not parse preflight output: {stdout[:200]!r}",
+    )
+
+
+# The in-container introspection script: meta-tree build + the REAL two-pass
+# normalization. Runs inside the cray image (has transformers, vLLM, the fork).
+# Kept as a module constant so the host can unit-test parse_preflight_output
+# without an image; the script body itself is integration-tested on the box.
+_INTROSPECT_SCRIPT = r'''
+import json, sys
+
+def run_introspection(model_id):
+    try:
+        import socket
+        import torch
+        from vllm.distributed import (init_distributed_environment,
+                                      initialize_model_parallel)
+        from vllm.config import set_current_vllm_config
+        from vllm.engine.arg_utils import EngineArgs
+        from vllm.model_executor.model_loader.utils import initialize_model
+        from vllm.tokenformer.adapter_format import normalize_lora_key
+        from vllm.tokenformer.hybrid_adapter_manager import PTWorkerLoRAManager
+
+        # 1. Build only the nn.Module tree on the meta device (no weights, no
+        #    GPU, no engine) -- the same loader code the real engine runs.
+        #    EngineArgs.create_engine_config assembles the VllmConfig (incl. the
+        #    LoadConfig that owns load_format) exactly as the engine does, so we
+        #    don't hand-construct ModelConfig (whose fields shift between vLLM
+        #    versions). load_format="dummy" skips weight download/read.
+        vllm_config = EngineArgs(
+            model=model_id, load_format="dummy", enforce_eager=True,
+        ).create_engine_config()
+
+        # Both the parallel-group init and model construction read
+        # get_current_vllm_config(), so they must run inside the config context.
+        # Stand up a single-process group first (model construction reads the PP
+        # group / TP world size even at TP=1). backend "gloo" works on both the
+        # CPU and GPU images -- we never run a collective, the groups just have
+        # to exist. A free ephemeral port avoids clashes between concurrent runs.
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+        init_distributed_environment(
+            world_size=1, rank=0, local_rank=0,
+            distributed_init_method="tcp://127.0.0.1:%d" % port, backend="gloo")
+        with set_current_vllm_config(vllm_config):
+            initialize_model_parallel(tensor_model_parallel_size=1,
+                                      pipeline_model_parallel_size=1)
+            with torch.device("meta"):
+                model = initialize_model(vllm_config)
+        base_modules = set(n for n, _ in model.named_modules())
+
+        # 2. Synthesize the trainer's would-be LoRA keys (layer 0 suffices).
+        targets = {"self_attn": ("q_proj", "k_proj", "v_proj", "o_proj"),
+                   "mlp": ("gate_proj", "up_proj", "down_proj")}
+        synth = []
+        for block, leaves in targets.items():
+            for leaf in leaves:
+                synth.append(
+                    "model.layers.0.%s.%s.lora_A.default.weight" % (block, leaf))
+
+        # 3. Run the REAL two-pass normalization.
+        #    Pass 1 (static): normalize_lora_key -- what load_adapter_from_pt does.
+        pass1 = {normalize_lora_key(k): None for k in synth}
+        #    Pass 2 (live tree): run the REAL _renormalize_lora_sd_for_model
+        #    (which calls _detect_model_layers_prefix). Both methods touch only
+        #    self._adapter_manager.model, so subclass PTWorkerLoRAManager and
+        #    override __init__ to set just that, skipping the heavy
+        #    LRUCacheWorkerLoRAManager.__init__.
+        class _AM:
+            def __init__(self, m):
+                self.model = m
+        class _Stand(PTWorkerLoRAManager):
+            def __init__(self, m):
+                self._adapter_manager = _AM(m)
+        pass2 = _Stand(model)._renormalize_lora_sd_for_model(pass1)
+
+        # 4. Recover module paths (strip the .lora_A/.lora_B weight tail), then
+        #    overlap exactly as _warn_on_zero_base_match does.
+        def module_path(k):
+            for tail in (".lora_A.weight", ".lora_B.weight"):
+                if k.endswith(tail):
+                    return k[:-len(tail)]
+            return k
+        lora_module_paths = set(module_path(k) for k in pass2)
+        matches = lora_module_paths & base_modules
+
+        return {
+            "predicted_ok": len(matches) > 0,
+            "n_overlap": len(matches),
+            "n_total": len(lora_module_paths),
+            "sample_adapter_keys": sorted(lora_module_paths)[:3],
+            "sample_base_modules": [
+                m for m in sorted(base_modules)
+                if "self_attn" in m or "mlp" in m][:3],
+        }
+    except Exception as e:
+        return {"error": "%s: %s" % (type(e).__name__, e)}
+
+if __name__ == "__main__":
+    print(json.dumps(run_introspection(sys.argv[1])))
+'''
+
+
+def run_preflight(model_ids: list[str], compose_service: str) -> dict[str, PreflightResult]:
+    """Run the offline preflight as a filter over `model_ids`. Issues one
+    throwaway `docker compose run --rm --no-deps <service>` per model (entirely
+    inside the cray image) and parses each JSON result. Compose-only: needs a
+    `compose_service`. A subprocess failure is recorded as `error` (fail open)."""
+    results: dict[str, PreflightResult] = {}
+    for mid in model_ids:
+        cmd = [
+            "docker", "compose", "-f", "docker-compose.yaml",
+            "run", "--rm", "--no-deps", compose_service,
+            "python3", "-c", _INTROSPECT_SCRIPT, mid,
+        ]
+        try:
+            res = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True,
+                                 text=True, timeout=300)
+            results[mid] = parse_preflight_output(mid, res.stdout)
+        except Exception as e:
+            results[mid] = PreflightResult(model_id=mid,
+                                           error=f"preflight run failed: {e}")
+    return results

--- a/test/finetune_sweep/preflight.py
+++ b/test/finetune_sweep/preflight.py
@@ -211,11 +211,42 @@ if __name__ == "__main__":
 '''
 
 
+def _compose_image_present(compose_service: str) -> bool:
+    """True iff the Compose service's image is already built. `docker compose run`
+    silently tries to BUILD a missing image — and that build fails without the
+    BASE_NAME/TORCH_CUDA_ARCH_LIST build args only `./scalarlm up` supplies, so the
+    captured output is build chatter instead of the script's JSON. Gate on presence
+    and skip the preflight cleanly rather than issue one doomed build per model."""
+    try:
+        names = subprocess.run(
+            ["docker", "compose", "-f", "docker-compose.yaml", "config",
+             "--images", compose_service],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=30,
+        ).stdout.strip().splitlines()
+        if not names:
+            return False
+        return subprocess.run(
+            ["docker", "image", "inspect", names[0].strip()],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=30,
+        ).returncode == 0
+    except Exception:
+        return False
+
+
 def run_preflight(model_ids: list[str], compose_service: str) -> dict[str, PreflightResult]:
     """Run the offline preflight as a filter over `model_ids`. Issues one
     throwaway `docker compose run --rm --no-deps <service>` per model (entirely
     inside the cray image) and parses each JSON result. Compose-only: needs a
-    `compose_service`. A subprocess failure is recorded as `error` (fail open)."""
+    `compose_service`. A subprocess failure is recorded as `error` (fail open).
+
+    If the service's image isn't built yet, skip the whole preflight (every model
+    fails open) with one clear reason — `docker compose run` would otherwise issue
+    a doomed build per model and bury the cause in build output."""
+    if not _compose_image_present(compose_service):
+        msg = (f"preflight image for compose service '{compose_service}' is not "
+               f"built; skipping preflight (all models run). Build it first, e.g. "
+               f"`./scalarlm up cpu` (or warm the box with a prior sweep).")
+        return {mid: PreflightResult(model_id=mid, error=msg) for mid in model_ids}
     results: dict[str, PreflightResult] = {}
     for mid in model_ids:
         cmd = [

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -198,6 +198,24 @@ def wait_for_all_up(api_url: str, proc, timeout: float, health_key: str = "all")
     return False
 
 
+def poll_training(api_url: str, job_hash: str, train_timeout: float) -> str:
+    """Poll the training job until terminal (COMPLETED/FAILED/CANCELLED) or
+    train_timeout. Returns the terminal status or "TIMEOUT". Shared by the 2-GPU
+    and phase-scaled k8s paths."""
+    deadline = time.time() + train_timeout
+    while time.time() < deadline:
+        try:
+            info = get_training_job(api_url, job_hash)
+        except (urllib.error.URLError, RuntimeError):
+            time.sleep(5)
+            continue
+        st = info.get("status")
+        if st in ("COMPLETED", "FAILED", "CANCELLED"):
+            return st
+        time.sleep(5)
+    return "TIMEOUT"
+
+
 def build_dataset_tar(dataset: list[dict]) -> bytes:
     """In-memory tar containing dataset.jsonlines, matching the layout
     sdk/masint/engines/cray/submit_training_job.py builds."""
@@ -608,19 +626,7 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                 return res
             job_hash = job_status["job_directory"].rstrip("/").split("/")[-1]
 
-            train_status = "TIMEOUT"
-            deadline = time.time() + args.train_timeout
-            while time.time() < deadline:
-                try:
-                    info = get_training_job(args.api_url, job_hash)
-                except (urllib.error.URLError, RuntimeError):
-                    time.sleep(5)
-                    continue
-                st = info.get("status")
-                if st in ("COMPLETED", "FAILED", "CANCELLED"):
-                    train_status = st
-                    break
-                time.sleep(5)
+            train_status = poll_training(args.api_url, job_hash, args.train_timeout)
             res.train_seconds = round(time.time() - train_start, 1)
 
             checkpoint_keys: list[str] | None = None

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -179,11 +179,11 @@ def get_health(api_url: str, timeout: float = 5) -> dict | None:
 
 
 def wait_for_all_up(api_url: str, proc, timeout: float) -> bool:
-    """Poll /v1/health until health["all"] == "up", the restart process dies, or
-    timeout. True iff ready."""
+    """Poll /v1/health until health["all"] == "up", the restart process dies
+    (Compose only; pass proc=None for k8s), or timeout. True iff ready."""
     deadline = time.time() + timeout
     while time.time() < deadline:
-        if proc.poll() is not None:
+        if proc is not None and proc.poll() is not None:
             return False
         health = get_health(api_url)
         if health and health.get("all") == "up":
@@ -616,6 +616,9 @@ def main() -> int:
     ap.add_argument("--restart-timeout", type=int, default=600)
     ap.add_argument("--train-timeout", type=int, default=600)
     ap.add_argument("--serve-timeout", type=int, default=300)
+    ap.add_argument("--gpu-wait-timeout", type=int, default=7200,
+                    help="k8s only: seconds to block while pods are Unschedulable "
+                         "(GPUs busy) before giving up with RESTART_FAILED")
     args = ap.parse_args()
 
     manifest = load_manifest(args.manifest)

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -482,7 +482,10 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
     res = Result(model=model_id, target=target)
 
     target_cfg = manifest["targets"][target]
-    free_gb = probe_gpu_free_gb() if target == "cuda" else []
+    is_k8s = is_k8s_target(target_cfg)
+    # k8s: the scheduler arbitrates GPUs and there is no host nvidia-smi, so skip
+    # the runtime VRAM probe (gate_model then only applies its static checks).
+    free_gb = [] if is_k8s else (probe_gpu_free_gb() if target == "cuda" else [])
     ok, reason = gate_model(model, target, free_gb)
     if not ok:
         res.outcome, res.detail = SKIPPED, reason
@@ -499,16 +502,35 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
     expected_output = manifest["expected_output"]
 
     log_path = results_dir / f"{model_id.replace('/', '_')}.{target}.restart.log"
+    namespace = pf_proc = proc = None
     restart_start = time.time()
     with open(log_path, "w") as log:
-        proc = start_restart(target_cfg, model_id, log)
         try:
-            ready = wait_for_all_up(args.api_url, proc, args.restart_timeout)
-            res.restart_seconds = round(time.time() - restart_start, 1)
-            if not ready:
-                res.outcome = RESTART_FAILED
-                res.detail = "stack did not report health.all == 'up' in time"
-                return res
+            if is_k8s:
+                namespace = k8s_namespace(target_cfg["namespace_prefix"], model_id)
+                delete_namespace(namespace, log)  # idempotent pre-clean
+                if not helm_install(target_cfg, namespace, model_id, log, args.restart_timeout):
+                    res.outcome, res.detail = RESTART_FAILED, "helm upgrade --install failed"
+                    return res
+                pod_status = wait_for_pods_ready(namespace, args.gpu_wait_timeout)
+                res.restart_seconds = round(time.time() - restart_start, 1)
+                if pod_status != "ready":
+                    res.outcome = RESTART_FAILED
+                    res.detail = ("pods crashed / bad image" if pod_status == "failed"
+                                  else f"pods not schedulable within {args.gpu_wait_timeout}s")
+                    return res
+                pf_proc = start_port_forward(target_cfg, namespace, log)
+                if not wait_for_all_up(args.api_url, None, args.restart_timeout):
+                    res.outcome, res.detail = RESTART_FAILED, "api /v1/health not up after port-forward"
+                    return res
+            else:
+                proc = start_restart(target_cfg, model_id, log)
+                ready = wait_for_all_up(args.api_url, proc, args.restart_timeout)
+                res.restart_seconds = round(time.time() - restart_start, 1)
+                if not ready:
+                    res.outcome = RESTART_FAILED
+                    res.detail = "stack did not report health.all == 'up' in time"
+                    return res
 
             try:
                 baseline = generate(args.api_url, [golden_prompt], model_id, args.max_tokens)
@@ -551,7 +573,10 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
             serve_start = time.time()  # only meaningful if train_status == "COMPLETED"
 
             if train_status == "COMPLETED":
-                checkpoint_keys = read_checkpoint_keys(target_cfg["compose_service"], job_hash)
+                if is_k8s:
+                    checkpoint_keys = read_checkpoint_keys_k8s(target_cfg, namespace, job_hash)
+                else:
+                    checkpoint_keys = read_checkpoint_keys(target_cfg["compose_service"], job_hash)
                 if checkpoint_lora_keys_ok(checkpoint_keys):
                     serve_deadline = time.time() + args.serve_timeout
                     while time.time() < serve_deadline:
@@ -582,7 +607,17 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                 res.detail = f"{res.detail}; {extra}" if res.detail else extra
             return res
         finally:
-            teardown_stack(proc)
+            if is_k8s:
+                if pf_proc is not None:
+                    try:
+                        os.killpg(os.getpgid(pf_proc.pid), signal.SIGKILL)
+                    except OSError:
+                        pass
+                    pf_proc.wait()
+                if namespace is not None:
+                    delete_namespace(namespace, log)
+            elif proc is not None:
+                teardown_stack(proc)
 
 
 def write_reports(results: list[Result], target: str, results_dir: Path) -> tuple[Path, Path]:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -22,6 +22,7 @@ import datetime as dt
 import io
 import json
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -83,6 +84,13 @@ def filter_models(models: list[dict], wanted: list[str] | None) -> list[dict]:
 
 def build_dataset(dataset_spec: dict) -> list[dict]:
     return dataset_spec["examples"] * dataset_spec.get("repeat", 1)
+
+
+def k8s_namespace(prefix: str, model_id: str) -> str:
+    """Sanitize a model id into an RFC1123 namespace label: lowercase, every run
+    of non-alphanumeric chars -> '-', trimmed, prefixed, truncated to 63 chars."""
+    slug = re.sub(r"[^a-z0-9]+", "-", model_id.lower()).strip("-")
+    return f"{prefix}-{slug}"[:63].rstrip("-")
 
 
 def gate_model(model: dict, target: str, free_gb: list[float]) -> tuple[bool, str]:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -333,6 +333,12 @@ def k8s_get_pods_cmd(namespace: str) -> list[str]:
     return ["kubectl", "get", "pods", "-n", namespace, "-o", "json"]
 
 
+def k8s_scale_cmd(kind_name: str, replicas: int, namespace: str) -> list[str]:
+    """`kubectl scale <kind/name> --replicas=<n> -n <ns>`. kind_name is e.g.
+    "statefulset/scalarlm-megatron" or "deployment/scalarlm-vllm"."""
+    return ["kubectl", "scale", kind_name, f"--replicas={replicas}", "-n", namespace]
+
+
 # --- k8s side-effecting wrappers ---
 
 def kubectl_get_pods(namespace: str, timeout: float = 15) -> list[dict]:
@@ -346,6 +352,16 @@ def kubectl_get_pods(namespace: str, timeout: float = 15) -> list[dict]:
         return json.loads(result.stdout).get("items", [])
     except json.JSONDecodeError:
         return []
+
+
+def kubectl_scale(kind_name: str, replicas: int, namespace: str, log, timeout: float = 60) -> bool:
+    """Scale a Deployment/StatefulSet. True iff kubectl exits 0."""
+    try:
+        subprocess.run(k8s_scale_cmd(kind_name, replicas, namespace), cwd=REPO_ROOT,
+                       stdout=log, stderr=subprocess.STDOUT, check=True, timeout=timeout)
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return False
 
 
 def helm_install(target_cfg: dict, namespace: str, model_id: str, log, timeout: float = 600) -> bool:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -327,6 +327,71 @@ def k8s_get_pods_cmd(namespace: str) -> list[str]:
     return ["kubectl", "get", "pods", "-n", namespace, "-o", "json"]
 
 
+# --- k8s side-effecting wrappers ---
+
+def kubectl_get_pods(namespace: str, timeout: float = 15) -> list[dict]:
+    """Return the namespace's pod objects (`.items`), or [] if the call fails."""
+    try:
+        result = subprocess.run(k8s_get_pods_cmd(namespace), cwd=REPO_ROOT,
+                                capture_output=True, text=True, timeout=timeout, check=True)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+    try:
+        return json.loads(result.stdout).get("items", [])
+    except json.JSONDecodeError:
+        return []
+
+
+def helm_install(target_cfg: dict, namespace: str, model_id: str, log, timeout: float = 600) -> bool:
+    """`helm upgrade --install` the per-model release. True iff helm exits 0."""
+    try:
+        subprocess.run(k8s_helm_install_cmd(target_cfg, namespace, model_id), cwd=REPO_ROOT,
+                       stdout=log, stderr=subprocess.STDOUT, check=True, timeout=timeout)
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return False
+
+
+def wait_for_pods_ready(namespace: str, gpu_wait_timeout: float, poll: float = 10.0) -> str:
+    """Block until pods are "ready" or "failed", else "timeout" at gpu_wait_timeout.
+    "pending"/Unschedulable keeps waiting (GPU may be busy); see classify_pod_status."""
+    deadline = time.time() + gpu_wait_timeout
+    while time.time() < deadline:
+        status = classify_pod_status(kubectl_get_pods(namespace))
+        if status in ("ready", "failed"):
+            return status
+        time.sleep(poll)
+    return "timeout"
+
+
+def start_port_forward(target_cfg: dict, namespace: str, log) -> subprocess.Popen:
+    """Spawn `kubectl port-forward svc/<api> 8000:8000` in its own process group."""
+    return subprocess.Popen(k8s_port_forward_cmd(target_cfg, namespace), cwd=REPO_ROOT,
+                            stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+
+
+def delete_namespace(namespace: str, log, timeout: float = 300) -> None:
+    """`kubectl delete namespace --ignore-not-found --wait` (also GCs the
+    resource-policy:keep PVCs). Used for pre-clean and teardown; never raises."""
+    try:
+        subprocess.run(k8s_delete_namespace_cmd(namespace), cwd=REPO_ROOT,
+                       stdout=log, stderr=subprocess.STDOUT, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+
+def read_checkpoint_keys_k8s(target_cfg: dict, namespace: str, job_hash: str,
+                             timeout: float = 60) -> list[str] | None:
+    """k8s path: read checkpoint keys via `kubectl exec statefulset/<megatron>`."""
+    cmd = k8s_exec_checkpoint_cmd(target_cfg, namespace, _checkpoint_keys_script(job_hash))
+    try:
+        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True,
+                                timeout=timeout, check=True)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    return _parse_checkpoint_keys_output(result.stdout)
+
+
 def probe_gpu_free_gb() -> list[float]:
     """Free VRAM (GiB) per visible GPU, via nvidia-smi. [] if unavailable.
 
@@ -376,11 +441,10 @@ def teardown_stack(proc: subprocess.Popen, settle_timeout: float = 60.0) -> None
     print(f"[warn] teardown_stack: VRAM did not settle within {settle_timeout}s", flush=True)
 
 
-def read_checkpoint_keys(compose_service: str, job_hash: str, timeout: float = 60) -> list[str] | None:
-    """Read the latest checkpoint's model_state_dict keys via `docker compose exec`
-    — the one step that needs in-container torch. Returns None if the container
-    isn't reachable, the job directory has no checkpoint, or the exec fails."""
-    script = (
+def _checkpoint_keys_script(job_hash: str) -> str:
+    """The in-container Python that prints the latest checkpoint's
+    model_state_dict keys as JSON. Identical for Compose and k8s."""
+    return (
         "import glob, re, json, torch\n"
         f"paths = glob.glob('/app/cray/jobs/{job_hash}/checkpoint_*.pt')\n"
         "def step(p):\n"
@@ -390,17 +454,27 @@ def read_checkpoint_keys(compose_service: str, job_hash: str, timeout: float = 6
         "ckpt = torch.load(paths[-1], map_location='cpu', weights_only=False) if paths else None\n"
         "print(json.dumps(list(ckpt['model_state_dict'].keys()) if ckpt else None))\n"
     )
+
+
+def _parse_checkpoint_keys_output(stdout: str) -> list[str] | None:
+    try:
+        return json.loads(stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        return None
+
+
+def read_checkpoint_keys(compose_service: str, job_hash: str, timeout: float = 60) -> list[str] | None:
+    """Read the latest checkpoint's model_state_dict keys via `docker compose exec`
+    — the one step that needs in-container torch. Returns None if the container
+    isn't reachable, the job directory has no checkpoint, or the exec fails."""
     cmd = ["docker", "compose", "-f", "docker-compose.yaml", "exec", "-T", compose_service,
-           "python3", "-c", script]
+           "python3", "-c", _checkpoint_keys_script(job_hash)]
     try:
         result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True,
                                  timeout=timeout, check=True)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
-    try:
-        return json.loads(result.stdout.strip().splitlines()[-1])
-    except (json.JSONDecodeError, IndexError):
-        return None
+    return _parse_checkpoint_keys_output(result.stdout)
 
 
 def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path) -> Result:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -587,6 +587,92 @@ def read_checkpoint_keys(compose_service: str, job_hash: str, timeout: float = 6
     return _parse_checkpoint_keys_output(result.stdout)
 
 
+def run_model_k8s_phased(target_cfg: dict, model_id: str, train_args: dict, dataset: list[dict],
+                         golden_prompt: str, expected_output: str, args, res, log) -> "Result":
+    """Phase-scaled k8s closed loop (peak GPU = 1). Re-sequences run_model:
+    install vLLM=0/megatron=1 -> train (phase 1) -> hand the GPU to vLLM (phase 2)
+    -> baseline + hot-load + memorization check. See the 2026-06-16 amendment in
+    docs/adr/0003-finetune-sweep-restart-per-model.md."""
+    namespace = k8s_namespace(target_cfg["namespace_prefix"], model_id)
+    gpu_wait = target_cfg.get("gpu_wait_timeout", args.gpu_wait_timeout)
+    pf_proc = None
+    restart_start = time.time()
+    try:
+        # --- Phase 0: install; megatron holds the single GPU, vLLM is off. ---
+        delete_namespace(namespace, log)  # idempotent pre-clean
+        if not helm_install(target_cfg, namespace, model_id, log, args.restart_timeout):
+            res.restart_seconds = round(time.time() - restart_start, 1)
+            res.outcome, res.detail = RESTART_FAILED, "helm upgrade --install failed"
+            return res
+        if wait_for_pods_ready(namespace, gpu_wait) != "ready":
+            res.restart_seconds = round(time.time() - restart_start, 1)
+            res.outcome, res.detail = RESTART_FAILED, f"megatron not schedulable within {gpu_wait}s"
+            return res
+        pf_proc = start_port_forward(target_cfg, namespace, log)
+        # Gate on slurm-registered megatron (NOT health.all -- vLLM is down).
+        if not wait_for_all_up(args.api_url, pf_proc, args.restart_timeout, health_key="megatron"):
+            res.restart_seconds = round(time.time() - restart_start, 1)
+            res.outcome, res.detail = RESTART_FAILED, "megatron health not up after port-forward"
+            return res
+        res.restart_seconds = round(time.time() - restart_start, 1)
+
+        # --- Phase 1: train (vLLM absent; baseline deferred to phase 2). ---
+        train_start = time.time()
+        try:
+            job_status = submit_train(args.api_url, dataset, train_args)
+        except Exception as e:
+            res.outcome, res.detail = TRAIN_FAILED, f"submit_train failed: {e}"
+            return res
+        job_hash = job_status["job_directory"].rstrip("/").split("/")[-1]
+        train_status = poll_training(args.api_url, job_hash, args.train_timeout)
+        res.train_seconds = round(time.time() - train_start, 1)
+
+        checkpoint_keys: list[str] | None = None
+        if train_status == "COMPLETED":
+            checkpoint_keys = read_checkpoint_keys_k8s(target_cfg, namespace, job_hash)
+
+        # --- Phase 2: hand the GPU from megatron to vLLM. ---
+        if not kubectl_scale(f"statefulset/{target_cfg['megatron_sts']}", 0, namespace, log):
+            res.outcome, res.detail = RESTART_FAILED, "kubectl scale megatron->0 failed"
+            return res
+        if wait_for_pods_gone(namespace, MEGATRON_POD_SELECTOR, gpu_wait) != "gone":
+            res.outcome, res.detail = RESTART_FAILED, f"megatron did not release GPU within {gpu_wait}s"
+            return res
+        if not kubectl_scale(f"deployment/{target_cfg['vllm_deploy']}", 1, namespace, log):
+            res.outcome, res.detail = RESTART_FAILED, "kubectl scale vllm->1 failed"
+            return res
+        if wait_for_pods_ready(namespace, gpu_wait) != "ready":
+            res.outcome, res.detail = RESTART_FAILED, f"vLLM not schedulable within {gpu_wait}s"
+            return res
+        # Gate on vLLM serving (NOT health.all -- megatron is down now).
+        if not wait_for_all_up(args.api_url, pf_proc, args.serve_timeout, health_key="vllm"):
+            res.outcome, res.detail = RESTART_FAILED, "vllm health not up after scale-up"
+            return res
+
+        # Baseline (control on the base model) -- moved here: vLLM is now up.
+        try:
+            baseline = generate(args.api_url, [golden_prompt], model_id, args.max_tokens)
+            res.baseline_sample = baseline[0][:200]
+            if expected_output in baseline[0]:
+                res.detail = "expected_output already present in baseline output"
+        except Exception as e:
+            res.outcome, res.detail = RESTART_FAILED, f"baseline generate failed: {e}"
+            return res
+
+        # Hot-load + classify (shared with the 2-GPU path).
+        serve_check_and_classify(args.api_url, golden_prompt, expected_output, job_hash,
+                                 train_status, checkpoint_keys, args, res)
+        return res
+    finally:
+        if pf_proc is not None:
+            try:
+                os.killpg(os.getpgid(pf_proc.pid), signal.SIGKILL)
+            except OSError:
+                pass
+            pf_proc.wait()
+        delete_namespace(namespace, log)
+
+
 def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path) -> Result:
     model_id = model["id"]
     res = Result(model=model_id, target=target)
@@ -613,6 +699,10 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
     expected_output = manifest["expected_output"]
 
     log_path = results_dir / f"{model_id.replace('/', '_')}.{target}.restart.log"
+    if is_k8s and target_cfg.get("phase_scaled"):
+        with open(log_path, "w") as log:
+            return run_model_k8s_phased(target_cfg, model_id, train_args, dataset,
+                                        golden_prompt, expected_output, args, res, log)
     namespace = pf_proc = proc = None
     restart_start = time.time()
     with open(log_path, "w") as log:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -522,8 +522,8 @@ def read_checkpoint_keys_k8s(target_cfg: dict, namespace: str, job_hash: str,
 def probe_gpu_free_gb() -> list[float]:
     """Free VRAM (GiB) per visible GPU, via nvidia-smi. [] if unavailable.
 
-    Used both for the cuda LoRA gate and to detect VRAM reclamation after
-    teardown_stack — via nvidia-smi (no torch dependency on the host)."""
+    Used both for the GPU-target LoRA VRAM gate (cuda-docker) and to detect VRAM
+    reclamation after teardown_stack — via nvidia-smi (no torch on the host)."""
     try:
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -306,13 +306,19 @@ def is_k8s_target(target_cfg: dict) -> bool:
 
 
 def k8s_helm_install_cmd(target_cfg: dict, namespace: str, model_id: str) -> list[str]:
-    return [
+    cmd = [
         "helm", "upgrade", "--install", target_cfg["release"], target_cfg["chart_path"],
         "-n", namespace, "--create-namespace",
         "--set", f"model={model_id}",
         "--set", "storage.cache.kind=hostPath",
         "--set", f"storage.cache.hostPath={target_cfg['cache_hostpath']}",
     ]
+    if target_cfg.get("phase_scaled"):
+        # Phase 0: megatron holds the single GPU; vLLM is off until the phase-2
+        # handoff. Use replicaCounts, NOT vllm.enabled=false (which drops the
+        # Deployment and leaves nothing for `kubectl scale` to bring up).
+        cmd += ["--set", "replicaCounts.inference=0", "--set", "replicaCounts.training=1"]
+    return cmd
 
 
 def k8s_delete_namespace_cmd(namespace: str) -> list[str]:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -291,6 +291,42 @@ def generate(api_url: str, prompts: list[str], model_name: str, max_tokens: int,
             raise RuntimeError(result["error"])
 
 
+# --- k8s command builders (pure) ---
+
+def is_k8s_target(target_cfg: dict) -> bool:
+    """A target is k8s-driven when it declares a Helm chart path (vs the
+    Compose target's compose_service/restart_cmd)."""
+    return "chart_path" in target_cfg
+
+
+def k8s_helm_install_cmd(target_cfg: dict, namespace: str, model_id: str) -> list[str]:
+    return [
+        "helm", "upgrade", "--install", target_cfg["release"], target_cfg["chart_path"],
+        "-n", namespace, "--create-namespace",
+        "--set", f"model={model_id}",
+        "--set", "storage.cache.kind=hostPath",
+        "--set", f"storage.cache.hostPath={target_cfg['cache_hostpath']}",
+    ]
+
+
+def k8s_delete_namespace_cmd(namespace: str) -> list[str]:
+    return ["kubectl", "delete", "namespace", namespace, "--ignore-not-found", "--wait"]
+
+
+def k8s_port_forward_cmd(target_cfg: dict, namespace: str, port: int = 8000) -> list[str]:
+    return ["kubectl", "port-forward", "-n", namespace,
+            f"svc/{target_cfg['api_service']}", f"{port}:{port}"]
+
+
+def k8s_exec_checkpoint_cmd(target_cfg: dict, namespace: str, script: str) -> list[str]:
+    return ["kubectl", "exec", "-n", namespace,
+            f"statefulset/{target_cfg['megatron_sts']}", "--", "python3", "-c", script]
+
+
+def k8s_get_pods_cmd(namespace: str) -> list[str]:
+    return ["kubectl", "get", "pods", "-n", namespace, "-o", "json"]
+
+
 def probe_gpu_free_gb() -> list[float]:
     """Free VRAM (GiB) per visible GPU, via nvidia-smi. [] if unavailable.
 

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -907,6 +907,23 @@ def run_model_k8s_phased(target_cfg: dict, model_id: str, train_args: dict, data
         delete_namespace(namespace, log)
 
 
+def build_train_args(manifest: dict, target_cfg: dict, model: dict,
+                     sweep_run_id: str) -> dict:
+    """Assemble a model's training params, in increasing precedence:
+    manifest train_args_defaults < target train_args_overrides < the model's own
+    `train_args` < the fixed llm_name/sweep_run_id. The per-model layer lets one
+    model opt out of a global default — e.g. `train_args: {dtype: bfloat16}` for a
+    flagship model that would OOM under the default float32 in the Spark's shared
+    128GiB unified pool (fp32 32B ≈ 128GiB vs bf16 ≈ 64GiB)."""
+    return {
+        "llm_name": model["id"],
+        **manifest["train_args_defaults"],
+        **target_cfg.get("train_args_overrides", {}),
+        **model.get("train_args", {}),
+        "sweep_run_id": sweep_run_id,
+    }
+
+
 def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path) -> Result:
     model_id = model["id"]
     res = Result(model=model_id, target=target)
@@ -929,12 +946,7 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
         res.outcome, res.detail = SKIPPED, reason
         return res
 
-    train_args = {
-        "llm_name": model_id,
-        **manifest["train_args_defaults"],
-        **target_cfg.get("train_args_overrides", {}),
-        "sweep_run_id": args.sweep_run_id,
-    }
+    train_args = build_train_args(manifest, target_cfg, model, args.sweep_run_id)
     dataset = build_dataset(manifest["dataset"])
     golden_prompt = manifest["golden_prompt"]
     expected_output = manifest["expected_output"]

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -698,8 +698,8 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
     # k8s: the scheduler arbitrates GPUs and there is no host nvidia-smi, so skip
     # the runtime VRAM probe (free_gb=None tells gate_model the VRAM check is
     # not applicable; only its static checks apply).
-    free_gb = None if is_k8s else (probe_gpu_free_gb() if target == "cuda" else [])
-    ok, reason = gate_model(model, target, free_gb)
+    free_gb = None if is_k8s else (probe_gpu_free_gb() if target_requests_gpu(target_cfg) else [])
+    ok, reason = gate_model(model, target_cfg, free_gb)
     if not ok:
         res.outcome, res.detail = SKIPPED, reason
         return res
@@ -820,13 +820,19 @@ def write_reports(results: list[Result], target: str, results_dir: Path) -> tupl
 
 def main() -> int:
     ap = argparse.ArgumentParser(description="Fine-tune sweep (tier d, LoRA only).")
-    ap.add_argument("--target", required=True, choices=["cpu", "cuda"])
+    ap.add_argument("--target", required=True,
+                    help="manifest target key (e.g. cpu, cuda-docker, cuda-k8s); "
+                         "validated against the manifest after load")
     ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap.add_argument("--results-dir", type=Path, default=DEFAULT_RESULTS_DIR)
     ap.add_argument("--models", nargs="*", help="optional subset of model IDs to run")
     ap.add_argument("--api-url", default="http://localhost:8000")
     ap.add_argument("--max-tokens", type=int, default=64)
-    ap.add_argument("--restart-timeout", type=int, default=600)
+    ap.add_argument("--restart-timeout", type=int, default=3000,
+                    help="health-wait cap (s). Default 3000 (50 min) covers a cold "
+                         "`./scalarlm up nvidia --build` (vLLM compiles from source) "
+                         "on a fresh GPU box; only a ceiling, so happy paths are "
+                         "unaffected. Subsequent --force-recreate builds are cache hits.")
     ap.add_argument("--train-timeout", type=int, default=600)
     ap.add_argument("--serve-timeout", type=int, default=300)
     ap.add_argument("--gpu-wait-timeout", type=int, default=7200,

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -200,6 +200,36 @@ def wait_for_all_up(api_url: str, proc, timeout: float, health_key: str = "all")
     return False
 
 
+def get_served_models(api_url: str, timeout: float = 5) -> set[str]:
+    """Model ids vLLM currently serves (via the cray API's /v1/models proxy).
+    Empty set if the endpoint is unreachable or malformed."""
+    req = urllib.request.Request(f"{api_url}/v1/models", method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            data = json.loads(r.read())
+        return {m["id"] for m in data.get("data", [])}
+    except (urllib.error.URLError, ConnectionError, OSError, ValueError, KeyError, TypeError):
+        return set()
+
+
+def wait_for_model_served(api_url: str, model_id: str, proc, timeout: float) -> bool:
+    """Like wait_for_all_up, but also requires the served model to be `model_id`.
+    The Compose teardown leaves the previous model's container running (see
+    teardown_stack), so health.all=="up" alone can be satisfied by the STALE
+    stack before `--force-recreate` swaps in the new model — gating on
+    /v1/models too makes the runner block until the new container is actually
+    serving model_id."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc is not None and proc.poll() is not None:
+            return False
+        health = get_health(api_url)
+        if health and health.get("all") == "up" and model_id in get_served_models(api_url):
+            return True
+        time.sleep(2)
+    return False
+
+
 def poll_training(api_url: str, job_hash: str, train_timeout: float) -> str:
     """Poll the training job until terminal (COMPLETED/FAILED/CANCELLED) or
     train_timeout. Returns the terminal status or "TIMEOUT". Shared by the 2-GPU
@@ -749,11 +779,14 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                 res.restart_seconds = round(time.time() - restart_start, 1)
             else:
                 proc = start_restart(target_cfg, model_id, log)
-                ready = wait_for_all_up(args.api_url, proc, args.restart_timeout)
+                # Model-aware wait: a stale (previous-model) container left
+                # running by teardown_stack is still health.all=="up", so we
+                # also gate on /v1/models serving model_id before proceeding.
+                ready = wait_for_model_served(args.api_url, model_id, proc, args.restart_timeout)
                 res.restart_seconds = round(time.time() - restart_start, 1)
                 if not ready:
                     res.outcome = RESTART_FAILED
-                    res.detail = "stack did not report health.all == 'up' in time"
+                    res.detail = f"stack did not serve {model_id} (health.all/up + /v1/models) in time"
                     return res
 
             try:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -182,15 +182,17 @@ def get_health(api_url: str, timeout: float = 5) -> dict | None:
         return None
 
 
-def wait_for_all_up(api_url: str, proc, timeout: float) -> bool:
-    """Poll /v1/health until health["all"] == "up", the restart process dies
-    (Compose only; pass proc=None for k8s), or timeout. True iff ready."""
+def wait_for_all_up(api_url: str, proc, timeout: float, health_key: str = "all") -> bool:
+    """Poll /v1/health until health[health_key] == "up", the restart process dies
+    (Compose only; pass proc=None for k8s), or timeout. True iff ready. The
+    phase-scaled k8s path passes health_key="megatron" (phase 1) / "vllm" (phase 2)
+    because health["all"] is structurally down when only one GPU service is up."""
     deadline = time.time() + timeout
     while time.time() < deadline:
         if proc is not None and proc.poll() is not None:
             return False
         health = get_health(api_url)
-        if health and health.get("all") == "up":
+        if health and health.get(health_key) == "up":
             return True
         time.sleep(2)
     return False

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -363,6 +363,14 @@ def is_k8s_target(target_cfg: dict) -> bool:
     return "chart_path" in target_cfg
 
 
+def target_requests_gpu(target_cfg: dict) -> bool:
+    """True iff this target runs training on a GPU. Config-driven (not keyed on
+    the target name), mirroring is_k8s_target: JobConfig defaults gpus=1 and only
+    the cpu target overrides it to 0, so this is True for the GPU targets
+    (cuda-docker, cuda-k8s) and False for cpu."""
+    return target_cfg.get("train_args_overrides", {}).get("gpus", 1) >= 1
+
+
 def k8s_helm_install_cmd(target_cfg: dict, namespace: str, model_id: str) -> list[str]:
     cmd = [
         "helm", "upgrade", "--install", target_cfg["release"], target_cfg["chart_path"],

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -601,8 +601,27 @@ def read_checkpoint_keys_k8s(target_cfg: dict, namespace: str, job_hash: str,
     return _parse_checkpoint_keys_output(result.stdout)
 
 
+def _parse_gpu_free_gb(stdout: str) -> list[float]:
+    """Parse `nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits`
+    (MiB per GPU) into GiB. Non-numeric lines are skipped: unified-memory parts
+    (GB10/DGX Spark) report '[N/A]' for memory.free, which must not crash int()."""
+    out: list[float] = []
+    for line in stdout.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(int(line) / 1024)
+        except ValueError:
+            continue  # '[N/A]' on unified-memory GPUs
+    return out
+
+
 def probe_gpu_free_gb() -> list[float]:
-    """Free VRAM (GiB) per visible GPU, via nvidia-smi. [] if unavailable.
+    """Free VRAM (GiB) per visible GPU that reports a numeric figure, via
+    nvidia-smi. [] if nvidia-smi is unavailable or no GPU reports numeric free
+    memory (e.g. a unified-memory GB10 reporting '[N/A]' — use gpu_count to tell
+    that apart from a box with no GPU).
 
     Used both for the GPU-target LoRA VRAM gate (cuda-docker) and to detect VRAM
     reclamation after teardown_stack — via nvidia-smi (no torch on the host)."""
@@ -613,7 +632,32 @@ def probe_gpu_free_gb() -> list[float]:
         )
     except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return []
-    return [int(line.strip()) / 1024 for line in result.stdout.strip().splitlines() if line.strip()]
+    return _parse_gpu_free_gb(result.stdout)
+
+
+def gpu_count() -> int:
+    """Number of GPUs nvidia-smi enumerates, regardless of whether they report a
+    numeric memory figure. Lets the caller distinguish a unified-memory GPU
+    (present, but memory.free '[N/A]' — GB10/DGX Spark) from a box with no GPU."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=10, check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return 0
+    return len([line for line in result.stdout.strip().splitlines() if line.strip()])
+
+
+def _vram_for_gate(free_gb: list[float], n_gpus: int) -> list[float] | None:
+    """Decide the VRAM-gate input from probed free memory and GPU count. Returns
+    None — "VRAM check not applicable", same as the k8s path — when a GPU is
+    present but reports no numeric free figure (unified memory, GB10/DGX Spark ->
+    '[N/A]'): there is no discrete VRAM pool to gate on, so never SKIP for it.
+    [] (genuinely no GPU visible) and a populated list pass straight through."""
+    if not free_gb and n_gpus > 0:
+        return None
+    return free_gb
 
 
 def start_restart(target_cfg: dict, model_id: str, log) -> subprocess.Popen:
@@ -784,8 +828,15 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
     is_k8s = is_k8s_target(target_cfg)
     # k8s: the scheduler arbitrates GPUs and there is no host nvidia-smi, so skip
     # the runtime VRAM probe (free_gb=None tells gate_model the VRAM check is
-    # not applicable; only its static checks apply).
-    free_gb = None if is_k8s else (probe_gpu_free_gb() if target_requests_gpu(target_cfg) else [])
+    # not applicable; only its static checks apply). For a Compose GPU target,
+    # _vram_for_gate also yields None on a unified-memory GPU (GB10/DGX Spark,
+    # whose nvidia-smi memory.free is '[N/A]') — no discrete VRAM pool to gate on.
+    if is_k8s:
+        free_gb = None
+    elif target_requests_gpu(target_cfg):
+        free_gb = _vram_for_gate(probe_gpu_free_gb(), gpu_count())
+    else:
+        free_gb = []
     ok, reason = gate_model(model, target_cfg, free_gb)
     if not ok:
         res.outcome, res.detail = SKIPPED, reason

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -518,12 +518,13 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                     res.restart_seconds = round(time.time() - restart_start, 1)
                     res.outcome, res.detail = RESTART_FAILED, "helm upgrade --install failed"
                     return res
-                pod_status = wait_for_pods_ready(namespace, args.gpu_wait_timeout)
+                gpu_wait = target_cfg.get("gpu_wait_timeout", args.gpu_wait_timeout)
+                pod_status = wait_for_pods_ready(namespace, gpu_wait)
                 if pod_status != "ready":
                     res.restart_seconds = round(time.time() - restart_start, 1)
                     res.outcome = RESTART_FAILED
                     res.detail = ("pods crashed / bad image" if pod_status == "failed"
-                                  else f"pods not schedulable within {args.gpu_wait_timeout}s")
+                                  else f"pods not schedulable within {gpu_wait}s")
                     return res
                 pf_proc = start_port_forward(target_cfg, namespace, log)
                 if not wait_for_all_up(args.api_url, pf_proc, args.restart_timeout):

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -45,6 +45,8 @@ DEFAULT_RESULTS_DIR = HERE / "results"
 # Outcome enum (see docs/adr/0003-finetune-sweep-restart-per-model.md). Best -> worst.
 PASS = "PASS"
 NO_MEMORIZATION = "NO_MEMORIZATION"
+ADAPTER_NO_OP = "ADAPTER_NO_OP"
+PRECHECK_NO_OP = "PRECHECK_NO_OP"
 ADAPTER_NOT_LOADED = "ADAPTER_NOT_LOADED"
 BAD_CHECKPOINT = "BAD_CHECKPOINT"
 TRAIN_FAILED = "TRAIN_FAILED"
@@ -53,7 +55,8 @@ RESTART_FAILED = "RESTART_FAILED"
 SKIPPED = "SKIPPED"
 
 # NO_MEMORIZATION is expected (not yet a hard fail) until the LoRA-memorization
-# open question in the design spec is resolved.
+# open question in the design spec is resolved. ADAPTER_NO_OP and PRECHECK_NO_OP
+# are both failing: the adapter served (or is predicted to serve) base output.
 NON_FAILING_OUTCOMES = {PASS, SKIPPED, NO_MEMORIZATION}
 
 
@@ -64,6 +67,7 @@ class Result:
     adapter_type: str = "lora"
     outcome: str = SKIPPED
     detail: str = ""
+    hint: str = ""  # root-cause hint (preflight key diff, or scraped no-op warning)
     baseline_sample: str = ""
     adapter_sample: str = ""
     restart_seconds: float = 0.0
@@ -160,10 +164,13 @@ def checkpoint_lora_keys_ok(state_dict_keys: list[str] | None) -> bool:
 
 
 def classify_result(train_status: str, checkpoint_keys: list[str] | None,
-                     adapter_loaded: bool, memorized: bool) -> str:
+                     adapter_loaded: bool, memorized: bool,
+                     adapter_is_noop: bool = False) -> str:
     """Map the per-step results of run_model's training+serving pipeline to an
     outcome. Assumes train_status == "COMPLETED" for any value not handled by
-    the first two branches."""
+    the first two branches. `adapter_is_noop` is True when the adapter served
+    output byte-identical to the baseline (LoRA silently dropped at activation);
+    combined with "did not memorize" it is the ADAPTER_NO_OP failure."""
     if train_status in ("FAILED", "CANCELLED"):
         return TRAIN_FAILED
     if train_status == "TIMEOUT":
@@ -172,7 +179,36 @@ def classify_result(train_status: str, checkpoint_keys: list[str] | None,
         return BAD_CHECKPOINT
     if not adapter_loaded:
         return ADAPTER_NOT_LOADED
+    if adapter_is_noop and not memorized:
+        return ADAPTER_NO_OP
     return PASS if memorized else NO_MEMORIZATION
+
+
+def preflight_hint(pf_result) -> str:
+    """Human-readable key diff for a PRECHECK_NO_OP row: the normalized adapter
+    module paths the preflight produced vs a sample of the base model's modules,
+    so a failure is self-explanatory without a per-model forensic dive."""
+    return (f"adapter keys {pf_result.sample_adapter_keys} "
+            f"vs base {pf_result.sample_base_modules}")
+
+
+def split_by_preflight(models: list[dict], pf_results: dict,
+                       target: str) -> tuple[list[dict], list["Result"]]:
+    """Partition `models` into (to_run, skipped) using the offline preflight.
+    A model whose PreflightResult `predicted_noop` is True (zero module overlap,
+    no build error) is excluded and recorded as a PRECHECK_NO_OP Result with a
+    key-diff hint. Models with no entry, or whose preflight errored (fail open),
+    stay in to_run — a preflight crash never silently skips a model."""
+    to_run: list[dict] = []
+    skipped: list[Result] = []
+    for m in models:
+        pf = pf_results.get(m["id"])
+        if pf is not None and pf.predicted_noop:
+            skipped.append(Result(model=m["id"], target=target,
+                                  outcome=PRECHECK_NO_OP, hint=preflight_hint(pf)))
+        else:
+            to_run.append(m)
+    return to_run, skipped
 
 
 def get_health(api_url: str, timeout: float = 5) -> dict | None:
@@ -250,11 +286,14 @@ def poll_training(api_url: str, job_hash: str, train_timeout: float) -> str:
 
 def serve_check_and_classify(api_url: str, golden_prompt: str, expected_output: str,
                              job_hash: str, train_status: str,
-                             checkpoint_keys: list[str] | None, args, res: "Result") -> None:
+                             checkpoint_keys: list[str] | None, args, res: "Result",
+                             baseline_full: str = "") -> None:
     """Hot-load the trained adapter, classify the outcome, and set the result
     fields (serve_seconds, outcome, adapter_sample, detail). Shared by the 2-GPU
     and phase-scaled k8s paths; the caller reads `checkpoint_keys` first (the read
-    mechanism differs per path)."""
+    mechanism differs per path) and passes the FULL baseline string for the no-op
+    discriminator (byte-identical adapter output under greedy decoding -> the LoRA
+    silently dropped at activation -> ADAPTER_NO_OP)."""
     adapter_loaded = False
     adapter_text = ""
     last_serve_error = ""
@@ -272,7 +311,9 @@ def serve_check_and_classify(api_url: str, golden_prompt: str, expected_output: 
     res.serve_seconds = round(time.time() - serve_start, 1)
 
     memorized = expected_output in adapter_text
-    res.outcome = classify_result(train_status, checkpoint_keys, adapter_loaded, memorized)
+    adapter_is_noop = adapter_loaded and adapter_text == baseline_full
+    res.outcome = classify_result(train_status, checkpoint_keys, adapter_loaded,
+                                  memorized, adapter_is_noop=adapter_is_noop)
     res.adapter_sample = adapter_text[:200]
 
     if res.outcome == TRAIN_FAILED:
@@ -283,6 +324,9 @@ def serve_check_and_classify(api_url: str, golden_prompt: str, expected_output: 
         res.detail = f"checkpoint keys: {checkpoint_keys}"
     elif res.outcome == ADAPTER_NOT_LOADED:
         res.detail = f"adapter never became servable; last error: {last_serve_error}"
+    elif res.outcome == ADAPTER_NO_OP:
+        extra = "adapter served output byte-identical to baseline (LoRA not applied)"
+        res.detail = f"{res.detail}; {extra}" if res.detail else extra
     elif res.outcome == NO_MEMORIZATION:
         extra = "adapter served but did not memorize expected_output"
         res.detail = f"{res.detail}; {extra}" if res.detail else extra
@@ -347,12 +391,20 @@ def get_training_job(api_url: str, job_hash: str, timeout: float = 10) -> dict:
 
 
 def generate(api_url: str, prompts: list[str], model_name: str, max_tokens: int,
-              poll_timeout: float = 300) -> list[str]:
+              poll_timeout: float = 300, temperature: float = 0.0) -> list[str]:
     """POST /v1/generate then poll /v1/generate/get_results until every result has
     a response, raising on any error (mirrors handle_error/poll_for_responses in
-    sdk/masint/engines/async_cray.py)."""
+    sdk/masint/engines/async_cray.py).
+    Default temperature=0.0 ensures greedy-decoding determinism for the no-op
+    discriminator.
+    """
     request_timeout = 30
-    body = json.dumps({"prompts": prompts, "model": model_name, "max_tokens": max_tokens}).encode()
+    body = json.dumps({
+        "prompts": prompts,
+        "model": model_name,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }).encode()
     req = urllib.request.Request(
         f"{api_url}/v1/generate", data=body,
         headers={"Content-Type": "application/json"}, method="POST",
@@ -708,9 +760,11 @@ def run_model_k8s_phased(target_cfg: dict, model_id: str, train_args: dict, data
             res.outcome, res.detail = RESTART_FAILED, f"baseline generate failed: {e}"
             return res
 
-        # Hot-load + classify (shared with the 2-GPU path).
+        # Hot-load + classify (shared with the 2-GPU path); pass the full
+        # baseline for the no-op discriminator.
         serve_check_and_classify(args.api_url, golden_prompt, expected_output, job_hash,
-                                 train_status, checkpoint_keys, args, res)
+                                 train_status, checkpoint_keys, args, res,
+                                 baseline_full=baseline[0])
         return res
     finally:
         if pf_proc is not None:
@@ -817,8 +871,27 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                     checkpoint_keys = read_checkpoint_keys_k8s(target_cfg, namespace, job_hash)
                 else:
                     checkpoint_keys = read_checkpoint_keys(target_cfg["compose_service"], job_hash)
+            # Hot-load + classify (shared with the phased k8s path). The full
+            # baseline string drives the in-sweep no-op discriminator: a served
+            # adapter whose output is byte-identical to baseline under greedy
+            # decoding never applied the LoRA -> ADAPTER_NO_OP.
             serve_check_and_classify(args.api_url, golden_prompt, expected_output, job_hash,
-                                     train_status, checkpoint_keys, args, res)
+                                     train_status, checkpoint_keys, args, res,
+                                     baseline_full=baseline[0])
+
+            # If ADAPTER_NO_OP, scrape logs for the a-priori known warning.
+            if res.outcome == ADAPTER_NO_OP:
+                try:
+                    logs = subprocess.run(
+                        ["docker", "compose", "-f", "docker-compose.yaml", "logs", "--no-color", target_cfg["compose_service"]],
+                        cwd=REPO_ROOT, capture_output=True, text=True
+                    ).stdout
+                    match = [l for l in logs.splitlines() if "NONE of its" in l and "match the base model" in l]
+                    if match:
+                        res.hint = match[-1]
+                except Exception:
+                    pass
+
             return res
         finally:
             if is_k8s:
@@ -842,13 +915,14 @@ def write_reports(results: list[Result], target: str, results_dir: Path) -> tupl
     json_path.write_text(json.dumps([asdict(r) for r in results], indent=2))
 
     lines = [f"# Fine-tune sweep — `{target}` — {stamp}", "",
-             "| Model | Outcome | Detail | Baseline sample | Adapter sample | restart_s | train_s | serve_s |",
-             "|---|---|---|---|---|---|---|---|"]
+             "| Model | Outcome | Detail | Hint | Baseline sample | Adapter sample | restart_s | train_s | serve_s |",
+             "|---|---|---|---|---|---|---|---|---|"]
     for r in results:
         baseline = r.baseline_sample.replace("\n", " ").replace("|", "\\|")[:60]
         adapter = r.adapter_sample.replace("\n", " ").replace("|", "\\|")[:60]
         detail = r.detail.replace("|", "\\|")
-        lines.append(f"| `{r.model}` | {r.outcome} | {detail} | {baseline} | {adapter} "
+        hint = r.hint.replace("\n", " ").replace("|", "\\|")
+        lines.append(f"| `{r.model}` | {r.outcome} | {detail} | {hint} | {baseline} | {adapter} "
                      f"| {r.restart_seconds} | {r.train_seconds} | {r.serve_seconds} |")
     md_path.write_text("\n".join(lines) + "\n")
     return json_path, md_path
@@ -874,6 +948,9 @@ def main() -> int:
     ap.add_argument("--gpu-wait-timeout", type=int, default=7200,
                     help="k8s only: seconds to block while pods are Unschedulable "
                          "(GPUs busy) before giving up with RESTART_FAILED")
+    ap.add_argument("--no-preflight", action="store_true",
+                    help="skip the offline LoRA no-op preflight; run every model "
+                         "even if it is predicted to serve base output")
     args = ap.parse_args()
 
     manifest = load_manifest(args.manifest)
@@ -884,7 +961,21 @@ def main() -> int:
 
     models = filter_models(manifest["models"], args.models)
 
-    results = []
+    # Offline preflight: predict the silent LoRA no-op before paying for a
+    # model's restart + train + serve, and skip those models. Compose-only —
+    # k8s targets have no `compose_service`, so they run unfiltered (the
+    # in-sweep ADAPTER_NO_OP discriminator is still ground truth there).
+    results: list[Result] = []
+    compose_service = manifest["targets"][args.target].get("compose_service")
+    if not args.no_preflight and compose_service:
+        from preflight import run_preflight
+        print(f"\n=== preflight ({len(models)} models) ===", flush=True)
+        pf_results = run_preflight([m["id"] for m in models], compose_service)
+        models, skipped = split_by_preflight(models, pf_results, args.target)
+        for s in skipped:
+            print(f"--> {s.model}: {s.outcome} ({s.hint})", flush=True)
+        results.extend(skipped)
+
     for m in models:
         print(f"\n=== {m['id']} [{args.target}] ===", flush=True)
         r = run_model(manifest, args.target, m, args, args.results_dir)

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -93,9 +93,11 @@ def k8s_namespace(prefix: str, model_id: str) -> str:
     return f"{prefix}-{slug}"[:63].rstrip("-")
 
 
-def gate_model(model: dict, target: str, free_gb: list[float]) -> tuple[bool, str]:
+def gate_model(model: dict, target: str, free_gb: list[float] | None) -> tuple[bool, str]:
     """Decide whether `model` should run on `target`. cpu is opt-in via cpu_ok;
-    cuda is gated on the LoRA VRAM gate vs. probed free VRAM."""
+    cuda is gated on the LoRA VRAM gate vs. probed free VRAM. `free_gb is None`
+    means the VRAM check is not applicable (k8s: the scheduler arbitrates GPU
+    fit) — only the static checks apply."""
     if target == "cpu":
         if not model.get("cpu_ok"):
             return False, "no cpu_ok opt-in for this model"
@@ -104,6 +106,8 @@ def gate_model(model: dict, target: str, free_gb: list[float]) -> tuple[bool, st
     gate_gb = model.get("adapters", {}).get("lora", {}).get("gate_gb")
     if gate_gb is None:
         return False, "no adapters.lora.gate_gb declared"
+    if free_gb is None:
+        return True, ""  # k8s: scheduler arbitrates GPU fit; skip the VRAM check
     if not free_gb or max(free_gb) < gate_gb:
         return False, (f"LoRA needs >={gate_gb:g}GiB free; "
                         f"free GiB: {[round(f, 1) for f in free_gb]}")
@@ -484,8 +488,9 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
     target_cfg = manifest["targets"][target]
     is_k8s = is_k8s_target(target_cfg)
     # k8s: the scheduler arbitrates GPUs and there is no host nvidia-smi, so skip
-    # the runtime VRAM probe (gate_model then only applies its static checks).
-    free_gb = [] if is_k8s else (probe_gpu_free_gb() if target == "cuda" else [])
+    # the runtime VRAM probe (free_gb=None tells gate_model the VRAM check is
+    # not applicable; only its static checks apply).
+    free_gb = None if is_k8s else (probe_gpu_free_gb() if target == "cuda" else [])
     ok, reason = gate_model(model, target, free_gb)
     if not ok:
         res.outcome, res.detail = SKIPPED, reason
@@ -510,19 +515,22 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                 namespace = k8s_namespace(target_cfg["namespace_prefix"], model_id)
                 delete_namespace(namespace, log)  # idempotent pre-clean
                 if not helm_install(target_cfg, namespace, model_id, log, args.restart_timeout):
+                    res.restart_seconds = round(time.time() - restart_start, 1)
                     res.outcome, res.detail = RESTART_FAILED, "helm upgrade --install failed"
                     return res
                 pod_status = wait_for_pods_ready(namespace, args.gpu_wait_timeout)
-                res.restart_seconds = round(time.time() - restart_start, 1)
                 if pod_status != "ready":
+                    res.restart_seconds = round(time.time() - restart_start, 1)
                     res.outcome = RESTART_FAILED
                     res.detail = ("pods crashed / bad image" if pod_status == "failed"
                                   else f"pods not schedulable within {args.gpu_wait_timeout}s")
                     return res
                 pf_proc = start_port_forward(target_cfg, namespace, log)
-                if not wait_for_all_up(args.api_url, None, args.restart_timeout):
+                if not wait_for_all_up(args.api_url, pf_proc, args.restart_timeout):
+                    res.restart_seconds = round(time.time() - restart_start, 1)
                     res.outcome, res.detail = RESTART_FAILED, "api /v1/health not up after port-forward"
                     return res
+                res.restart_seconds = round(time.time() - restart_start, 1)
             else:
                 proc = start_restart(target_cfg, model_id, log)
                 ready = wait_for_all_up(args.api_url, proc, args.restart_timeout)

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -966,18 +966,16 @@ def main() -> int:
     # k8s targets have no `compose_service`, so they run unfiltered (the
     # in-sweep ADAPTER_NO_OP discriminator is still ground truth there).
     results: list[Result] = []
-    target_cfg = manifest["targets"][args.target]
-    compose_service = target_cfg.get("compose_service")
+    compose_service = manifest["targets"][args.target].get("compose_service")
     if not args.no_preflight and compose_service:
         from preflight import run_preflight
-        # The introspection is CPU-only and just needs an image with vLLM + the
-        # fork, so a GPU target can run it in an already-built CPU image
-        # (`preflight_service`, default: the target's compose_service) instead of
-        # triggering a multi-GB GPU image build via `docker compose run`.
-        preflight_service = target_cfg.get("preflight_service", compose_service)
-        print(f"\n=== preflight ({len(models)} models, service={preflight_service}) ===",
+        # Preflight runs inside the target's already-built serving image. It is
+        # gated on that image existing (run_preflight skips cleanly if not), since
+        # `docker compose run` would otherwise attempt a doomed build of a missing
+        # image — failing on the BASE_NAME build arg only `./scalarlm up` supplies.
+        print(f"\n=== preflight ({len(models)} models, service={compose_service}) ===",
               flush=True)
-        pf_results = run_preflight([m["id"] for m in models], preflight_service)
+        pf_results = run_preflight([m["id"] for m in models], compose_service)
         # Log EVERY result, not just the skips: a fail-open (build/introspection
         # error -> run the model) must be loud, otherwise a wholly-broken preflight
         # looks identical to "every model predicted OK".

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -12,7 +12,8 @@ in-container step (reading LoRA checkpoint keys) via `docker compose exec`.
 
 Usage:
     python3 run_finetune_sweep.py --target cpu
-    python3 run_finetune_sweep.py --target cuda --models tiny-random/gemma-4-dense
+    python3 run_finetune_sweep.py --target cuda-docker            # GPU via Docker Compose (scheduler-less box)
+    python3 run_finetune_sweep.py --target cuda-k8s --models Qwen/Qwen2.5-0.5B
 """
 
 from __future__ import annotations
@@ -522,8 +523,7 @@ def probe_gpu_free_gb() -> list[float]:
     """Free VRAM (GiB) per visible GPU, via nvidia-smi. [] if unavailable.
 
     Used both for the cuda LoRA gate and to detect VRAM reclamation after
-    teardown_stack — same role as probe_gpu_free_gb in test/model_sweep/run_sweep.py,
-    but via nvidia-smi (no torch dependency on the host)."""
+    teardown_stack — via nvidia-smi (no torch dependency on the host)."""
     try:
         result = subprocess.run(
             ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
@@ -536,7 +536,7 @@ def probe_gpu_free_gb() -> list[float]:
 
 def start_restart(target_cfg: dict, model_id: str, log) -> subprocess.Popen:
     """Launch `SCALARLM_MODEL=<model> ./scalarlm up <target>` in its own process
-    group, non-blocking (mirrors run_sweep.py:279-280)."""
+    group, non-blocking."""
     cmd = target_cfg["restart_cmd"].format(model=model_id)
     return subprocess.Popen(cmd, shell=True, cwd=REPO_ROOT, stdout=log,
                              stderr=subprocess.STDOUT, start_new_session=True)
@@ -544,7 +544,10 @@ def start_restart(target_cfg: dict, model_id: str, log) -> subprocess.Popen:
 
 def teardown_stack(proc: subprocess.Popen, settle_timeout: float = 60.0) -> None:
     """SIGKILL the restart process's whole process group, then wait for VRAM to
-    stop climbing (mirrors teardown_engine in test/model_sweep/run_sweep.py)."""
+    stop climbing. NOTE: `./scalarlm up` runs `docker compose up` in the
+    foreground, so SIGKILL stops the compose CLI but leaves the container (and its
+    GPU) running; the next run's --force-recreate reclaims it, or `docker compose
+    down <service>` does."""
     try:
         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
     except OSError:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -329,8 +329,11 @@ def k8s_exec_checkpoint_cmd(target_cfg: dict, namespace: str, script: str) -> li
             f"statefulset/{target_cfg['megatron_sts']}", "--", "python3", "-c", script]
 
 
-def k8s_get_pods_cmd(namespace: str) -> list[str]:
-    return ["kubectl", "get", "pods", "-n", namespace, "-o", "json"]
+def k8s_get_pods_cmd(namespace: str, selector: str | None = None) -> list[str]:
+    cmd = ["kubectl", "get", "pods", "-n", namespace]
+    if selector:
+        cmd += ["-l", selector]
+    return cmd + ["-o", "json"]
 
 
 def k8s_scale_cmd(kind_name: str, replicas: int, namespace: str) -> list[str]:
@@ -341,10 +344,11 @@ def k8s_scale_cmd(kind_name: str, replicas: int, namespace: str) -> list[str]:
 
 # --- k8s side-effecting wrappers ---
 
-def kubectl_get_pods(namespace: str, timeout: float = 15) -> list[dict]:
-    """Return the namespace's pod objects (`.items`), or [] if the call fails."""
+def kubectl_get_pods(namespace: str, selector: str | None = None, timeout: float = 15) -> list[dict]:
+    """Return the namespace's pod objects (`.items`), optionally filtered by a
+    label selector, or [] if the call fails."""
     try:
-        result = subprocess.run(k8s_get_pods_cmd(namespace), cwd=REPO_ROOT,
+        result = subprocess.run(k8s_get_pods_cmd(namespace, selector), cwd=REPO_ROOT,
                                 capture_output=True, text=True, timeout=timeout, check=True)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return []
@@ -382,6 +386,26 @@ def wait_for_pods_ready(namespace: str, gpu_wait_timeout: float, poll: float = 1
         status = classify_pod_status(kubectl_get_pods(namespace))
         if status in ("ready", "failed"):
             return status
+        time.sleep(poll)
+    return "timeout"
+
+
+# Megatron pods carry this component label (chart _helpers.tpl megatronlabels);
+# used to wait for the megatron pod to fully delete during the phase-2 handoff.
+MEGATRON_POD_SELECTOR = "app.kubernetes.io/component=megatron"
+
+
+def wait_for_pods_gone(namespace: str, selector: str, gpu_wait_timeout: float,
+                       poll: float = 5.0) -> str:
+    """Block until no pod matching `selector` exists (its nvidia.com/gpu request is
+    released only on full deletion, not while Terminating), else "timeout" at
+    gpu_wait_timeout. Phase-2 handoff: megatron must be gone before vLLM claims the
+    card. Polling beats `kubectl wait --for=delete`, which errors when zero pods
+    already match."""
+    deadline = time.time() + gpu_wait_timeout
+    while time.time() < deadline:
+        if not kubectl_get_pods(namespace, selector):
+            return "gone"
         time.sleep(poll)
     return "timeout"
 

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""Fine-tune sweep — tier (d) integration test: LoRA train -> hot-load -> serve.
+
+Runs ON THE HOST (not inside the cray container) because restarting the stack
+(`./scalarlm up <target>`) is itself a host-level `docker compose ... --force-recreate`
+that would kill anything running inside the container being restarted. See
+docs/adr/0003-finetune-sweep-restart-per-model.md.
+
+Talks to the cray API over plain HTTP (stdlib urllib, no SDK/aiohttp dependency)
+for health/train/generate, uses `nvidia-smi` for VRAM probing, and the ONE
+in-container step (reading LoRA checkpoint keys) via `docker compose exec`.
+
+Usage:
+    python3 run_finetune_sweep.py --target cpu
+    python3 run_finetune_sweep.py --target cuda --models tiny-random/gemma-4-dense
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import io
+import json
+import os
+import signal
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).parent
+REPO_ROOT = HERE.parent.parent
+DEFAULT_MANIFEST = HERE / "finetune-sweep.yaml"
+DEFAULT_RESULTS_DIR = HERE / "results"
+
+# Outcome enum (see docs/adr/0003-finetune-sweep-restart-per-model.md). Best -> worst.
+PASS = "PASS"
+NO_MEMORIZATION = "NO_MEMORIZATION"
+ADAPTER_NOT_LOADED = "ADAPTER_NOT_LOADED"
+BAD_CHECKPOINT = "BAD_CHECKPOINT"
+TRAIN_FAILED = "TRAIN_FAILED"
+TRAIN_TIMEOUT = "TRAIN_TIMEOUT"
+RESTART_FAILED = "RESTART_FAILED"
+SKIPPED = "SKIPPED"
+
+# NO_MEMORIZATION is expected (not yet a hard fail) until the LoRA-memorization
+# open question in the design spec is resolved.
+NON_FAILING_OUTCOMES = {PASS, SKIPPED, NO_MEMORIZATION}
+
+
+@dataclass
+class Result:
+    model: str
+    target: str
+    adapter_type: str = "lora"
+    outcome: str = SKIPPED
+    detail: str = ""
+    baseline_sample: str = ""
+    adapter_sample: str = ""
+    restart_seconds: float = 0.0
+    train_seconds: float = 0.0
+    serve_seconds: float = 0.0
+
+
+def load_manifest(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def filter_models(models: list[dict], wanted: list[str] | None) -> list[dict]:
+    if not wanted:
+        return models
+    wanted_set = set(wanted)
+    return [m for m in models if m["id"] in wanted_set]
+
+
+def build_dataset(dataset_spec: dict) -> list[dict]:
+    return dataset_spec["examples"] * dataset_spec.get("repeat", 1)
+
+
+def gate_model(model: dict, target: str, free_gb: list[float]) -> tuple[bool, str]:
+    """Decide whether `model` should run on `target`. cpu is opt-in via cpu_ok;
+    cuda is gated on the LoRA VRAM gate vs. probed free VRAM."""
+    if target == "cpu":
+        if not model.get("cpu_ok"):
+            return False, "no cpu_ok opt-in for this model"
+        return True, ""
+
+    gate_gb = model.get("adapters", {}).get("lora", {}).get("gate_gb")
+    if gate_gb is None:
+        return False, "no adapters.lora.gate_gb declared"
+    if not free_gb or max(free_gb) < gate_gb:
+        return False, (f"LoRA needs >={gate_gb:g}GiB free; "
+                        f"free GiB: {[round(f, 1) for f in free_gb]}")
+    return True, ""
+
+
+def checkpoint_lora_keys_ok(state_dict_keys: list[str] | None) -> bool:
+    """True iff the checkpoint's state-dict keys include both LoRA matrices."""
+    if not state_dict_keys:
+        return False
+    return (any("lora_A" in k for k in state_dict_keys)
+            and any("lora_B" in k for k in state_dict_keys))
+
+
+def classify_result(train_status: str, checkpoint_keys: list[str] | None,
+                     adapter_loaded: bool, memorized: bool) -> str:
+    """Map the per-step results of run_model's training+serving pipeline to an
+    outcome. Assumes train_status == "COMPLETED" for any value not handled by
+    the first two branches."""
+    if train_status in ("FAILED", "CANCELLED"):
+        return TRAIN_FAILED
+    if train_status == "TIMEOUT":
+        return TRAIN_TIMEOUT
+    if not checkpoint_lora_keys_ok(checkpoint_keys):
+        return BAD_CHECKPOINT
+    if not adapter_loaded:
+        return ADAPTER_NOT_LOADED
+    return PASS if memorized else NO_MEMORIZATION
+
+
+def get_health(api_url: str, timeout: float = 5) -> dict | None:
+    req = urllib.request.Request(f"{api_url}/v1/health", method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read())
+    except (urllib.error.URLError, ConnectionError, OSError, ValueError):
+        return None
+
+
+def wait_for_all_up(api_url: str, proc, timeout: float) -> bool:
+    """Poll /v1/health until health["all"] == "up", the restart process dies, or
+    timeout. True iff ready."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            return False
+        health = get_health(api_url)
+        if health and health.get("all") == "up":
+            return True
+        time.sleep(2)
+    return False
+
+
+def build_dataset_tar(dataset: list[dict]) -> bytes:
+    """In-memory tar containing dataset.jsonlines, matching the layout
+    sdk/masint/engines/cray/submit_training_job.py builds."""
+    jsonl = "\n".join(json.dumps(row) for row in dataset).encode() + b"\n"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo(name="dataset.jsonlines")
+        info.size = len(jsonl)
+        tar.addfile(info, io.BytesIO(jsonl))
+    return buf.getvalue()
+
+
+def submit_train(api_url: str, dataset: list[dict], train_args: dict, timeout: float = 30) -> dict:
+    """POST /v1/megatron/train as multipart/form-data (file=dataset tar,
+    params=train_args JSON), matching make_multipart_writer. Returns job_status."""
+    boundary = uuid.uuid4().hex
+    tar_bytes = build_dataset_tar(dataset)
+    params_json = json.dumps(train_args).encode()
+
+    body = io.BytesIO()
+
+    def write_field(name, filename, content_type, data):
+        body.write(f"--{boundary}\r\n".encode())
+        disp = f'form-data; name="{name}"'
+        if filename:
+            disp += f'; filename="{filename}"'
+        body.write(f"Content-Disposition: {disp}\r\n".encode())
+        body.write(f"Content-Type: {content_type}\r\n".encode())
+        body.write(b"\r\n")
+        body.write(data)
+        body.write(b"\r\n")
+
+    write_field("file", "dataset", "application/octet-stream", tar_bytes)
+    write_field("params", None, "application/json", params_json)
+    body.write(f"--{boundary}--\r\n".encode())
+
+    req = urllib.request.Request(
+        f"{api_url}/v1/megatron/train",
+        data=body.getvalue(),
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read())["job_status"]
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"POST /v1/megatron/train failed {e.code}: {e.read().decode()}") from e
+
+
+def get_training_job(api_url: str, job_hash: str, timeout: float = 10) -> dict:
+    req = urllib.request.Request(f"{api_url}/v1/megatron/train/{job_hash}", method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return json.loads(r.read())["job_status"]
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"GET /v1/megatron/train/{job_hash} failed {e.code}: {e.read().decode()}") from e
+
+
+def generate(api_url: str, prompts: list[str], model_name: str, max_tokens: int,
+              poll_timeout: float = 300) -> list[str]:
+    """POST /v1/generate then poll /v1/generate/get_results until every result has
+    a response, raising on any error (mirrors handle_error/poll_for_responses in
+    sdk/masint/engines/async_cray.py)."""
+    request_timeout = 30
+    body = json.dumps({"prompts": prompts, "model": model_name, "max_tokens": max_tokens}).encode()
+    req = urllib.request.Request(
+        f"{api_url}/v1/generate", data=body,
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=request_timeout) as r:
+        result = json.loads(r.read())
+    if result.get("error"):
+        raise RuntimeError(result["error"])
+    if not result.get("results"):
+        raise RuntimeError(f"no results in response: {result}")
+
+    deadline = time.time() + poll_timeout
+    while True:
+        for item in result["results"]:
+            if item.get("error"):
+                raise RuntimeError(item["error"])
+        if all(item["response"] is not None for item in result["results"]):
+            return [item["response"] for item in result["results"]]
+        if time.time() > deadline:
+            raise TimeoutError("generate did not complete in time")
+        time.sleep(2)
+
+        request_ids = [item["request_id"] for item in result["results"]]
+        poll_body = json.dumps({"request_ids": request_ids}).encode()
+        poll_req = urllib.request.Request(
+            f"{api_url}/v1/generate/get_results", data=poll_body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with urllib.request.urlopen(poll_req, timeout=request_timeout) as r:
+            result = json.loads(r.read())
+        if result.get("error"):
+            raise RuntimeError(result["error"])
+
+
+def probe_gpu_free_gb() -> list[float]:
+    """Free VRAM (GiB) per visible GPU, via nvidia-smi. [] if unavailable.
+
+    Used both for the cuda LoRA gate and to detect VRAM reclamation after
+    teardown_stack — same role as probe_gpu_free_gb in test/model_sweep/run_sweep.py,
+    but via nvidia-smi (no torch dependency on the host)."""
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "--query-gpu=memory.free", "--format=csv,noheader,nounits"],
+            capture_output=True, text=True, timeout=10, check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return []
+    return [int(line.strip()) / 1024 for line in result.stdout.strip().splitlines() if line.strip()]
+
+
+def start_restart(target_cfg: dict, model_id: str, log) -> subprocess.Popen:
+    """Launch `SCALARLM_MODEL=<model> ./scalarlm up <target>` in its own process
+    group, non-blocking (mirrors run_sweep.py:279-280)."""
+    cmd = target_cfg["restart_cmd"].format(model=model_id)
+    return subprocess.Popen(cmd, shell=True, cwd=REPO_ROOT, stdout=log,
+                             stderr=subprocess.STDOUT, start_new_session=True)
+
+
+def teardown_stack(proc: subprocess.Popen, settle_timeout: float = 60.0) -> None:
+    """SIGKILL the restart process's whole process group, then wait for VRAM to
+    stop climbing (mirrors teardown_engine in test/model_sweep/run_sweep.py)."""
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except OSError:
+        pass
+    proc.wait()
+    if not probe_gpu_free_gb():
+        return  # cpu / no visible GPUs - nothing to reclaim
+    last, stable = -1.0, 0
+    deadline = time.time() + settle_timeout
+    while time.time() < deadline:
+        time.sleep(1.0)
+        cur = sum(probe_gpu_free_gb())
+        if cur <= last + 0.25:
+            stable += 1
+            if stable >= 2:
+                return
+        else:
+            stable = 0
+        last = cur
+    print(f"[warn] teardown_stack: VRAM did not settle within {settle_timeout}s", flush=True)
+
+
+def read_checkpoint_keys(compose_service: str, job_hash: str, timeout: float = 60) -> list[str] | None:
+    """Read the latest checkpoint's model_state_dict keys via `docker compose exec`
+    — the one step that needs in-container torch. Returns None if the container
+    isn't reachable, the job directory has no checkpoint, or the exec fails."""
+    script = (
+        "import glob, re, json, torch\n"
+        f"paths = glob.glob('/app/cray/jobs/{job_hash}/checkpoint_*.pt')\n"
+        "def step(p):\n"
+        "    m = re.search(r'checkpoint_(\\d+)\\.pt', p)\n"
+        "    return int(m.group(1)) if m else -1\n"
+        "paths.sort(key=step)\n"
+        "ckpt = torch.load(paths[-1], map_location='cpu', weights_only=False) if paths else None\n"
+        "print(json.dumps(list(ckpt['model_state_dict'].keys()) if ckpt else None))\n"
+    )
+    cmd = ["docker", "compose", "-f", "docker-compose.yaml", "exec", "-T", compose_service,
+           "python3", "-c", script]
+    try:
+        result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True,
+                                 timeout=timeout, check=True)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    try:
+        return json.loads(result.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        return None
+
+
+def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path) -> Result:
+    model_id = model["id"]
+    res = Result(model=model_id, target=target)
+
+    target_cfg = manifest["targets"][target]
+    free_gb = probe_gpu_free_gb() if target == "cuda" else []
+    ok, reason = gate_model(model, target, free_gb)
+    if not ok:
+        res.outcome, res.detail = SKIPPED, reason
+        return res
+
+    train_args = {
+        "llm_name": model_id,
+        **manifest["train_args_defaults"],
+        **target_cfg.get("train_args_overrides", {}),
+        "sweep_run_id": args.sweep_run_id,
+    }
+    dataset = build_dataset(manifest["dataset"])
+    golden_prompt = manifest["golden_prompt"]
+    expected_output = manifest["expected_output"]
+
+    log_path = results_dir / f"{model_id.replace('/', '_')}.{target}.restart.log"
+    restart_start = time.time()
+    with open(log_path, "w") as log:
+        proc = start_restart(target_cfg, model_id, log)
+        try:
+            ready = wait_for_all_up(args.api_url, proc, args.restart_timeout)
+            res.restart_seconds = round(time.time() - restart_start, 1)
+            if not ready:
+                res.outcome = RESTART_FAILED
+                res.detail = "stack did not report health.all == 'up' in time"
+                return res
+
+            try:
+                baseline = generate(args.api_url, [golden_prompt], model_id, args.max_tokens)
+                res.baseline_sample = baseline[0][:200]
+                if expected_output in baseline[0]:
+                    res.detail = "expected_output already present in baseline output"
+            except Exception as e:
+                res.outcome = RESTART_FAILED
+                res.detail = f"baseline generate failed: {e}"
+                return res
+
+            train_start = time.time()
+            try:
+                job_status = submit_train(args.api_url, dataset, train_args)
+            except Exception as e:
+                res.outcome = TRAIN_FAILED
+                res.detail = f"submit_train failed: {e}"
+                return res
+            job_hash = job_status["job_directory"].rstrip("/").split("/")[-1]
+
+            train_status = "TIMEOUT"
+            deadline = time.time() + args.train_timeout
+            while time.time() < deadline:
+                try:
+                    info = get_training_job(args.api_url, job_hash)
+                except (urllib.error.URLError, RuntimeError):
+                    time.sleep(5)
+                    continue
+                st = info.get("status")
+                if st in ("COMPLETED", "FAILED", "CANCELLED"):
+                    train_status = st
+                    break
+                time.sleep(5)
+            res.train_seconds = round(time.time() - train_start, 1)
+
+            checkpoint_keys: list[str] | None = None
+            adapter_loaded = False
+            adapter_text = ""
+            last_serve_error = ""
+            serve_start = time.time()  # only meaningful if train_status == "COMPLETED"
+
+            if train_status == "COMPLETED":
+                checkpoint_keys = read_checkpoint_keys(target_cfg["compose_service"], job_hash)
+                if checkpoint_lora_keys_ok(checkpoint_keys):
+                    serve_deadline = time.time() + args.serve_timeout
+                    while time.time() < serve_deadline:
+                        try:
+                            adapter_out = generate(args.api_url, [golden_prompt], job_hash, args.max_tokens)
+                            adapter_text = adapter_out[0]
+                            adapter_loaded = True
+                            break
+                        except Exception as e:
+                            last_serve_error = str(e)
+                            time.sleep(5)
+            res.serve_seconds = round(time.time() - serve_start, 1)
+
+            memorized = expected_output in adapter_text
+            res.outcome = classify_result(train_status, checkpoint_keys, adapter_loaded, memorized)
+            res.adapter_sample = adapter_text[:200]
+
+            if res.outcome == TRAIN_FAILED:
+                res.detail = f"job ended with status {train_status}"
+            elif res.outcome == TRAIN_TIMEOUT:
+                res.detail = f"job did not reach a terminal status within {args.train_timeout}s"
+            elif res.outcome == BAD_CHECKPOINT:
+                res.detail = f"checkpoint keys: {checkpoint_keys}"
+            elif res.outcome == ADAPTER_NOT_LOADED:
+                res.detail = f"adapter never became servable; last error: {last_serve_error}"
+            elif res.outcome == NO_MEMORIZATION:
+                extra = "adapter served but did not memorize expected_output"
+                res.detail = f"{res.detail}; {extra}" if res.detail else extra
+            return res
+        finally:
+            teardown_stack(proc)
+
+
+def write_reports(results: list[Result], target: str, results_dir: Path) -> tuple[Path, Path]:
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    json_path = results_dir / f"finetune.{target}.{stamp}.json"
+    md_path = results_dir / f"finetune.{target}.{stamp}.md"
+
+    json_path.write_text(json.dumps([asdict(r) for r in results], indent=2))
+
+    lines = [f"# Fine-tune sweep — `{target}` — {stamp}", "",
+             "| Model | Outcome | Detail | Baseline sample | Adapter sample | restart_s | train_s | serve_s |",
+             "|---|---|---|---|---|---|---|---|"]
+    for r in results:
+        baseline = r.baseline_sample.replace("\n", " ").replace("|", "\\|")[:60]
+        adapter = r.adapter_sample.replace("\n", " ").replace("|", "\\|")[:60]
+        detail = r.detail.replace("|", "\\|")
+        lines.append(f"| `{r.model}` | {r.outcome} | {detail} | {baseline} | {adapter} "
+                     f"| {r.restart_seconds} | {r.train_seconds} | {r.serve_seconds} |")
+    md_path.write_text("\n".join(lines) + "\n")
+    return json_path, md_path
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Fine-tune sweep (tier d, LoRA only).")
+    ap.add_argument("--target", required=True, choices=["cpu", "cuda"])
+    ap.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    ap.add_argument("--results-dir", type=Path, default=DEFAULT_RESULTS_DIR)
+    ap.add_argument("--models", nargs="*", help="optional subset of model IDs to run")
+    ap.add_argument("--api-url", default="http://localhost:8000")
+    ap.add_argument("--max-tokens", type=int, default=64)
+    ap.add_argument("--restart-timeout", type=int, default=600)
+    ap.add_argument("--train-timeout", type=int, default=600)
+    ap.add_argument("--serve-timeout", type=int, default=300)
+    args = ap.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    if args.target not in manifest["targets"]:
+        ap.error(f"unknown target {args.target!r}; have {list(manifest['targets'])}")
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    args.sweep_run_id = uuid.uuid4().hex
+
+    models = filter_models(manifest["models"], args.models)
+
+    results = []
+    for m in models:
+        print(f"\n=== {m['id']} [{args.target}] ===", flush=True)
+        r = run_model(manifest, args.target, m, args, args.results_dir)
+        print(f"--> {r.model}: {r.outcome} ({r.detail})", flush=True)
+        results.append(r)
+
+    json_path, md_path = write_reports(results, args.target, args.results_dir)
+    print("\n" + md_path.read_text())
+    print(f"\nWrote {json_path}\n      {md_path}")
+
+    hard_fail = any(r.outcome not in NON_FAILING_OUTCOMES for r in results)
+    return 1 if hard_fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -966,11 +966,31 @@ def main() -> int:
     # k8s targets have no `compose_service`, so they run unfiltered (the
     # in-sweep ADAPTER_NO_OP discriminator is still ground truth there).
     results: list[Result] = []
-    compose_service = manifest["targets"][args.target].get("compose_service")
+    target_cfg = manifest["targets"][args.target]
+    compose_service = target_cfg.get("compose_service")
     if not args.no_preflight and compose_service:
         from preflight import run_preflight
-        print(f"\n=== preflight ({len(models)} models) ===", flush=True)
-        pf_results = run_preflight([m["id"] for m in models], compose_service)
+        # The introspection is CPU-only and just needs an image with vLLM + the
+        # fork, so a GPU target can run it in an already-built CPU image
+        # (`preflight_service`, default: the target's compose_service) instead of
+        # triggering a multi-GB GPU image build via `docker compose run`.
+        preflight_service = target_cfg.get("preflight_service", compose_service)
+        print(f"\n=== preflight ({len(models)} models, service={preflight_service}) ===",
+              flush=True)
+        pf_results = run_preflight([m["id"] for m in models], preflight_service)
+        # Log EVERY result, not just the skips: a fail-open (build/introspection
+        # error -> run the model) must be loud, otherwise a wholly-broken preflight
+        # looks identical to "every model predicted OK".
+        for mid in (m["id"] for m in models):
+            r = pf_results.get(mid)
+            if r is None:
+                continue
+            if r.error:
+                print(f"    [preflight] {mid}: ERROR -> fail-open (will run): "
+                      f"{r.error[:160]}", flush=True)
+            else:
+                print(f"    [preflight] {mid}: predicted_ok={r.predicted_ok} "
+                      f"overlap={r.n_overlap}/{r.n_total}", flush=True)
         models, skipped = split_by_preflight(models, pf_results, args.target)
         for s in skipped:
             print(f"--> {s.model}: {s.outcome} ({s.hint})", flush=True)

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -110,6 +110,41 @@ def gate_model(model: dict, target: str, free_gb: list[float]) -> tuple[bool, st
     return True, ""
 
 
+# Container waiting reasons that mean the rollout is broken, not just slow.
+FATAL_WAITING_REASONS = {
+    "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "InvalidImageName",
+    "CreateContainerConfigError", "CreateContainerError", "RunContainerError",
+}
+
+
+def classify_pod_status(pods: list[dict]) -> str:
+    """Classify a namespace's pods for block-and-wait scheduling. Returns:
+      "failed"  - a pod is in a fatal state (crash / bad image / Failed phase);
+                  stop and fail fast (RESTART_FAILED).
+      "ready"   - every pod is Running with all containers ready; proceed.
+      "pending" - nothing fatal yet but not all ready (incl. Pending /
+                  Unschedulable / ContainerCreating); keep waiting for the
+                  scheduler to place the GPU pods.
+    """
+    if not pods:
+        return "pending"
+    all_ready = True
+    for pod in pods:
+        status = pod.get("status", {})
+        if status.get("phase") == "Failed":
+            return "failed"
+        container_statuses = status.get("containerStatuses", [])
+        if not container_statuses or status.get("phase") != "Running":
+            all_ready = False
+        for cs in container_statuses:
+            waiting = cs.get("state", {}).get("waiting")
+            if waiting and waiting.get("reason") in FATAL_WAITING_REASONS:
+                return "failed"
+            if not cs.get("ready", False):
+                all_ready = False
+    return "ready" if all_ready else "pending"
+
+
 def checkpoint_lora_keys_ok(state_dict_keys: list[str] | None) -> bool:
     """True iff the checkpoint's state-dict keys include both LoRA matrices."""
     if not state_dict_keys:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -299,15 +299,11 @@ def serve_check_and_classify(api_url: str, golden_prompt: str, expected_output: 
     last_serve_error = ""
     serve_start = time.time()  # serve_seconds only meaningful when train_status == "COMPLETED"
     if train_status == "COMPLETED" and checkpoint_lora_keys_ok(checkpoint_keys):
-        serve_deadline = time.time() + args.serve_timeout
-        while time.time() < serve_deadline:
-            try:
-                adapter_text = generate(api_url, [golden_prompt], job_hash, args.max_tokens)[0]
-                adapter_loaded = True
-                break
-            except Exception as e:
-                last_serve_error = str(e)
-                time.sleep(5)
+        text, last_serve_error = generate_with_retry(
+            api_url, golden_prompt, job_hash, args.max_tokens,
+            args.serve_timeout, args.generate_timeout)
+        if text is not None:
+            adapter_text, adapter_loaded = text, True
     res.serve_seconds = round(time.time() - serve_start, 1)
 
     memorized = expected_output in adapter_text
@@ -391,14 +387,17 @@ def get_training_job(api_url: str, job_hash: str, timeout: float = 10) -> dict:
 
 
 def generate(api_url: str, prompts: list[str], model_name: str, max_tokens: int,
-              poll_timeout: float = 300, temperature: float = 0.0) -> list[str]:
+              poll_timeout: float = 300, temperature: float = 0.0,
+              request_timeout: float = 30) -> list[str]:
     """POST /v1/generate then poll /v1/generate/get_results until every result has
     a response, raising on any error (mirrors handle_error/poll_for_responses in
     sdk/masint/engines/async_cray.py).
     Default temperature=0.0 ensures greedy-decoding determinism for the no-op
-    discriminator.
+    discriminator. cray serves /v1/generate SYNCHRONOUSLY (the handler blocks until
+    generation finishes), so request_timeout must exceed the per-call latency — the
+    first call after a restart pays cold-start (engine init/CUDA-graph capture +
+    worker warmup, ~146s on the GB10/DGX Spark); see generate_with_retry.
     """
-    request_timeout = 30
     body = json.dumps({
         "prompts": prompts,
         "model": model_name,
@@ -437,6 +436,28 @@ def generate(api_url: str, prompts: list[str], model_name: str, max_tokens: int,
             result = json.loads(r.read())
         if result.get("error"):
             raise RuntimeError(result["error"])
+
+
+def generate_with_retry(api_url: str, prompt: str, model_name: str, max_tokens: int,
+                        deadline_s: float, request_timeout: float) -> tuple[str | None, str]:
+    """Call generate() for a single prompt, retrying every 5s until it succeeds or
+    deadline_s elapses (always at least one attempt). Returns (text, "") on success
+    or (None, last_error) if it never succeeds. Absorbs the cold-start window after
+    a restart, where the first /v1/generate can block past one request_timeout while
+    the engine finishes init/CUDA-graph capture + worker warmup (~146s on the
+    GB10/DGX Spark). The adapter serve path always retried; this gives the baseline
+    generate the same resilience instead of failing the whole run on one timeout."""
+    deadline = time.time() + deadline_s
+    last_error = ""
+    while True:
+        try:
+            return generate(api_url, [prompt], model_name, max_tokens,
+                            request_timeout=request_timeout)[0], ""
+        except Exception as e:
+            last_error = str(e)
+        if time.time() >= deadline:
+            return None, last_error
+        time.sleep(5)
 
 
 # --- k8s command builders (pure) ---
@@ -795,20 +816,22 @@ def run_model_k8s_phased(target_cfg: dict, model_id: str, train_args: dict, data
             return res
 
         # Baseline (control on the base model) -- moved here: vLLM is now up.
-        try:
-            baseline = generate(args.api_url, [golden_prompt], model_id, args.max_tokens)
-            res.baseline_sample = baseline[0][:200]
-            if expected_output in baseline[0]:
-                res.detail = "expected_output already present in baseline output"
-        except Exception as e:
-            res.outcome, res.detail = RESTART_FAILED, f"baseline generate failed: {e}"
+        # Retry across the cold-start window (first generate after scale-up).
+        baseline_text, base_err = generate_with_retry(
+            args.api_url, golden_prompt, model_id, args.max_tokens,
+            args.serve_timeout, args.generate_timeout)
+        if baseline_text is None:
+            res.outcome, res.detail = RESTART_FAILED, f"baseline generate failed: {base_err}"
             return res
+        res.baseline_sample = baseline_text[:200]
+        if expected_output in baseline_text:
+            res.detail = "expected_output already present in baseline output"
 
         # Hot-load + classify (shared with the 2-GPU path); pass the full
         # baseline for the no-op discriminator.
         serve_check_and_classify(args.api_url, golden_prompt, expected_output, job_hash,
                                  train_status, checkpoint_keys, args, res,
-                                 baseline_full=baseline[0])
+                                 baseline_full=baseline_text)
         return res
     finally:
         if pf_proc is not None:
@@ -894,15 +917,19 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                     res.detail = f"stack did not serve {model_id} (health.all/up + /v1/models) in time"
                     return res
 
-            try:
-                baseline = generate(args.api_url, [golden_prompt], model_id, args.max_tokens)
-                res.baseline_sample = baseline[0][:200]
-                if expected_output in baseline[0]:
-                    res.detail = "expected_output already present in baseline output"
-            except Exception as e:
+            # Retry across the cold-start window: health.all/up + /v1/models can
+            # be satisfied before the inference worker finishes warmup, so the
+            # first /v1/generate may block past one request_timeout.
+            baseline_text, base_err = generate_with_retry(
+                args.api_url, golden_prompt, model_id, args.max_tokens,
+                args.serve_timeout, args.generate_timeout)
+            if baseline_text is None:
                 res.outcome = RESTART_FAILED
-                res.detail = f"baseline generate failed: {e}"
+                res.detail = f"baseline generate failed: {base_err}"
                 return res
+            res.baseline_sample = baseline_text[:200]
+            if expected_output in baseline_text:
+                res.detail = "expected_output already present in baseline output"
 
             train_start = time.time()
             try:
@@ -928,7 +955,7 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
             # decoding never applied the LoRA -> ADAPTER_NO_OP.
             serve_check_and_classify(args.api_url, golden_prompt, expected_output, job_hash,
                                      train_status, checkpoint_keys, args, res,
-                                     baseline_full=baseline[0])
+                                     baseline_full=baseline_text)
 
             # If ADAPTER_NO_OP, scrape logs for the a-priori known warning.
             if res.outcome == ADAPTER_NO_OP:
@@ -996,6 +1023,12 @@ def main() -> int:
                          "unaffected. Subsequent --force-recreate builds are cache hits.")
     ap.add_argument("--train-timeout", type=int, default=600)
     ap.add_argument("--serve-timeout", type=int, default=300)
+    ap.add_argument("--generate-timeout", type=int, default=300,
+                    help="per-call /v1/generate socket timeout (s). cray serves "
+                         "generate synchronously, so this must exceed the first "
+                         "post-restart inference latency (engine init/CUDA-graph "
+                         "capture + worker warmup, ~146s on the GB10/DGX Spark). "
+                         "Baseline + adapter calls retry within --serve-timeout.")
     ap.add_argument("--gpu-wait-timeout", type=int, default=7200,
                     help="k8s only: seconds to block while pods are Unschedulable "
                          "(GPUs busy) before giving up with RESTART_FAILED")

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -371,6 +371,13 @@ def k8s_helm_install_cmd(target_cfg: dict, namespace: str, model_id: str) -> lis
         "--set", "storage.cache.kind=hostPath",
         "--set", f"storage.cache.hostPath={target_cfg['cache_hostpath']}",
     ]
+    # Right-size the jobs PVC per target (chart default is 100Gi). Lets a small
+    # model claim e.g. 20Gi so its Longhorn replica fits under the node's
+    # scheduling ceiling. Omitted -> chart default applies. NOTE: the jobs PVC
+    # has helm.sh/resource-policy: keep and PVCs can't shrink, so a changed size
+    # only takes effect on a freshly provisioned namespace, not an in-place upgrade.
+    if "jobs_size" in target_cfg:
+        cmd += ["--set", f"storage.jobs.size={target_cfg['jobs_size']}"]
     if target_cfg.get("phase_scaled"):
         # Phase 0: megatron holds the single GPU; vLLM is off until the phase-2
         # handoff. Use replicaCounts, NOT vllm.enabled=false (which drops the

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -192,20 +192,38 @@ def preflight_hint(pf_result) -> str:
             f"vs base {pf_result.sample_base_modules}")
 
 
+def is_gated_repo_error(error: str) -> bool:
+    """True iff a preflight error is an HF gated-repo / auth failure (401). Unlike
+    a transient build/introspection crash (which fails open), this is
+    deterministic — the model can't load without access — so the sweep SKIPs it
+    rather than paying a doomed restart + train + serve that ends in the same 401."""
+    e = error.lower()
+    return "gated repo" in e or "401 client error" in e
+
+
 def split_by_preflight(models: list[dict], pf_results: dict,
                        target: str) -> tuple[list[dict], list["Result"]]:
     """Partition `models` into (to_run, skipped) using the offline preflight.
     A model whose PreflightResult `predicted_noop` is True (zero module overlap,
-    no build error) is excluded and recorded as a PRECHECK_NO_OP Result with a
-    key-diff hint. Models with no entry, or whose preflight errored (fail open),
-    stay in to_run — a preflight crash never silently skips a model."""
+    no build error) is excluded as a PRECHECK_NO_OP Result with a key-diff hint;
+    a model whose preflight hit an HF gated-repo/401 error is excluded as SKIPPED
+    (deterministic — no point running it). Models with no entry, or whose preflight
+    errored for any OTHER reason (fail open), stay in to_run — a preflight crash
+    never silently skips a model."""
     to_run: list[dict] = []
     skipped: list[Result] = []
     for m in models:
         pf = pf_results.get(m["id"])
-        if pf is not None and pf.predicted_noop:
+        if pf is None:
+            to_run.append(m)
+        elif pf.predicted_noop:
             skipped.append(Result(model=m["id"], target=target,
                                   outcome=PRECHECK_NO_OP, hint=preflight_hint(pf)))
+        elif pf.error and is_gated_repo_error(pf.error):
+            skipped.append(Result(model=m["id"], target=target, outcome=SKIPPED,
+                                  detail="gated HF repo (preflight 401) — request access "
+                                         "or wire HF_TOKEN into the compose env",
+                                  hint=pf.error[:120]))
         else:
             to_run.append(m)
     return to_run, skipped
@@ -248,22 +266,64 @@ def get_served_models(api_url: str, timeout: float = 5) -> set[str]:
         return set()
 
 
-def wait_for_model_served(api_url: str, model_id: str, proc, timeout: float) -> bool:
+def get_compose_restart_count(compose_service: str, timeout: float = 10) -> int | None:
+    """The Docker RestartCount of the compose service's container, or None if it
+    can't be read. A value that climbs during wait_for_model_served means a crashed
+    vLLM is being restart-looped by `restart: unless-stopped` (PID 1 is
+    `one_server.main` under `set -e`, so a crash exits the container) — a broken
+    model, not a slow one. The k8s path has no Compose container, so its callers
+    pass compose_service=None and skip this."""
+    try:
+        cid = subprocess.run(
+            ["docker", "compose", "-f", "docker-compose.yaml", "ps", "-q", compose_service],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=timeout, check=True,
+        ).stdout.strip()
+        if not cid:
+            return None
+        rc = subprocess.run(
+            ["docker", "inspect", "--format", "{{.RestartCount}}", cid],
+            cwd=REPO_ROOT, capture_output=True, text=True, timeout=timeout, check=True,
+        ).stdout.strip()
+        return int(rc)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError):
+        return None
+
+
+def wait_for_model_served(api_url: str, model_id: str, proc, timeout: float,
+                          compose_service: str | None = None,
+                          crash_check_every: float = 15.0) -> str:
     """Like wait_for_all_up, but also requires the served model to be `model_id`.
     The Compose teardown leaves the previous model's container running (see
     teardown_stack), so health.all=="up" alone can be satisfied by the STALE
     stack before `--force-recreate` swaps in the new model — gating on
     /v1/models too makes the runner block until the new container is actually
-    serving model_id."""
+    serving model_id. Returns:
+      "served"      - health.all up AND /v1/models serves model_id.
+      "crashed"     - the container's RestartCount climbed: vLLM crashed and
+                      `restart: unless-stopped` is restart-looping it. Fail fast
+                      instead of waiting out `timeout` (the foreground `docker
+                      compose up` survives container restarts, so proc never dies).
+      "proc_exited" - the foreground `./scalarlm up` process died.
+      "timeout"     - none of the above within `timeout`.
+    Pass compose_service to enable crash detection (Compose only)."""
     deadline = time.time() + timeout
+    baseline_restarts = (get_compose_restart_count(compose_service)
+                         if compose_service else None)
+    last_crash_check = time.time()
     while time.time() < deadline:
         if proc is not None and proc.poll() is not None:
-            return False
+            return "proc_exited"
         health = get_health(api_url)
         if health and health.get("all") == "up" and model_id in get_served_models(api_url):
-            return True
+            return "served"
+        if (compose_service and baseline_restarts is not None
+                and time.time() - last_crash_check >= crash_check_every):
+            last_crash_check = time.time()
+            rc = get_compose_restart_count(compose_service)
+            if rc is not None and rc > baseline_restarts:
+                return "crashed"
         time.sleep(2)
-    return False
+    return "timeout"
 
 
 def poll_training(api_url: str, job_hash: str, train_timeout: float) -> str:
@@ -914,11 +974,22 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
                 # Model-aware wait: a stale (previous-model) container left
                 # running by teardown_stack is still health.all=="up", so we
                 # also gate on /v1/models serving model_id before proceeding.
-                ready = wait_for_model_served(args.api_url, model_id, proc, args.restart_timeout)
+                # Pass compose_service so a crash-looping vLLM fails fast (a model
+                # that crashes the engine would otherwise hang the whole
+                # restart_timeout while restart:unless-stopped re-inits it).
+                status = wait_for_model_served(args.api_url, model_id, proc,
+                                               args.restart_timeout,
+                                               compose_service=target_cfg["compose_service"])
                 res.restart_seconds = round(time.time() - restart_start, 1)
-                if not ready:
+                if status != "served":
                     res.outcome = RESTART_FAILED
-                    res.detail = f"stack did not serve {model_id} (health.all/up + /v1/models) in time"
+                    res.detail = {
+                        "crashed": f"vLLM crash-looped serving {model_id} "
+                                   f"(container RestartCount climbed)",
+                        "proc_exited": f"`./scalarlm up` exited before serving {model_id}",
+                        "timeout": f"stack did not serve {model_id} "
+                                   f"(health.all/up + /v1/models) within {args.restart_timeout}s",
+                    }.get(status, f"stack did not serve {model_id}")
                     return res
 
             # Retry across the cold-start window: health.all/up + /v1/models can
@@ -1072,7 +1143,9 @@ def main() -> int:
             if r is None:
                 continue
             if r.error:
-                print(f"    [preflight] {mid}: ERROR -> fail-open (will run): "
+                tag = ("gated repo -> SKIP" if is_gated_repo_error(r.error)
+                       else "fail-open (will run)")
+                print(f"    [preflight] {mid}: ERROR -> {tag}: "
                       f"{r.error[:160]}", flush=True)
             else:
                 print(f"    [preflight] {mid}: predicted_ok={r.predicted_ok} "

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -274,7 +274,11 @@ def poll_training(api_url: str, job_hash: str, train_timeout: float) -> str:
     while time.time() < deadline:
         try:
             info = get_training_job(api_url, job_hash)
-        except (urllib.error.URLError, RuntimeError):
+        except (OSError, RuntimeError):
+            # OSError covers urllib.error.URLError AND raw socket errors like
+            # ConnectionResetError (Errno 104) — the co-located training job can
+            # saturate the GPU and make the API server briefly reset connections;
+            # retry until train_timeout instead of crashing the run.
             time.sleep(5)
             continue
         st = info.get("status")

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -216,6 +216,46 @@ def poll_training(api_url: str, job_hash: str, train_timeout: float) -> str:
     return "TIMEOUT"
 
 
+def serve_check_and_classify(api_url: str, golden_prompt: str, expected_output: str,
+                             job_hash: str, train_status: str,
+                             checkpoint_keys: list[str] | None, args, res: "Result") -> None:
+    """Hot-load the trained adapter, classify the outcome, and set the result
+    fields (serve_seconds, outcome, adapter_sample, detail). Shared by the 2-GPU
+    and phase-scaled k8s paths; the caller reads `checkpoint_keys` first (the read
+    mechanism differs per path)."""
+    adapter_loaded = False
+    adapter_text = ""
+    last_serve_error = ""
+    serve_start = time.time()  # serve_seconds only meaningful when train_status == "COMPLETED"
+    if train_status == "COMPLETED" and checkpoint_lora_keys_ok(checkpoint_keys):
+        serve_deadline = time.time() + args.serve_timeout
+        while time.time() < serve_deadline:
+            try:
+                adapter_text = generate(api_url, [golden_prompt], job_hash, args.max_tokens)[0]
+                adapter_loaded = True
+                break
+            except Exception as e:
+                last_serve_error = str(e)
+                time.sleep(5)
+    res.serve_seconds = round(time.time() - serve_start, 1)
+
+    memorized = expected_output in adapter_text
+    res.outcome = classify_result(train_status, checkpoint_keys, adapter_loaded, memorized)
+    res.adapter_sample = adapter_text[:200]
+
+    if res.outcome == TRAIN_FAILED:
+        res.detail = f"job ended with status {train_status}"
+    elif res.outcome == TRAIN_TIMEOUT:
+        res.detail = f"job did not reach a terminal status within {args.train_timeout}s"
+    elif res.outcome == BAD_CHECKPOINT:
+        res.detail = f"checkpoint keys: {checkpoint_keys}"
+    elif res.outcome == ADAPTER_NOT_LOADED:
+        res.detail = f"adapter never became servable; last error: {last_serve_error}"
+    elif res.outcome == NO_MEMORIZATION:
+        extra = "adapter served but did not memorize expected_output"
+        res.detail = f"{res.detail}; {extra}" if res.detail else extra
+
+
 def build_dataset_tar(dataset: list[dict]) -> bytes:
     """In-memory tar containing dataset.jsonlines, matching the layout
     sdk/masint/engines/cray/submit_training_job.py builds."""
@@ -630,44 +670,13 @@ def run_model(manifest: dict, target: str, model: dict, args, results_dir: Path)
             res.train_seconds = round(time.time() - train_start, 1)
 
             checkpoint_keys: list[str] | None = None
-            adapter_loaded = False
-            adapter_text = ""
-            last_serve_error = ""
-            serve_start = time.time()  # only meaningful if train_status == "COMPLETED"
-
             if train_status == "COMPLETED":
                 if is_k8s:
                     checkpoint_keys = read_checkpoint_keys_k8s(target_cfg, namespace, job_hash)
                 else:
                     checkpoint_keys = read_checkpoint_keys(target_cfg["compose_service"], job_hash)
-                if checkpoint_lora_keys_ok(checkpoint_keys):
-                    serve_deadline = time.time() + args.serve_timeout
-                    while time.time() < serve_deadline:
-                        try:
-                            adapter_out = generate(args.api_url, [golden_prompt], job_hash, args.max_tokens)
-                            adapter_text = adapter_out[0]
-                            adapter_loaded = True
-                            break
-                        except Exception as e:
-                            last_serve_error = str(e)
-                            time.sleep(5)
-            res.serve_seconds = round(time.time() - serve_start, 1)
-
-            memorized = expected_output in adapter_text
-            res.outcome = classify_result(train_status, checkpoint_keys, adapter_loaded, memorized)
-            res.adapter_sample = adapter_text[:200]
-
-            if res.outcome == TRAIN_FAILED:
-                res.detail = f"job ended with status {train_status}"
-            elif res.outcome == TRAIN_TIMEOUT:
-                res.detail = f"job did not reach a terminal status within {args.train_timeout}s"
-            elif res.outcome == BAD_CHECKPOINT:
-                res.detail = f"checkpoint keys: {checkpoint_keys}"
-            elif res.outcome == ADAPTER_NOT_LOADED:
-                res.detail = f"adapter never became servable; last error: {last_serve_error}"
-            elif res.outcome == NO_MEMORIZATION:
-                extra = "adapter served but did not memorize expected_output"
-                res.detail = f"{res.detail}; {extra}" if res.detail else extra
+            serve_check_and_classify(args.api_url, golden_prompt, expected_output, job_hash,
+                                     train_status, checkpoint_keys, args, res)
             return res
         finally:
             if is_k8s:

--- a/test/finetune_sweep/run_finetune_sweep.py
+++ b/test/finetune_sweep/run_finetune_sweep.py
@@ -93,12 +93,13 @@ def k8s_namespace(prefix: str, model_id: str) -> str:
     return f"{prefix}-{slug}"[:63].rstrip("-")
 
 
-def gate_model(model: dict, target: str, free_gb: list[float] | None) -> tuple[bool, str]:
-    """Decide whether `model` should run on `target`. cpu is opt-in via cpu_ok;
-    cuda is gated on the LoRA VRAM gate vs. probed free VRAM. `free_gb is None`
-    means the VRAM check is not applicable (k8s: the scheduler arbitrates GPU
-    fit) — only the static checks apply."""
-    if target == "cpu":
+def gate_model(model: dict, target_cfg: dict, free_gb: list[float] | None) -> tuple[bool, str]:
+    """Decide whether `model` should run on this target. A CPU target (no GPU
+    requested) is opt-in via cpu_ok; a GPU target is gated on the LoRA VRAM gate
+    vs. probed free VRAM. `free_gb is None` means the VRAM check is not applicable
+    (k8s: the scheduler arbitrates GPU fit) — only the static checks apply.
+    Branches on target config (target_requests_gpu), not the literal target name."""
+    if not target_requests_gpu(target_cfg):
         if not model.get("cpu_ok"):
             return False, "no cpu_ok opt-in for this model"
         return True, ""

--- a/test/integration/vllm/test_preflight_two_pass_fidelity.py
+++ b/test/integration/vllm/test_preflight_two_pass_fidelity.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""In-image two-pass fidelity test for the fine-tune sweep preflight.
+
+Runs inside the cray image (needs torch + the vLLM fork); a no-op on the host.
+For a decoder-only model whose vLLM tree is ``model.layers.*``
+(``Qwen/Qwen2.5-0.5B``), the trainer's synthesized LoRA keys overlap the vLLM
+module set ONLY AFTER BOTH passes of the fork's serve-time normalization:
+
+  pass 1  ``normalize_lora_key``             -- statically OVER-maps
+                                               ``model.layers.*`` to
+                                               ``language_model.model.layers.*``
+  pass 2  ``_renormalize_lora_sd_for_model`` -- detects the live ``model.layers.``
+                                               prefix and corrects pass 1
+
+A one-pass (or HF-meta) check would mispredict this model as a silent no-op and
+wrongly skip it with ``PRECHECK_NO_OP``. This is the regression that justifies
+running the preflight through the *real* ``_renormalize_lora_sd_for_model`` (see
+docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md and
+ADR 0003's 2026-06-18 amendment).
+
+The torch-free seams (key synthesis, overlap, JSON parsing, classify_result) are
+covered on the host in test/unit/test_finetune_sweep_preflight.py; this file is
+the in-image complement and is guarded with ``importorskip`` so it skips cleanly
+where torch/vLLM are unavailable.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SWEEP_DIR = REPO_ROOT / "test" / "finetune_sweep"
+
+# Make the fork importable the same way the sibling in-image tests do; in the
+# cray image the PYTHONPATH already includes it, so this is host-robustness only.
+_VLLM_DIR = str(REPO_ROOT / "vllm")
+if _VLLM_DIR not in sys.path:
+    sys.path.insert(0, _VLLM_DIR)
+
+# Skip the whole module off-image (no torch / no fork) rather than erroring.
+pytest.importorskip("torch")
+pytest.importorskip("vllm.tokenformer.adapter_format")
+
+# A decoder-only model whose vLLM tree is `model.layers.*` — the exact case a
+# one-pass check mispredicts. Already in the sweep manifest, so it is cached.
+FIDELITY_MODEL = "Qwen/Qwen2.5-0.5B"
+
+
+def _load_preflight():
+    """Load the host-side preflight module (torch-free) to reach its REAL
+    in-container script body, `_INTROSPECT_SCRIPT`."""
+    spec = importlib.util.spec_from_file_location(
+        "preflight", _SWEEP_DIR / "preflight.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_introspection(model_id: str) -> dict:
+    """Execute the preflight's ACTUAL in-container script body (not a copy) and
+    return its result dict, so this test can never drift from what the preflight
+    runs at sweep time. `__name__` is set to something other than `__main__` so
+    the script's CLI block (which prints JSON) does not fire."""
+    pf = _load_preflight()
+    ns: dict = {"__name__": "preflight_introspect_test"}
+    exec(pf._INTROSPECT_SCRIPT, ns)  # noqa: S102 -- running the real script body is the point
+    return ns["run_introspection"](model_id)
+
+
+def test_pass1_alone_overmaps_decoder_keys():
+    """Pass 1 statically over-maps `model.layers.*` -> `language_model.model.
+    layers.*`. Against Qwen2.5's real `model.layers.*` tree that lands nowhere —
+    so a one-pass overlap check would predict a (false) no-op. This documents
+    *why* pass 2 is required; the next test shows pass 2 fixing it."""
+    from vllm.tokenformer.adapter_format import normalize_lora_key
+
+    key = "model.layers.0.self_attn.q_proj.lora_A.default.weight"
+    normalized = normalize_lora_key(key)
+    assert normalized.startswith("language_model.model.layers."), (
+        f"expected pass 1 to over-map the decoder key, got {normalized!r}")
+
+
+def test_two_pass_normalization_overlaps_decoder_tree():
+    """The full two-pass normalization (the real script body, against a meta
+    device build of Qwen2.5's vLLM tree) lands the synthesized keys back on
+    `model.layers.*` -> predicted_ok with non-zero overlap. A one-pass / HF-meta
+    check would mispredict this model as a silent no-op."""
+    result = _run_introspection(FIDELITY_MODEL)
+
+    assert not result.get("error"), \
+        f"meta-tree introspection failed: {result.get('error')}"
+    assert result["predicted_ok"] is True, \
+        f"two-pass overlap was zero — pass 2 regressed? result={result}"
+    assert result["n_overlap"] > 0
+    # Sanity: the synthesized target set is non-trivial (q/k/v/o + gate/up/down,
+    # collapsed by q/k/v and gate/up fusion in the vLLM tree).
+    assert result["n_total"] > 0

--- a/test/unit/test_doc_mask_decision.py
+++ b/test/unit/test_doc_mask_decision.py
@@ -1,0 +1,69 @@
+"""
+Unit tests for cray_megatron.megatron.doc_mask.doc_mask_decision.
+
+The trainer packs short documents into one block and builds a 4D
+block-diagonal+causal attention mask so packed docs don't attend across each
+other. Text decoders accept the 4D mask; some ...ForConditionalGeneration
+wrappers (e.g. Gemma3ForConditionalGeneration) compute their loss internally and
+index the logits by a *2D* attention_mask, so a 4D mask raises
+`IndexError: too many indices for tensor of dimension 3` — the gemma-3-4b-it
+TRAIN_FAILED. For those models we fall back to the 2D mask. These tests use
+lightweight fakes (a dict batch + a config stub) so they don't import the heavy
+training_loop module (gpu_aware_mpi / mpi).
+"""
+
+from types import SimpleNamespace
+
+from cray_megatron.megatron.doc_mask import (
+    BUILD,
+    NONE,
+    SKIP_MULTIMODAL,
+    SKIP_SEQLEN,
+    doc_mask_decision,
+    is_multimodal,
+)
+
+CAP = 16384
+
+
+def _text_config():
+    return SimpleNamespace(model_type="llama")  # no vision_config attribute
+
+
+def _multimodal_config():
+    return SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+
+
+def test_packed_text_model_builds_4d_mask():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, 128, _text_config(), CAP) == BUILD
+
+
+def test_multimodal_skips_4d_mask_even_when_packed_and_short():
+    batch = {"document_ids": object()}
+    # The whole point of the fix: a vision-config wrapper must NOT get the 4D mask.
+    assert doc_mask_decision(batch, 128, _multimodal_config(), CAP) == SKIP_MULTIMODAL
+
+
+def test_seqlen_over_cap_skips_for_text_model():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _text_config(), CAP) == SKIP_SEQLEN
+
+
+def test_multimodal_skip_takes_precedence_over_seqlen():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _multimodal_config(), CAP) == SKIP_MULTIMODAL
+
+
+def test_unpacked_batch_is_none():
+    assert doc_mask_decision({}, 128, _text_config(), CAP) == NONE
+    # Even a multimodal model with no packing needs no special handling.
+    assert doc_mask_decision({}, 128, _multimodal_config(), CAP) == NONE
+
+
+def test_is_multimodal_predicate():
+    assert is_multimodal(_multimodal_config()) is True
+    assert is_multimodal(_text_config()) is False
+    assert is_multimodal(None) is False
+    # vision_config present but None must read as not-multimodal.
+    assert is_multimodal(SimpleNamespace(vision_config=None)) is False

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -60,3 +60,44 @@ def test_classify_imagepull_is_failed():
 
 def test_classify_failed_phase_is_failed():
     assert rfs.classify_pod_status([{"status": {"phase": "Failed"}}]) == "failed"
+
+CUDA_CFG = {
+    "chart_path": "deployment/helm/scalarlm",
+    "release": "scalarlm",
+    "namespace_prefix": "sweep",
+    "megatron_sts": "scalarlm-megatron",
+    "api_service": "scalarlm",
+    "cache_hostpath": "/root/.cache",
+    "gpu_wait_timeout": 7200,
+}
+
+def test_is_k8s_target_true_for_chart_path():
+    assert rfs.is_k8s_target(CUDA_CFG) is True
+
+def test_is_k8s_target_false_for_compose():
+    assert rfs.is_k8s_target({"compose_service": "cray", "restart_cmd": "x"}) is False
+
+def test_helm_install_cmd():
+    cmd = rfs.k8s_helm_install_cmd(CUDA_CFG, "sweep-qwen", "Qwen/Qwen2.5-0.5B")
+    assert cmd[:5] == ["helm", "upgrade", "--install", "scalarlm", "deployment/helm/scalarlm"]
+    assert "-n" in cmd and "sweep-qwen" in cmd and "--create-namespace" in cmd
+    assert "model=Qwen/Qwen2.5-0.5B" in cmd
+    assert "storage.cache.kind=hostPath" in cmd
+    assert "storage.cache.hostPath=/root/.cache" in cmd
+
+def test_delete_namespace_cmd():
+    assert rfs.k8s_delete_namespace_cmd("sweep-qwen") == [
+        "kubectl", "delete", "namespace", "sweep-qwen", "--ignore-not-found", "--wait"]
+
+def test_port_forward_cmd():
+    assert rfs.k8s_port_forward_cmd(CUDA_CFG, "sweep-qwen") == [
+        "kubectl", "port-forward", "-n", "sweep-qwen", "svc/scalarlm", "8000:8000"]
+
+def test_exec_checkpoint_cmd_targets_statefulset():
+    cmd = rfs.k8s_exec_checkpoint_cmd(CUDA_CFG, "sweep-qwen", "print(1)")
+    assert cmd == ["kubectl", "exec", "-n", "sweep-qwen",
+                   "statefulset/scalarlm-megatron", "--", "python3", "-c", "print(1)"]
+
+def test_get_pods_cmd():
+    assert rfs.k8s_get_pods_cmd("sweep-qwen") == [
+        "kubectl", "get", "pods", "-n", "sweep-qwen", "-o", "json"]

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -121,3 +121,8 @@ def test_kubectl_get_pods_parses_items(monkeypatch):
         stdout = '{"items": [{"status": {"phase": "Running"}}]}'
     monkeypatch.setattr(rfs.subprocess, "run", lambda *a, **k: _R())
     assert rfs.kubectl_get_pods("sweep-qwen") == [{"status": {"phase": "Running"}}]
+
+def test_wait_for_all_up_accepts_none_proc(monkeypatch):
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"all": "up"})
+    # proc=None must not raise and must return True when health is up.
+    assert rfs.wait_for_all_up("http://localhost:8000", None, timeout=1) is True

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -342,3 +342,19 @@ def test_target_requests_gpu_defaults_true_when_unset():
     # JobConfig defaults gpus=1, so a target with no override requests a GPU.
     assert rfs.target_requests_gpu({}) is True
     assert rfs.target_requests_gpu({"train_args_overrides": {}}) is True
+
+def test_manifest_targets_dispatch_correctly():
+    manifest = rfs.load_manifest(rfs.DEFAULT_MANIFEST)
+    targets = manifest["targets"]
+    # cuda-docker: Compose lifecycle (not k8s) + GPU probe path
+    assert "cuda-docker" in targets
+    assert rfs.is_k8s_target(targets["cuda-docker"]) is False
+    assert rfs.target_requests_gpu(targets["cuda-docker"]) is True
+    assert targets["cuda-docker"]["compose_service"] == "cray-nvidia"
+    # cuda-k8s: k8s lifecycle (renamed from cuda) + GPU
+    assert "cuda-k8s" in targets and "cuda" not in targets
+    assert rfs.is_k8s_target(targets["cuda-k8s"]) is True
+    assert rfs.target_requests_gpu(targets["cuda-k8s"]) is True
+    # cpu: Compose lifecycle, no GPU
+    assert rfs.is_k8s_target(targets["cpu"]) is False
+    assert rfs.target_requests_gpu(targets["cpu"]) is False

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -183,6 +183,26 @@ def test_gate_model_gpu_still_gates_on_free_gb_list():
     assert rfs.gate_model(model, gpu_cfg, [4.0])[0] is False   # not enough free
     assert rfs.gate_model(model, gpu_cfg, [16.0])[0] is True   # enough free
 
+def test_build_train_args_layers_defaults_target_and_fixed():
+    manifest = {"train_args_defaults": {"dtype": "float32", "max_steps": 60}}
+    target_cfg = {"train_args_overrides": {"gpus": 1}}
+    ta = rfs.build_train_args(manifest, target_cfg, {"id": "m"}, "run-123")
+    assert ta == {"llm_name": "m", "dtype": "float32", "max_steps": 60,
+                  "gpus": 1, "sweep_run_id": "run-123"}
+
+def test_build_train_args_per_model_overrides_default():
+    manifest = {"train_args_defaults": {"dtype": "float32", "max_steps": 60}}
+    model = {"id": "Qwen/Qwen2.5-32B-Instruct", "train_args": {"dtype": "bfloat16"}}
+    ta = rfs.build_train_args(manifest, {"train_args_overrides": {"gpus": 1}}, model, "r")
+    assert ta["dtype"] == "bfloat16"   # per-model wins over the float32 default
+    assert ta["max_steps"] == 60 and ta["gpus"] == 1  # others untouched
+
+def test_build_train_args_per_model_overrides_target():
+    manifest = {"train_args_defaults": {"dtype": "float32"}}
+    model = {"id": "m", "train_args": {"gpus": 2}}
+    ta = rfs.build_train_args(manifest, {"train_args_overrides": {"gpus": 1}}, model, "r")
+    assert ta["gpus"] == 2  # most-specific (per-model) layer wins
+
 def test_gate_model_cpu_requires_cpu_ok_optin():
     cpu_cfg = {"train_args_overrides": {"gpus": 0}}
     assert rfs.gate_model({"id": "m"}, cpu_cfg, [])[0] is False           # no cpu_ok

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -163,3 +163,17 @@ def test_wait_for_all_up_default_key_is_all(monkeypatch):
     monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"vllm": "up", "all": "down"})
     monkeypatch.setattr(rfs.time, "sleep", lambda s: None)  # don't actually sleep 2s
     assert rfs.wait_for_all_up("http://x", None, timeout=0.01) is False  # no health_key -> default "all" -> False
+
+def test_k8s_scale_cmd():
+    assert rfs.k8s_scale_cmd("statefulset/scalarlm-megatron", 0, "sweep-qwen") == [
+        "kubectl", "scale", "statefulset/scalarlm-megatron", "--replicas=0", "-n", "sweep-qwen"]
+
+def test_kubectl_scale_true_on_success(monkeypatch):
+    monkeypatch.setattr(rfs.subprocess, "run", lambda *a, **k: None)
+    assert rfs.kubectl_scale("deployment/scalarlm-vllm", 1, "sweep-qwen", log=None) is True
+
+def test_kubectl_scale_false_on_error(monkeypatch):
+    def boom(*a, **k):
+        raise rfs.subprocess.CalledProcessError(1, a[0])
+    monkeypatch.setattr(rfs.subprocess, "run", boom)
+    assert rfs.kubectl_scale("deployment/scalarlm-vllm", 1, "sweep-qwen", log=None) is False

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -178,6 +178,35 @@ def test_vram_for_gate_empty_when_no_gpu_visible():
 def test_vram_for_gate_passes_through_numeric_free():
     assert rfs._vram_for_gate([16.0], 1) == [16.0]
 
+def test_generate_with_retry_returns_on_first_success(monkeypatch):
+    monkeypatch.setattr(rfs, "generate", lambda *a, **k: ["hello"])
+    text, err = rfs.generate_with_retry("u", "p", "m", 8, deadline_s=10, request_timeout=5)
+    assert text == "hello" and err == ""
+
+def test_generate_with_retry_retries_then_succeeds(monkeypatch):
+    # The first attempt fails (cold-start window after a restart); the retry wins.
+    calls = {"n": 0}
+    def flaky(*a, **k):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("warming up")
+        return ["ok"]
+    monkeypatch.setattr(rfs, "generate", flaky)
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    text, err = rfs.generate_with_retry("u", "p", "m", 8, deadline_s=10, request_timeout=5)
+    assert text == "ok" and calls["n"] == 2
+
+def test_generate_with_retry_gives_up_after_deadline_but_attempts_once(monkeypatch):
+    # deadline_s=0 still makes exactly one attempt, then reports the last error.
+    calls = {"n": 0}
+    def always_timeout(*a, **k):
+        calls["n"] += 1
+        raise TimeoutError("timed out")
+    monkeypatch.setattr(rfs, "generate", always_timeout)
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    text, err = rfs.generate_with_retry("u", "p", "m", 8, deadline_s=0, request_timeout=5)
+    assert text is None and "timed out" in err and calls["n"] == 1
+
 def test_kubectl_get_pods_returns_empty_on_called_process_error(monkeypatch):
     def _boom(*a, **k):
         raise rfs.subprocess.CalledProcessError(1, "kubectl")
@@ -265,9 +294,10 @@ class _ServeArgs:  # minimal stand-in for the argparse Namespace fields used her
     serve_timeout = 1
     train_timeout = 60
     max_tokens = 32
+    generate_timeout = 1
 
 def test_serve_check_sets_pass_on_memorization(monkeypatch):
-    monkeypatch.setattr(rfs, "generate", lambda api, prompts, jh, mt: ["... SECRET123 ..."])
+    monkeypatch.setattr(rfs, "generate", lambda api, prompts, jh, mt, **k: ["... SECRET123 ..."])
     res = rfs.Result(model="m", target="cuda")
     rfs.serve_check_and_classify("http://x", "p", "SECRET123", "abc", "COMPLETED",
                                  ["base.lora_A.weight", "base.lora_B.weight"], _ServeArgs(), res)
@@ -309,13 +339,14 @@ def test_run_model_k8s_phased_orders_gpu_handoff(monkeypatch, tmp_path):
     monkeypatch.setattr(rfs, "wait_for_pods_gone", lambda *a, **k: "gone")
     # baseline (model="Qwen/...") has no secret; adapter (model="abc") memorizes it.
     monkeypatch.setattr(rfs, "generate",
-                        lambda api, prompts, model, mt: ["x SECRET123 y"] if model == "abc"
+                        lambda api, prompts, model, mt, **k: ["x SECRET123 y"] if model == "abc"
                         else ["plain baseline"])
     monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
 
     cfg = {**CUDA_CFG, "vllm_deploy": "scalarlm-vllm", "phase_scaled": True}
     args = type("A", (), {"api_url": "http://x", "restart_timeout": 1, "serve_timeout": 1,
-                          "train_timeout": 1, "max_tokens": 32, "gpu_wait_timeout": 1})()
+                          "train_timeout": 1, "max_tokens": 32, "gpu_wait_timeout": 1,
+                          "generate_timeout": 1})()
     res = rfs.Result(model="Qwen/Qwen2.5-0.5B", target="cuda")
     with open(tmp_path / "log.txt", "w") as log:
         out = rfs.run_model_k8s_phased(cfg, "Qwen/Qwen2.5-0.5B", {}, [], "p", "SECRET123",
@@ -342,7 +373,8 @@ def test_run_model_k8s_phased_fails_fast_on_scale_down(monkeypatch, tmp_path):
 
     cfg = {**CUDA_CFG, "vllm_deploy": "scalarlm-vllm", "phase_scaled": True}
     args = type("A", (), {"api_url": "http://x", "restart_timeout": 1, "serve_timeout": 1,
-                          "train_timeout": 1, "max_tokens": 32, "gpu_wait_timeout": 1})()
+                          "train_timeout": 1, "max_tokens": 32, "gpu_wait_timeout": 1,
+                          "generate_timeout": 1})()
     res = rfs.Result(model="Qwen/Qwen2.5-0.5B", target="cuda")
     with open(tmp_path / "log.txt", "w") as log:
         out = rfs.run_model_k8s_phased(cfg, "Qwen/Qwen2.5-0.5B", {}, [], "p", "SECRET123",

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -85,6 +85,16 @@ def test_helm_install_cmd():
     assert "storage.cache.kind=hostPath" in cmd
     assert "storage.cache.hostPath=/root/.cache" in cmd
 
+def test_helm_install_cmd_omits_jobs_size_by_default():
+    # No jobs_size in cfg -> no override, chart default (100Gi) applies.
+    cmd = rfs.k8s_helm_install_cmd(CUDA_CFG, "sweep-qwen", "Qwen/Qwen2.5-0.5B")
+    assert not any(c.startswith("storage.jobs.size=") for c in cmd)
+
+def test_helm_install_cmd_sets_jobs_size_when_configured():
+    cfg = {**CUDA_CFG, "jobs_size": "20Gi"}
+    cmd = rfs.k8s_helm_install_cmd(cfg, "sweep-qwen", "Qwen/Qwen2.5-0.5B")
+    assert "storage.jobs.size=20Gi" in cmd
+
 def test_delete_namespace_cmd():
     assert rfs.k8s_delete_namespace_cmd("sweep-qwen") == [
         "kubectl", "delete", "namespace", "sweep-qwen", "--ignore-not-found", "--wait"]

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -289,6 +289,21 @@ def test_poll_training_times_out(monkeypatch):
     monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
     assert rfs.poll_training("http://x", "abc", train_timeout=0.01) == "TIMEOUT"
 
+def test_poll_training_retries_on_connection_reset(monkeypatch):
+    # The API server can reset the connection mid-training (GPU saturated by the
+    # co-located training job). ConnectionResetError is an OSError, not a URLError;
+    # poll_training must retry, not crash the whole run.
+    calls = {"n": 0}
+    def flaky(url, jh, timeout=10):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ConnectionResetError(104, "Connection reset by peer")
+        return {"status": "COMPLETED"}
+    monkeypatch.setattr(rfs, "get_training_job", flaky)
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    assert rfs.poll_training("http://x", "abc", train_timeout=5) == "COMPLETED"
+    assert calls["n"] == 2
+
 
 class _ServeArgs:  # minimal stand-in for the argparse Namespace fields used here
     serve_timeout = 1

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -153,3 +153,13 @@ def test_kubectl_get_pods_returns_empty_on_bad_json(monkeypatch):
         stdout = "not json"
     monkeypatch.setattr(rfs.subprocess, "run", lambda *a, **k: _R())
     assert rfs.kubectl_get_pods("sweep-qwen") == []
+
+def test_wait_for_all_up_gates_on_health_key(monkeypatch):
+    # `all` is down, but the vllm component is up -> gating on "vllm" succeeds.
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"vllm": "up", "all": "down"})
+    assert rfs.wait_for_all_up("http://x", None, timeout=1, health_key="vllm") is True
+
+def test_wait_for_all_up_default_key_is_all(monkeypatch):
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"vllm": "up", "all": "down"})
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)  # don't actually sleep 2s
+    assert rfs.wait_for_all_up("http://x", None, timeout=0.01) is False  # no health_key -> default "all" -> False

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -214,3 +214,12 @@ def test_helm_install_cmd_phase_scaled_sets_replica_counts():
     cmd = rfs.k8s_helm_install_cmd(cfg, "sweep-qwen", "Qwen/Qwen2.5-0.5B")
     assert "replicaCounts.inference=0" in cmd  # vLLM off in phase 0/1
     assert "replicaCounts.training=1" in cmd   # megatron holds the single GPU
+
+def test_poll_training_returns_terminal_status(monkeypatch):
+    monkeypatch.setattr(rfs, "get_training_job", lambda url, jh, timeout=10: {"status": "COMPLETED"})
+    assert rfs.poll_training("http://x", "abc", train_timeout=1) == "COMPLETED"
+
+def test_poll_training_times_out(monkeypatch):
+    monkeypatch.setattr(rfs, "get_training_job", lambda url, jh, timeout=10: {"status": "TRAINING"})
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    assert rfs.poll_training("http://x", "abc", train_timeout=0.01) == "TIMEOUT"

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -101,3 +101,23 @@ def test_exec_checkpoint_cmd_targets_statefulset():
 def test_get_pods_cmd():
     assert rfs.k8s_get_pods_cmd("sweep-qwen") == [
         "kubectl", "get", "pods", "-n", "sweep-qwen", "-o", "json"]
+
+def test_wait_for_pods_ready_returns_ready(monkeypatch):
+    monkeypatch.setattr(rfs, "kubectl_get_pods",
+                        lambda ns, timeout=15: [_pod("Running", [(True, None)])])
+    assert rfs.wait_for_pods_ready("sweep-qwen", gpu_wait_timeout=5, poll=0.01) == "ready"
+
+def test_wait_for_pods_ready_fails_fast_on_crash(monkeypatch):
+    monkeypatch.setattr(rfs, "kubectl_get_pods",
+                        lambda ns, timeout=15: [_pod("Running", [(False, "CrashLoopBackOff")])])
+    assert rfs.wait_for_pods_ready("sweep-qwen", gpu_wait_timeout=5, poll=0.01) == "failed"
+
+def test_wait_for_pods_ready_times_out_while_pending(monkeypatch):
+    monkeypatch.setattr(rfs, "kubectl_get_pods", lambda ns, timeout=15: [])  # always pending
+    assert rfs.wait_for_pods_ready("sweep-qwen", gpu_wait_timeout=0.05, poll=0.01) == "timeout"
+
+def test_kubectl_get_pods_parses_items(monkeypatch):
+    class _R:  # fake CompletedProcess
+        stdout = '{"items": [{"status": {"phase": "Running"}}]}'
+    monkeypatch.setattr(rfs.subprocess, "run", lambda *a, **k: _R())
+    assert rfs.kubectl_get_pods("sweep-qwen") == [{"status": {"phase": "Running"}}]

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -158,6 +158,26 @@ def test_gate_model_cpu_requires_cpu_ok_optin():
     assert rfs.gate_model({"id": "m"}, cpu_cfg, [])[0] is False           # no cpu_ok
     assert rfs.gate_model({"id": "m", "cpu_ok": True}, cpu_cfg, [])[0] is True
 
+def test_parse_gpu_free_gb_parses_numeric_mib_to_gib():
+    # nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits emits MiB.
+    assert rfs._parse_gpu_free_gb("1024\n2048\n") == [1.0, 2.0]
+
+def test_parse_gpu_free_gb_skips_na_unified_memory():
+    # GB10/DGX Spark unified memory reports '[N/A]' -- must skip, not crash int().
+    assert rfs._parse_gpu_free_gb("[N/A]\n") == []
+    assert rfs._parse_gpu_free_gb("[N/A]\n1024\n") == [1.0]
+
+def test_vram_for_gate_none_when_gpu_present_but_no_numeric_vram():
+    # Unified-memory GPU: enumerated (count>0) but free=[] -> gate not applicable
+    # (None), same as the k8s path; never a spurious SKIP.
+    assert rfs._vram_for_gate([], 1) is None
+
+def test_vram_for_gate_empty_when_no_gpu_visible():
+    assert rfs._vram_for_gate([], 0) == []
+
+def test_vram_for_gate_passes_through_numeric_free():
+    assert rfs._vram_for_gate([16.0], 1) == [16.0]
+
 def test_kubectl_get_pods_returns_empty_on_called_process_error(monkeypatch):
     def _boom(*a, **k):
         raise rfs.subprocess.CalledProcessError(1, "kubectl")

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -1,0 +1,28 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load the script module by path (it is not an importable package).
+_SPEC = importlib.util.spec_from_file_location(
+    "run_finetune_sweep",
+    Path(__file__).resolve().parents[1] / "finetune_sweep" / "run_finetune_sweep.py",
+)
+rfs = importlib.util.module_from_spec(_SPEC)
+# Register in sys.modules before exec so dataclasses can resolve cls.__module__.
+sys.modules[_SPEC.name] = rfs
+_SPEC.loader.exec_module(rfs)
+
+
+def test_k8s_namespace_sanitizes_model_id():
+    assert rfs.k8s_namespace("sweep", "Qwen/Qwen2.5-0.5B") == "sweep-qwen-qwen2-5-0-5b"
+
+def test_k8s_namespace_is_rfc1123_label():
+    ns = rfs.k8s_namespace("sweep", "masint/tiny-random-llama")
+    assert ns == "sweep-masint-tiny-random-llama"
+    assert ns == ns.lower() and "/" not in ns and "_" not in ns and "." not in ns
+    assert not ns.startswith("-") and not ns.endswith("-")
+
+def test_k8s_namespace_truncates_to_63_chars():
+    ns = rfs.k8s_namespace("sweep", "org/" + "a" * 200)
+    assert len(ns) <= 63
+    assert not ns.endswith("-")

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -203,3 +203,14 @@ def test_wait_for_pods_gone_times_out_while_present(monkeypatch):
 
 def test_megatron_pod_selector_is_component_label():
     assert rfs.MEGATRON_POD_SELECTOR == "app.kubernetes.io/component=megatron"
+
+def test_helm_install_cmd_no_phase_scaling_by_default():
+    cmd = rfs.k8s_helm_install_cmd(CUDA_CFG, "sweep-qwen", "Qwen/Qwen2.5-0.5B")
+    assert "replicaCounts.inference=0" not in cmd
+    assert "replicaCounts.training=1" not in cmd
+
+def test_helm_install_cmd_phase_scaled_sets_replica_counts():
+    cfg = {**CUDA_CFG, "phase_scaled": True}
+    cmd = rfs.k8s_helm_install_cmd(cfg, "sweep-qwen", "Qwen/Qwen2.5-0.5B")
+    assert "replicaCounts.inference=0" in cmd  # vLLM off in phase 0/1
+    assert "replicaCounts.training=1" in cmd   # megatron holds the single GPU

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -26,3 +26,37 @@ def test_k8s_namespace_truncates_to_63_chars():
     ns = rfs.k8s_namespace("sweep", "org/" + "a" * 200)
     assert len(ns) <= 63
     assert not ns.endswith("-")
+
+def _pod(phase, containers):
+    # containers: list of (ready: bool, waiting_reason: str | None)
+    cs = []
+    for ready, waiting in containers:
+        state = {"waiting": {"reason": waiting}} if waiting else {"running": {}}
+        cs.append({"ready": ready, "state": state})
+    return {"status": {"phase": phase, "containerStatuses": cs}}
+
+def test_classify_empty_is_pending():
+    assert rfs.classify_pod_status([]) == "pending"
+
+def test_classify_all_running_ready_is_ready():
+    pods = [_pod("Running", [(True, None)]), _pod("Running", [(True, None)])]
+    assert rfs.classify_pod_status(pods) == "ready"
+
+def test_classify_unschedulable_pending_is_pending():
+    # Pending pod with no container statuses yet (scheduler hasn't placed it).
+    assert rfs.classify_pod_status([{"status": {"phase": "Pending"}}]) == "pending"
+
+def test_classify_container_not_ready_is_pending():
+    pods = [_pod("Running", [(False, None)])]
+    assert rfs.classify_pod_status(pods) == "pending"
+
+def test_classify_crashloop_is_failed():
+    pods = [_pod("Running", [(False, "CrashLoopBackOff")])]
+    assert rfs.classify_pod_status(pods) == "failed"
+
+def test_classify_imagepull_is_failed():
+    pods = [_pod("Pending", [(False, "ImagePullBackOff")])]
+    assert rfs.classify_pod_status(pods) == "failed"
+
+def test_classify_failed_phase_is_failed():
+    assert rfs.classify_pod_status([{"status": {"phase": "Failed"}}]) == "failed"

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -137,6 +137,36 @@ def test_wait_for_all_up_accepts_none_proc(monkeypatch):
     # proc=None must not raise and must return True when health is up.
     assert rfs.wait_for_all_up("http://localhost:8000", None, timeout=1) is True
 
+def test_wait_for_model_served_returns_served_when_up(monkeypatch):
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"all": "up"})
+    monkeypatch.setattr(rfs, "get_served_models", lambda url, timeout=5: {"m"})
+    assert rfs.wait_for_model_served("http://x", "m", None, timeout=1) == "served"
+
+def test_wait_for_model_served_fails_fast_on_crash_loop(monkeypatch):
+    # vLLM never serves; the container RestartCount climbs (0 baseline -> 1) ->
+    # "crashed" without waiting out the timeout.
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"all": "down"})
+    monkeypatch.setattr(rfs, "get_served_models", lambda url, timeout=5: set())
+    counts = iter([0, 1, 1, 1])
+    monkeypatch.setattr(rfs, "get_compose_restart_count", lambda svc, timeout=10: next(counts))
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    status = rfs.wait_for_model_served("http://x", "m", None, timeout=100,
+                                       compose_service="cray-spark", crash_check_every=0)
+    assert status == "crashed"
+
+def test_wait_for_model_served_proc_exited(monkeypatch):
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"all": "down"})
+    monkeypatch.setattr(rfs, "get_served_models", lambda url, timeout=5: set())
+    proc = type("P", (), {"poll": lambda self: 1})()
+    assert rfs.wait_for_model_served("http://x", "m", proc, timeout=1) == "proc_exited"
+
+def test_wait_for_model_served_times_out(monkeypatch):
+    # No compose_service -> no crash check; health never up -> "timeout".
+    monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"all": "down"})
+    monkeypatch.setattr(rfs, "get_served_models", lambda url, timeout=5: set())
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    assert rfs.wait_for_model_served("http://x", "m", None, timeout=0.01) == "timeout"
+
 def test_gate_model_k8s_skips_vram_check_when_free_gb_none():
     model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
     ok, reason = rfs.gate_model(model, {"train_args_overrides": {"gpus": 1}}, None)
@@ -425,6 +455,8 @@ def test_manifest_targets_dispatch_correctly():
     assert rfs.target_requests_gpu(targets["cuda-spark"]) is True
     assert targets["cuda-spark"]["compose_service"] == "cray-spark"
     assert "spark" in targets["cuda-spark"]["restart_cmd"]
+    # Fast-feedback knobs ride SCALARLM_VLLM_ARGS in the restart_cmd.
+    assert "--enforce-eager" in targets["cuda-spark"]["restart_cmd"]
     # cuda-k8s: k8s lifecycle (renamed from cuda) + GPU
     assert "cuda-k8s" in targets and "cuda" not in targets
     assert rfs.is_k8s_target(targets["cuda-k8s"]) is True

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -223,3 +223,35 @@ def test_poll_training_times_out(monkeypatch):
     monkeypatch.setattr(rfs, "get_training_job", lambda url, jh, timeout=10: {"status": "TRAINING"})
     monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
     assert rfs.poll_training("http://x", "abc", train_timeout=0.01) == "TIMEOUT"
+
+
+class _ServeArgs:  # minimal stand-in for the argparse Namespace fields used here
+    serve_timeout = 1
+    train_timeout = 60
+    max_tokens = 32
+
+def test_serve_check_sets_pass_on_memorization(monkeypatch):
+    monkeypatch.setattr(rfs, "generate", lambda api, prompts, jh, mt: ["... SECRET123 ..."])
+    res = rfs.Result(model="m", target="cuda")
+    rfs.serve_check_and_classify("http://x", "p", "SECRET123", "abc", "COMPLETED",
+                                 ["base.lora_A.weight", "base.lora_B.weight"], _ServeArgs(), res)
+    assert res.outcome == rfs.PASS
+    assert "SECRET123" in res.adapter_sample
+
+def test_serve_check_adapter_not_loaded(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("404 model not found")
+    monkeypatch.setattr(rfs, "generate", boom)
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+    res = rfs.Result(model="m", target="cuda")
+    rfs.serve_check_and_classify("http://x", "p", "SECRET123", "abc", "COMPLETED",
+                                 ["base.lora_A.weight", "base.lora_B.weight"], _ServeArgs(), res)
+    assert res.outcome == rfs.ADAPTER_NOT_LOADED
+
+def test_serve_check_bad_checkpoint(monkeypatch):
+    # No lora_B key -> checkpoint_lora_keys_ok is False -> BAD_CHECKPOINT, no generate call.
+    monkeypatch.setattr(rfs, "generate", lambda *a, **k: (_ for _ in ()).throw(AssertionError("called")))
+    res = rfs.Result(model="m", target="cuda")
+    rfs.serve_check_and_classify("http://x", "p", "SECRET123", "abc", "COMPLETED",
+                                 ["base.lora_A.weight"], _ServeArgs(), res)
+    assert res.outcome == rfs.BAD_CHECKPOINT

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -255,3 +255,62 @@ def test_serve_check_bad_checkpoint(monkeypatch):
     rfs.serve_check_and_classify("http://x", "p", "SECRET123", "abc", "COMPLETED",
                                  ["base.lora_A.weight"], _ServeArgs(), res)
     assert res.outcome == rfs.BAD_CHECKPOINT
+
+
+def test_run_model_k8s_phased_orders_gpu_handoff(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(rfs, "delete_namespace", lambda ns, log, **k: None)
+    monkeypatch.setattr(rfs, "helm_install", lambda *a, **k: True)
+    monkeypatch.setattr(rfs, "wait_for_pods_ready", lambda ns, t, **k: "ready")
+    monkeypatch.setattr(rfs, "start_port_forward", lambda *a, **k: None)
+    monkeypatch.setattr(rfs, "wait_for_all_up", lambda *a, **k: True)
+    monkeypatch.setattr(rfs, "submit_train", lambda *a, **k: {"job_directory": "/app/cray/jobs/abc"})
+    monkeypatch.setattr(rfs, "poll_training", lambda *a, **k: "COMPLETED")
+    monkeypatch.setattr(rfs, "read_checkpoint_keys_k8s",
+                        lambda *a, **k: ["base.lora_A.weight", "base.lora_B.weight"])
+    monkeypatch.setattr(rfs, "kubectl_scale",
+                        lambda kn, r, ns, log, **k: (calls.append((kn, r)), True)[1])
+    monkeypatch.setattr(rfs, "wait_for_pods_gone", lambda *a, **k: "gone")
+    # baseline (model="Qwen/...") has no secret; adapter (model="abc") memorizes it.
+    monkeypatch.setattr(rfs, "generate",
+                        lambda api, prompts, model, mt: ["x SECRET123 y"] if model == "abc"
+                        else ["plain baseline"])
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+
+    cfg = {**CUDA_CFG, "vllm_deploy": "scalarlm-vllm", "phase_scaled": True}
+    args = type("A", (), {"api_url": "http://x", "restart_timeout": 1, "serve_timeout": 1,
+                          "train_timeout": 1, "max_tokens": 32, "gpu_wait_timeout": 1})()
+    res = rfs.Result(model="Qwen/Qwen2.5-0.5B", target="cuda")
+    with open(tmp_path / "log.txt", "w") as log:
+        out = rfs.run_model_k8s_phased(cfg, "Qwen/Qwen2.5-0.5B", {}, [], "p", "SECRET123",
+                                       args, res, log)
+
+    assert out.outcome == rfs.PASS
+    # megatron must be freed (->0) before vLLM claims the GPU (->1).
+    assert calls == [("statefulset/scalarlm-megatron", 0), ("deployment/scalarlm-vllm", 1)]
+
+
+def test_run_model_k8s_phased_fails_fast_on_scale_down(monkeypatch, tmp_path):
+    # Phase 0/1 succeed, then the megatron scale-down fails -> RESTART_FAILED.
+    monkeypatch.setattr(rfs, "delete_namespace", lambda ns, log, **k: None)
+    monkeypatch.setattr(rfs, "helm_install", lambda *a, **k: True)
+    monkeypatch.setattr(rfs, "wait_for_pods_ready", lambda ns, t, **k: "ready")
+    monkeypatch.setattr(rfs, "start_port_forward", lambda *a, **k: None)
+    monkeypatch.setattr(rfs, "wait_for_all_up", lambda *a, **k: True)
+    monkeypatch.setattr(rfs, "submit_train", lambda *a, **k: {"job_directory": "/app/cray/jobs/abc"})
+    monkeypatch.setattr(rfs, "poll_training", lambda *a, **k: "COMPLETED")
+    monkeypatch.setattr(rfs, "read_checkpoint_keys_k8s",
+                        lambda *a, **k: ["base.lora_A.weight", "base.lora_B.weight"])
+    monkeypatch.setattr(rfs, "kubectl_scale", lambda kn, r, ns, log, **k: False)  # scale fails
+    monkeypatch.setattr(rfs.time, "sleep", lambda s: None)
+
+    cfg = {**CUDA_CFG, "vllm_deploy": "scalarlm-vllm", "phase_scaled": True}
+    args = type("A", (), {"api_url": "http://x", "restart_timeout": 1, "serve_timeout": 1,
+                          "train_timeout": 1, "max_tokens": 32, "gpu_wait_timeout": 1})()
+    res = rfs.Result(model="Qwen/Qwen2.5-0.5B", target="cuda")
+    with open(tmp_path / "log.txt", "w") as log:
+        out = rfs.run_model_k8s_phased(cfg, "Qwen/Qwen2.5-0.5B", {}, [], "p", "SECRET123",
+                                       args, res, log)
+
+    assert out.outcome == rfs.RESTART_FAILED
+    assert "megatron->0" in out.detail

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -139,18 +139,24 @@ def test_wait_for_all_up_accepts_none_proc(monkeypatch):
 
 def test_gate_model_k8s_skips_vram_check_when_free_gb_none():
     model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
-    ok, reason = rfs.gate_model(model, "cuda", None)
+    ok, reason = rfs.gate_model(model, {"train_args_overrides": {"gpus": 1}}, None)
     assert ok is True and reason == ""
 
 def test_gate_model_k8s_still_requires_gate_gb_declared():
     model = {"id": "m"}  # no adapters.lora.gate_gb
-    ok, reason = rfs.gate_model(model, "cuda", None)
+    ok, reason = rfs.gate_model(model, {"train_args_overrides": {"gpus": 1}}, None)
     assert ok is False and "gate_gb" in reason
 
-def test_gate_model_cuda_still_gates_on_free_gb_list():
+def test_gate_model_gpu_still_gates_on_free_gb_list():
     model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
-    assert rfs.gate_model(model, "cuda", [4.0])[0] is False   # not enough free
-    assert rfs.gate_model(model, "cuda", [16.0])[0] is True    # enough free
+    gpu_cfg = {"train_args_overrides": {"gpus": 1}}
+    assert rfs.gate_model(model, gpu_cfg, [4.0])[0] is False   # not enough free
+    assert rfs.gate_model(model, gpu_cfg, [16.0])[0] is True   # enough free
+
+def test_gate_model_cpu_requires_cpu_ok_optin():
+    cpu_cfg = {"train_args_overrides": {"gpus": 0}}
+    assert rfs.gate_model({"id": "m"}, cpu_cfg, [])[0] is False           # no cpu_ok
+    assert rfs.gate_model({"id": "m", "cpu_ok": True}, cpu_cfg, [])[0] is True
 
 def test_kubectl_get_pods_returns_empty_on_called_process_error(monkeypatch):
     def _boom(*a, **k):

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -141,3 +141,15 @@ def test_gate_model_cuda_still_gates_on_free_gb_list():
     model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
     assert rfs.gate_model(model, "cuda", [4.0])[0] is False   # not enough free
     assert rfs.gate_model(model, "cuda", [16.0])[0] is True    # enough free
+
+def test_kubectl_get_pods_returns_empty_on_called_process_error(monkeypatch):
+    def _boom(*a, **k):
+        raise rfs.subprocess.CalledProcessError(1, "kubectl")
+    monkeypatch.setattr(rfs.subprocess, "run", _boom)
+    assert rfs.kubectl_get_pods("sweep-qwen") == []
+
+def test_kubectl_get_pods_returns_empty_on_bad_json(monkeypatch):
+    class _R:
+        stdout = "not json"
+    monkeypatch.setattr(rfs.subprocess, "run", lambda *a, **k: _R())
+    assert rfs.kubectl_get_pods("sweep-qwen") == []

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -126,3 +126,18 @@ def test_wait_for_all_up_accepts_none_proc(monkeypatch):
     monkeypatch.setattr(rfs, "get_health", lambda url, timeout=5: {"all": "up"})
     # proc=None must not raise and must return True when health is up.
     assert rfs.wait_for_all_up("http://localhost:8000", None, timeout=1) is True
+
+def test_gate_model_k8s_skips_vram_check_when_free_gb_none():
+    model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
+    ok, reason = rfs.gate_model(model, "cuda", None)
+    assert ok is True and reason == ""
+
+def test_gate_model_k8s_still_requires_gate_gb_declared():
+    model = {"id": "m"}  # no adapters.lora.gate_gb
+    ok, reason = rfs.gate_model(model, "cuda", None)
+    assert ok is False and "gate_gb" in reason
+
+def test_gate_model_cuda_still_gates_on_free_gb_list():
+    model = {"id": "m", "adapters": {"lora": {"gate_gb": 8}}}
+    assert rfs.gate_model(model, "cuda", [4.0])[0] is False   # not enough free
+    assert rfs.gate_model(model, "cuda", [16.0])[0] is True    # enough free

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -177,3 +177,29 @@ def test_kubectl_scale_false_on_error(monkeypatch):
         raise rfs.subprocess.CalledProcessError(1, a[0])
     monkeypatch.setattr(rfs.subprocess, "run", boom)
     assert rfs.kubectl_scale("deployment/scalarlm-vllm", 1, "sweep-qwen", log=None) is False
+
+def test_get_pods_cmd_with_selector():
+    assert rfs.k8s_get_pods_cmd("sweep-qwen", "app.kubernetes.io/component=megatron") == [
+        "kubectl", "get", "pods", "-n", "sweep-qwen",
+        "-l", "app.kubernetes.io/component=megatron", "-o", "json"]
+
+def test_get_pods_cmd_without_selector_unchanged():
+    assert rfs.k8s_get_pods_cmd("sweep-qwen") == [
+        "kubectl", "get", "pods", "-n", "sweep-qwen", "-o", "json"]
+
+def test_wait_for_pods_gone_returns_gone_when_empty(monkeypatch):
+    seen = []
+    def fake_get(ns, selector=None, timeout=15):
+        seen.append(selector)
+        return []
+    monkeypatch.setattr(rfs, "kubectl_get_pods", fake_get)
+    assert rfs.wait_for_pods_gone("sweep-qwen", "sel", gpu_wait_timeout=5, poll=0.01) == "gone"
+    assert seen[0] == "sel"  # selector must flow through to kubectl_get_pods
+
+def test_wait_for_pods_gone_times_out_while_present(monkeypatch):
+    monkeypatch.setattr(rfs, "kubectl_get_pods",
+                        lambda ns, selector=None, timeout=15: [{"metadata": {"name": "megatron-0"}}])
+    assert rfs.wait_for_pods_gone("sweep-qwen", "sel", gpu_wait_timeout=0.05, poll=0.01) == "timeout"
+
+def test_megatron_pod_selector_is_component_label():
+    assert rfs.MEGATRON_POD_SELECTOR == "app.kubernetes.io/component=megatron"

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -351,6 +351,13 @@ def test_manifest_targets_dispatch_correctly():
     assert rfs.is_k8s_target(targets["cuda-docker"]) is False
     assert rfs.target_requests_gpu(targets["cuda-docker"]) is True
     assert targets["cuda-docker"]["compose_service"] == "cray-nvidia"
+    # cuda-spark: Compose lifecycle (like cuda-docker) + GPU, but the cray-spark
+    # service (aarch64 + Blackwell) via `./scalarlm up spark`
+    assert "cuda-spark" in targets
+    assert rfs.is_k8s_target(targets["cuda-spark"]) is False
+    assert rfs.target_requests_gpu(targets["cuda-spark"]) is True
+    assert targets["cuda-spark"]["compose_service"] == "cray-spark"
+    assert "spark" in targets["cuda-spark"]["restart_cmd"]
     # cuda-k8s: k8s lifecycle (renamed from cuda) + GPU
     assert "cuda-k8s" in targets and "cuda" not in targets
     assert rfs.is_k8s_target(targets["cuda-k8s"]) is True

--- a/test/unit/test_finetune_sweep_k8s.py
+++ b/test/unit/test_finetune_sweep_k8s.py
@@ -324,3 +324,15 @@ def test_run_model_k8s_phased_fails_fast_on_scale_down(monkeypatch, tmp_path):
 
     assert out.outcome == rfs.RESTART_FAILED
     assert "megatron->0" in out.detail
+
+
+def test_target_requests_gpu_true_when_gpus_one():
+    assert rfs.target_requests_gpu({"train_args_overrides": {"gpus": 1}}) is True
+
+def test_target_requests_gpu_false_when_gpus_zero():
+    assert rfs.target_requests_gpu({"train_args_overrides": {"gpus": 0}}) is False
+
+def test_target_requests_gpu_defaults_true_when_unset():
+    # JobConfig defaults gpus=1, so a target with no override requests a GPU.
+    assert rfs.target_requests_gpu({}) is True
+    assert rfs.target_requests_gpu({"train_args_overrides": {}}) is True

--- a/test/unit/test_finetune_sweep_preflight.py
+++ b/test/unit/test_finetune_sweep_preflight.py
@@ -166,6 +166,30 @@ def test_split_by_preflight_runs_model_absent_from_results():
     assert skipped == []
 
 
+def test_is_gated_repo_error_matches_401_and_gated():
+    assert rfs.is_gated_repo_error("OSError: You are trying to access a gated repo. "
+                                   "... 401 Client Error.")
+    assert rfs.is_gated_repo_error("401 Client Error")
+    assert not rfs.is_gated_repo_error("ImportError: boom")  # generic crash -> fail open
+
+
+def test_split_by_preflight_skips_gated_repo_as_skipped():
+    # A gated/401 preflight error is deterministic -> SKIP (not fail-open run).
+    models = [{"id": "google/gemma-3-270m-it"}, {"id": "crashy"}]
+    pf_results = {
+        "google/gemma-3-270m-it": pf.PreflightResult(
+            "google/gemma-3-270m-it",
+            error="OSError: You are trying to access a gated repo. 401 Client Error."),
+        "crashy": pf.PreflightResult("crashy", error="ImportError: boom"),
+    }
+    to_run, skipped = rfs.split_by_preflight(models, pf_results, "cuda-spark")
+    assert [m["id"] for m in to_run] == ["crashy"]  # generic error still fails open
+    assert len(skipped) == 1
+    assert skipped[0].model == "google/gemma-3-270m-it"
+    assert skipped[0].outcome == rfs.SKIPPED
+    assert "gated" in skipped[0].detail.lower()
+
+
 # --- Cycle E: Result.hint surfaced as a report column ---
 
 def test_write_reports_has_hint_column(tmp_path):

--- a/test/unit/test_finetune_sweep_preflight.py
+++ b/test/unit/test_finetune_sweep_preflight.py
@@ -1,0 +1,183 @@
+"""Unit tests for the fine-tune sweep dry-test: the in-sweep ADAPTER_NO_OP
+discriminator (run_finetune_sweep.classify_result) and the offline preflight's
+torch-free seams (preflight.py). The two-pass normalization fidelity is verified
+in-image on the box, not here (no torch/vllm on the host)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_SWEEP_DIR = Path(__file__).resolve().parents[1] / "finetune_sweep"
+
+
+def _load(mod_name: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _SWEEP_DIR / f"{mod_name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+rfs = _load("run_finetune_sweep")
+pf = _load("preflight")
+
+
+# --- Cycle A: classify_result ADAPTER_NO_OP branch + precedence ---
+
+def test_classify_result_no_op_not_memorized_is_adapter_no_op():
+    outcome = rfs.classify_result(
+        train_status="COMPLETED",
+        checkpoint_keys=["base.layers.0.self_attn.q_proj.lora_A.weight",
+                         "base.layers.0.self_attn.q_proj.lora_B.weight"],
+        adapter_loaded=True,
+        memorized=False,
+        adapter_is_noop=True,
+    )
+    assert outcome == rfs.ADAPTER_NO_OP
+
+
+def test_classify_result_no_op_but_memorized_is_pass():
+    # Byte-identical to baseline yet the golden string is present (degenerate,
+    # but precedence must favor the memorization signal): not a no-op failure.
+    keys = ["m.lora_A.weight", "m.lora_B.weight"]
+    outcome = rfs.classify_result("COMPLETED", keys, adapter_loaded=True,
+                                  memorized=True, adapter_is_noop=True)
+    assert outcome == rfs.PASS
+
+
+def test_classify_result_applied_but_not_memorized_is_no_memorization():
+    keys = ["m.lora_A.weight", "m.lora_B.weight"]
+    outcome = rfs.classify_result("COMPLETED", keys, adapter_loaded=True,
+                                  memorized=False, adapter_is_noop=False)
+    assert outcome == rfs.NO_MEMORIZATION
+
+
+# --- Cycle B: synthesize_lora_keys (pure, torch-free) ---
+
+def test_synthesize_lora_keys_one_layer_standard_targets():
+    keys = pf.synthesize_lora_keys(n_layers=1)
+    assert set(keys) == {
+        "model.layers.0.self_attn.q_proj.lora_A.default.weight",
+        "model.layers.0.self_attn.k_proj.lora_A.default.weight",
+        "model.layers.0.self_attn.v_proj.lora_A.default.weight",
+        "model.layers.0.self_attn.o_proj.lora_A.default.weight",
+        "model.layers.0.mlp.gate_proj.lora_A.default.weight",
+        "model.layers.0.mlp.up_proj.lora_A.default.weight",
+        "model.layers.0.mlp.down_proj.lora_A.default.weight",
+    }
+
+
+# --- Cycle C: overlap (pure set logic, the permissive n_overlap > 0 rule) ---
+
+def test_overlap_zero_intersection():
+    base = {"model.layers.0.self_attn.q_proj", "model.layers.0.mlp.down_proj"}
+    lora = {"layers.0.self_attn.q_proj", "layers.0.mlp.down_proj"}  # prefix mismatch
+    assert pf.overlap(base, lora) == 0
+
+
+def test_overlap_partial_intersection():
+    base = {"model.layers.0.self_attn.q_proj", "model.layers.0.self_attn.k_proj"}
+    lora = {"model.layers.0.self_attn.q_proj", "model.layers.0.mlp.down_proj"}
+    assert pf.overlap(base, lora) == 1
+
+
+def test_overlap_full_intersection():
+    base = {"a", "b", "c"}
+    lora = {"a", "b"}
+    assert pf.overlap(base, lora) == 2
+
+
+# --- Cycle D: parse_preflight_output + fail-open semantics ---
+
+import json
+
+
+def test_parse_preflight_output_ok():
+    stdout = "some torch warning\n" + json.dumps({
+        "predicted_ok": True, "n_overlap": 7, "n_total": 7,
+        "sample_adapter_keys": ["model.layers.0.self_attn.q_proj"],
+        "sample_base_modules": ["model.layers.0.self_attn.q_proj"],
+    })
+    r = pf.parse_preflight_output("Qwen/Qwen2.5-0.5B", stdout)
+    assert r.model_id == "Qwen/Qwen2.5-0.5B"
+    assert r.predicted_ok is True
+    assert r.n_overlap == 7 and r.n_total == 7
+    assert r.error == ""
+    assert r.predicted_noop is False
+
+
+def test_parse_preflight_output_real_noop_is_skipped():
+    stdout = json.dumps({"predicted_ok": False, "n_overlap": 0, "n_total": 7,
+                         "sample_adapter_keys": ["layers.0.self_attn.q_proj"],
+                         "sample_base_modules": ["model.layers.0.self_attn.q_proj"]})
+    r = pf.parse_preflight_output("m", stdout)
+    assert r.predicted_ok is False
+    assert r.predicted_noop is True   # zero overlap, no error -> skip the model
+
+
+def test_parse_preflight_output_error_fails_open():
+    stdout = json.dumps({"error": "ImportError: no such model arch"})
+    r = pf.parse_preflight_output("m", stdout)
+    assert r.error
+    assert r.predicted_noop is False  # build crash -> run the model, don't skip
+
+
+def test_parse_preflight_output_garbage_fails_open():
+    r = pf.parse_preflight_output("m", "Traceback (most recent call last): boom")
+    assert r.error
+    assert r.predicted_noop is False
+
+
+# --- Cycle F: split_by_preflight partitions run-list vs PRECHECK_NO_OP rows ---
+
+def test_split_by_preflight_skips_predicted_noop_with_hint():
+    models = [{"id": "ok-model"}, {"id": "noop-model"}]
+    pf_results = {
+        "ok-model": pf.PreflightResult("ok-model", predicted_ok=True,
+                                       n_overlap=7, n_total=7),
+        "noop-model": pf.PreflightResult(
+            "noop-model", predicted_ok=False, n_overlap=0, n_total=7,
+            sample_adapter_keys=["language_model.model.layers.0.self_attn.q_proj"],
+            sample_base_modules=["model.layers.0.self_attn.q_proj"]),
+    }
+    to_run, skipped = rfs.split_by_preflight(models, pf_results, "cuda-docker")
+    assert [m["id"] for m in to_run] == ["ok-model"]
+    assert len(skipped) == 1
+    s = skipped[0]
+    assert s.model == "noop-model"
+    assert s.outcome == rfs.PRECHECK_NO_OP
+    assert "language_model.model.layers.0.self_attn.q_proj" in s.hint
+    assert "model.layers.0.self_attn.q_proj" in s.hint
+
+
+def test_split_by_preflight_fail_open_runs_model_on_build_error():
+    models = [{"id": "crashy"}]
+    pf_results = {"crashy": pf.PreflightResult("crashy", error="ImportError: boom")}
+    to_run, skipped = rfs.split_by_preflight(models, pf_results, "cuda-docker")
+    assert [m["id"] for m in to_run] == ["crashy"]  # build crash -> run, don't skip
+    assert skipped == []
+
+
+def test_split_by_preflight_runs_model_absent_from_results():
+    # A model with no preflight entry (e.g. preflight not run for it) runs.
+    models = [{"id": "unchecked"}]
+    to_run, skipped = rfs.split_by_preflight(models, {}, "cuda-docker")
+    assert [m["id"] for m in to_run] == ["unchecked"]
+    assert skipped == []
+
+
+# --- Cycle E: Result.hint surfaced as a report column ---
+
+def test_write_reports_has_hint_column(tmp_path):
+    results = [
+        rfs.Result(model="m1", target="cpu", outcome=rfs.PRECHECK_NO_OP,
+                   hint="adapter keys ['layers.0...'] vs base ['model.layers.0...']"),
+        rfs.Result(model="m2", target="cpu", outcome=rfs.PASS),
+    ]
+    _json_path, md_path = rfs.write_reports(results, "cpu", tmp_path)
+    md = md_path.read_text()
+    assert "Hint" in md.splitlines()[2]            # header row carries the column
+    assert "adapter keys" in md                     # the hint text is rendered
+    assert rfs.PRECHECK_NO_OP in md
+    # hint also present in the JSON
+    assert "adapter keys" in _json_path.read_text()

--- a/test/unit/test_resolve_target_modules.py
+++ b/test/unit/test_resolve_target_modules.py
@@ -57,6 +57,59 @@ class _NoOutputEmbeddings(nn.Module):
         return None
 
 
+class _MoeLike(nn.Module):
+    """A miniature Qwen3MoE-style ...ForCausalLM: per-layer self-attention plus a
+    sparse MLP with a router (`gate`) and routed `experts`. The expert (and
+    router) LoRA can't be served from a .pt adapter, so resolution must land on
+    attention only."""
+
+    def __init__(self, n_layers=2, n_experts=4):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": nn.ModuleDict(
+                        {
+                            "q_proj": nn.Linear(8, 8, bias=False),
+                            "k_proj": nn.Linear(8, 8, bias=False),
+                            "v_proj": nn.Linear(8, 8, bias=False),
+                            "o_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "mlp": nn.ModuleDict(
+                        {
+                            "gate": nn.Linear(8, n_experts, bias=False),  # router
+                            "experts": nn.ModuleList(
+                                nn.ModuleDict(
+                                    {
+                                        "gate_proj": nn.Linear(8, 8, bias=False),
+                                        "up_proj": nn.Linear(8, 8, bias=False),
+                                        "down_proj": nn.Linear(8, 8, bias=False),
+                                    }
+                                )
+                                for _ in range(n_experts)
+                            ),
+                        }
+                    ),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_moe_targets_attention_only_excludes_experts_and_router():
+    model = _MoeLike()
+    result = resolve_target_modules(model, "all-linear")
+    # Attention projections only — no expert MLP, no router, no head.
+    assert result == ["k_proj", "o_proj", "q_proj", "v_proj"]
+    for excluded in ("gate_proj", "up_proj", "down_proj", "gate", "lm_head"):
+        assert excluded not in result
+
+
 def test_all_linear_expands_to_distinct_leaf_names_minus_head():
     model = _DenseLike()
     resolved = resolve_target_modules(model, "all-linear")

--- a/test/unit/test_resolve_target_modules.py
+++ b/test/unit/test_resolve_target_modules.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for adapters.resolve_target_modules.resolve_target_modules.
+
+PEFT's "all-linear" shorthand fails to expand for some architectures
+(notably MoE: Qwen3MoeForCausalLM under peft 0.19 + transformers 5.x). PEFT
+falls back to iterating the literal string as a set of characters and raises
+`Target modules {'-','l','n','r','i','a','e'} not found in the base model`,
+which is the qwen3-moe TRAIN_FAILED in the cuda-spark sweep. We resolve the
+shorthand ourselves from the live model, so these tests use small synthetic
+nn.Modules rather than HF downloads.
+"""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from adapters.resolve_target_modules import resolve_target_modules
+
+
+class _DenseLike(nn.Module):
+    """A miniature ...ForCausalLM: attention + MLP projections + an output head,
+    with several layers so leaf names repeat (as in a real stacked model)."""
+
+    def __init__(self, n_layers=3):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+class _NoOutputEmbeddings(nn.Module):
+    """A model whose get_output_embeddings() returns None (some configs do);
+    the output head must still be excluded by its conventional leaf name."""
+
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(8, 8, bias=False)
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return None
+
+
+def test_all_linear_expands_to_distinct_leaf_names_minus_head():
+    model = _DenseLike()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == [
+        "down_proj",
+        "gate_proj",
+        "k_proj",
+        "o_proj",
+        "q_proj",
+        "up_proj",
+        "v_proj",
+    ]
+    assert "lm_head" not in resolved
+
+
+def test_repeated_leaf_names_collapse_to_a_set():
+    # 3 layers × 7 projections, but only 7 distinct leaf names survive.
+    model = _DenseLike(n_layers=3)
+    resolved = resolve_target_modules(model, "all-linear")
+    assert len(resolved) == 7
+
+
+def test_output_head_excluded_by_name_when_no_output_embeddings():
+    model = _NoOutputEmbeddings()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == ["q_proj"]
+
+
+class _Decoder(nn.Module):
+    """A miniature language tower: one block of attention + MLP projections."""
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "q_proj": nn.Linear(8, 8, bias=False),
+                        "k_proj": nn.Linear(8, 8, bias=False),
+                        "v_proj": nn.Linear(8, 8, bias=False),
+                        "o_proj": nn.Linear(8, 8, bias=False),
+                    }
+                )
+            ]
+        )
+
+
+class _VisionTower(nn.Module):
+    """A vision encoder that REUSES the language tower's leaf names — the
+    Gemma3 case that defeats plain leaf-name targeting."""
+
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.ModuleDict(
+            {
+                "q_proj": nn.Linear(8, 8, bias=False),
+                "k_proj": nn.Linear(8, 8, bias=False),
+            }
+        )
+
+
+class _MultimodalModel(nn.Module):
+    """A ...ForConditionalGeneration-shaped wrapper: a `vision_config` on the
+    config, `get_decoder()` returning the language tower, a vision tower whose
+    linears share leaf names with the language tower, and a tied output head."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+        self.language_model = _Decoder()
+        self.vision_tower = _VisionTower()
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_multimodal_targets_full_paths_under_language_decoder_only():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    # Every target is a full path inside the language tower...
+    assert resolved == [
+        "language_model.layers.0.k_proj",
+        "language_model.layers.0.o_proj",
+        "language_model.layers.0.q_proj",
+        "language_model.layers.0.v_proj",
+    ]
+    # ...and nothing in the vision tower, despite the shared k_proj/q_proj names.
+    assert not any("vision_tower" in name for name in resolved)
+
+
+def test_multimodal_resolution_excludes_output_head():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert not any(name.endswith("lm_head") for name in resolved)
+
+
+def test_explicit_list_is_passed_through_unchanged():
+    model = _DenseLike()
+    explicit = ["q_proj", "v_proj"]
+    assert resolve_target_modules(model, explicit) is explicit
+
+
+def test_explicit_non_shorthand_string_passes_through():
+    model = _DenseLike()
+    # A regex/string that isn't the "all-linear" shorthand is PEFT's own
+    # to interpret — we must not touch it.
+    assert resolve_target_modules(model, "q_proj") == "q_proj"
+
+
+def test_none_passes_through():
+    model = _DenseLike()
+    assert resolve_target_modules(model, None) is None


### PR DESCRIPTION
## Summary
- Standalone finetune-and-verify sweep: trains a LoRA adapter on a tiny single-pair dataset, checks the memorized string appears in the served response.
- `run_finetune_sweep.py`: per-model train/serve/generate with restart isolation + outcome classification.
- `finetune_memorization_check_gpu.py`: GPU memorization probe (LoRA only).
- `finetune-sweep.yaml`: real base (`Qwen/Qwen2.5-0.5B`), hyperparameters tuned to memorize the pair.

## Test Plan
- [ ] Run `python3 test/finetune_sweep/run_finetune_sweep.py` against a serving box; confirm it reaches MEMORIZED.