### PR TITLE
Serve /v1/models from config when vLLM's endpoint is unavailable

### DIFF
--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -34,10 +34,14 @@ from cray_infra.api.fastapi.routers.openai_v1_helpers import (
 from cray_infra.generate.metrics import get_metrics
 from cray_infra.util.get_config import get_config
 
+import aiohttp
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import StreamingResponse
 
+import asyncio
+import json
 import logging
+import time
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -47,17 +51,42 @@ openai_v1_router = APIRouter()
 
 @openai_v1_router.get("/models")
 async def list_models():
-    """List available models - proxy to vLLM server."""
-    session = get_global_session()
+    """List available models.
+
+    Prefer vLLM's own /v1/models, but fall back to ScalarLM's configured
+    model so discovery keeps working when the vLLM server's endpoint is
+    unavailable (e.g. the prometheus instrumentator returns 500). OpenAI
+    clients only need the ``{object: "list", data: [{id, ...}]}`` shape.
+    """
     config = get_config()
-    async with session.get(config["vllm_api_url"] + "/v1/models") as resp:
-        if resp.status == 200:
-            return await resp.json()
-        else:
-            return JSONResponse(
-                content={"error": f"Failed to fetch models: {resp.status}"},
-                status_code=resp.status,
+    try:
+        session = get_global_session()
+        async with session.get(
+            config["vllm_api_url"] + "/v1/models",
+            timeout=aiohttp.ClientTimeout(total=5),
+        ) as resp:
+            if resp.status == 200:
+                return await resp.json()
+            logger.warning(
+                "vLLM /v1/models returned %s; serving model list from config",
+                resp.status,
             )
+    except (aiohttp.ClientError, asyncio.TimeoutError, json.JSONDecodeError) as e:
+        logger.warning(
+            "vLLM /v1/models unavailable (%s); serving model list from config", e
+        )
+
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": config["model"],
+                "object": "model",
+                "created": int(time.time()),
+                "owned_by": "scalarlm",
+            }
+        ],
+    }
 
 
 @openai_v1_router.post("/completions")

--- a/test/unit/test_list_models_fallback.py
+++ b/test/unit/test_list_models_fallback.py
@@ -1,0 +1,130 @@
+"""
+Pin the contract for the ``GET /v1/models`` handler (``list_models``).
+
+It proxies vLLM's ``/v1/models`` when reachable, and otherwise falls back to an
+OpenAI-shaped list built from ``config["model"]`` so model discovery keeps
+working while vLLM's endpoint is unavailable (e.g. its prometheus instrumentator
+500s, or vLLM is still starting). Mirrors the proxy-then-config fallback already
+used by ``resolve_max_model_length``.
+
+The fallback is scoped to *expected* vLLM-unavailability failures (connection
+errors, timeouts, malformed bodies); unexpected errors are intentionally left to
+propagate rather than being masked as a healthy discovery response.
+"""
+
+import asyncio
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from cray_infra.api.fastapi.routers import openai_v1_router as r
+
+
+def _fake_session(payload=None, status=200, raises=None, json_raises=None, seen=None):
+    """Mimic aiohttp's ``session.get(...)`` async context manager.
+
+    ``status`` non-200 simulates vLLM error responses; ``raises`` an exception
+    on the request itself; ``json_raises`` an exception while decoding the body;
+    ``seen`` (a dict) captures the requested URL.
+    """
+    response = MagicMock()
+    response.status = status
+    if json_raises is not None:
+        response.json = AsyncMock(side_effect=json_raises)
+    else:
+        response.json = AsyncMock(return_value=payload)
+
+    @asynccontextmanager
+    async def fake_get(url, **kwargs):
+        if seen is not None:
+            seen["url"] = url
+            seen["kwargs"] = kwargs
+        if raises is not None:
+            raise raises
+        yield response
+
+    session = MagicMock()
+    session.get = fake_get
+    return session
+
+
+def _patches(session, *, model="cfg-model", vllm_url="http://vllm:8001"):
+    return (
+        patch.object(r, "get_global_session", return_value=session),
+        patch.object(
+            r,
+            "get_config",
+            return_value={"vllm_api_url": vllm_url, "model": model},
+        ),
+    )
+
+
+def _assert_config_fallback(result, model):
+    assert result["object"] == "list"
+    assert [m["id"] for m in result["data"]] == [model]
+    assert result["data"][0]["object"] == "model"
+    assert result["data"][0]["owned_by"] == "scalarlm"
+    assert isinstance(result["data"][0]["created"], int)
+
+
+@pytest.mark.asyncio
+async def test_proxies_vllm_when_healthy():
+    payload = {"object": "list", "data": [{"id": "a"}, {"id": "b"}]}
+    seen: dict = {}
+    session = _fake_session(payload, status=200, seen=seen)
+    p1, p2 = _patches(session)
+    with p1, p2:
+        result = await r.list_models()
+    assert result == payload
+    assert seen["url"] == "http://vllm:8001/v1/models"
+    # the discovery call must be bounded by a short timeout (guards regressions)
+    assert seen["kwargs"]["timeout"].total == 5
+
+
+@pytest.mark.asyncio
+async def test_falls_back_on_non_200():
+    session = _fake_session({}, status=503)
+    p1, p2 = _patches(session, model="m")
+    with p1, p2:
+        result = await r.list_models()
+    _assert_config_fallback(result, "m")
+
+
+@pytest.mark.asyncio
+async def test_falls_back_on_client_error():
+    session = _fake_session(raises=aiohttp.ClientConnectionError("refused"))
+    p1, p2 = _patches(session, model="m")
+    with p1, p2:
+        result = await r.list_models()
+    _assert_config_fallback(result, "m")
+
+
+@pytest.mark.asyncio
+async def test_falls_back_on_timeout():
+    session = _fake_session(raises=asyncio.TimeoutError())
+    p1, p2 = _patches(session, model="m")
+    with p1, p2:
+        result = await r.list_models()
+    _assert_config_fallback(result, "m")
+
+
+@pytest.mark.asyncio
+async def test_falls_back_on_malformed_json():
+    session = _fake_session(status=200, json_raises=json.JSONDecodeError("x", "", 0))
+    p1, p2 = _patches(session, model="m")
+    with p1, p2:
+        result = await r.list_models()
+    _assert_config_fallback(result, "m")
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_is_not_masked():
+    # A non-availability error (e.g. a real bug) must propagate rather than be
+    # silently turned into a healthy-looking config fallback.
+    session = _fake_session(raises=ValueError("boom"))
+    p1, p2 = _patches(session, model="m")
+    with p1, p2, pytest.raises(ValueError):
+        await r.list_models()


### PR DESCRIPTION
## Summary

`GET /v1/models` previously proxied vLLM's `/v1/models` and surfaced its errors
verbatim. When the vLLM server returns non-200 (e.g. its prometheus
instrumentator 500s on FastAPI ≥ 0.137) or is still starting, OpenAI-compatible
clients that probe `/v1/models` at startup break.

This makes `/v1/models` try the vLLM proxy first and fall back to a minimal
OpenAI-shaped model list built from `config["model"]`, so model discovery keeps
working during a vLLM `/v1/models` outage. It mirrors the proxy-then-config
fallback ScalarLM already uses in `resolve_max_model_length`.

## Behavior

- vLLM healthy → returns vLLM's `/v1/models` JSON unchanged (incl. adapters).
- vLLM `/v1/models` non-200 / connection error / timeout / malformed body →
  returns `{"object":"list","data":[{"id": <config model>, "object":"model",
  "owned_by":"scalarlm", ...}]}`, logged at warning level.
- A short request timeout (5 s) keeps a stalled vLLM from hanging discovery.
- **Unexpected** errors are intentionally **not** caught — they propagate, so a
  real bug surfaces instead of being masked as a healthy model list.

## Tests

`test/unit/test_list_models_fallback.py` (mirrors `test_resolve_max_model_length.py`):
proxy passthrough (asserting the timeout is applied), and fallback on non-200 /
connection error / timeout / malformed JSON, plus a guard that an unexpected
error propagates.

## Notes

- The fallback lists only the configured base model; the full list (incl.
  LoRA/tokenformer adapters) comes from the proxy path when vLLM is up —
  acceptable for a degraded discovery path.
- Keeps the diff focused (leaves the file's pre-existing formatting untouched).
