### PR TITLE
fix: finetune sweep training fixes (MoE, multimodal, adapter registry)

### DIFF
--- a/infra/cray_infra/training/register_megatron_models.py
+++ b/infra/cray_infra/training/register_megatron_models.py
@@ -8,6 +8,8 @@ import os
 
 import logging
 
+import yaml
+
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -37,14 +39,47 @@ async def get_models():
     if not os.path.exists(config["training_job_directory"]):
         return
 
+    served_base = config.get("model")
+
     for path in os.listdir(config["training_job_directory"]):
         root = os.path.join(config["training_job_directory"], path)
         logger.info(f"Checking {root}")
         # Look for any file matching *.pt* in this directory
         pt_files = list(Path(root).glob("*.pt"))
-        if pt_files:
-            logger.info(f"Found model {path}")
-            yield path
+        if not pt_files:
+            continue
+        # Only register adapters trained for the model this server is serving.
+        # The serve worker loads every registered adapter onto the single served
+        # base with no compatibility check; a LoRA trained for a different
+        # architecture has mismatched tensor shapes and crashes set_lora
+        # (IndexError in column_parallel_linear). In the multi-model finetune
+        # sweep the shared jobs/ dir accumulates adapters from many archs, so
+        # scope to the served base here. A missing/unreadable llm_name is kept
+        # (fail-open) so the ordinary single-model case is unaffected.
+        adaptor_base = _read_adaptor_base_model(root)
+        if served_base and adaptor_base and adaptor_base != served_base:
+            logger.info(
+                f"Skipping adaptor {path}: trained for {adaptor_base}, "
+                f"serving {served_base}"
+            )
+            continue
+        logger.info(f"Found model {path}")
+        yield path
+
+
+def _read_adaptor_base_model(job_directory_path):
+    """The base model (`llm_name`) an adapter was trained for, read from the
+    job's config.yaml, or None if unreadable."""
+    config_filepath = os.path.join(job_directory_path, "config.yaml")
+    try:
+        with open(config_filepath, "r") as file:
+            job_config = yaml.safe_load(file)
+    except (FileNotFoundError, yaml.YAMLError):
+        logger.warning(f"Could not read config.yaml in {job_directory_path}")
+        return None
+    if not job_config:
+        return None
+    return job_config.get("llm_name")
 
 
 async def get_registered_models():

--- a/ml/adapters/create_lora_model.py
+++ b/ml/adapters/create_lora_model.py
@@ -5,6 +5,8 @@ import logging
 
 from peft import get_peft_model, LoraConfig, TaskType
 
+from adapters.resolve_target_modules import resolve_target_modules
+
 logger = logging.getLogger(__name__)
 
 
@@ -15,7 +17,15 @@ def create_lora_model(model, device, train_lm_head=False):
     logger.info("Starting LoRA adapter module insertion...")
     step2_start = time.time()
     job_config = get_job_config()
-    lora_config = job_config["lora_config"]
+    lora_config = dict(job_config["lora_config"])
+
+    # Resolve PEFT's "all-linear" shorthand ourselves: its expansion silently
+    # fails for some architectures (Qwen3MoE under peft 0.19 + transformers 5.x)
+    # and raises "Target modules {char-set} not found" — the qwen3-moe sweep
+    # TRAIN_FAILED. For dense models this is identical to PEFT's expansion.
+    lora_config["target_modules"] = resolve_target_modules(
+        model, lora_config.get("target_modules", "all-linear")
+    )
 
     logger.info(f"LoRA config: {lora_config}")
 

--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -1,0 +1,153 @@
+"""Resolve PEFT's "all-linear" target-modules shorthand ourselves.
+
+PEFT's `LoraConfig(target_modules="all-linear")` is supposed to expand the
+shorthand to every linear layer except the output head. We resolve it ourselves
+for two reasons:
+
+1. **MoE.** Under peft 0.19 + transformers 5.x the expansion silently fails for
+   some architectures (observed for Qwen3MoeForCausalLM) and PEFT falls back to
+   iterating the literal string as a *set of characters*, raising
+   `Target modules {'-','l','n','r','i','a','e'} not found` — the `qwen3-moe`
+   TRAIN_FAILED in the cuda-spark sweep.
+
+2. **Multimodal.** For a `...ForConditionalGeneration` wrapper, "all-linear"
+   would also adapt the vision encoder. PEFT matches `target_modules` by name
+   *suffix across the whole model*, and a vision tower can reuse the language
+   tower's leaf names (Gemma3's `vision_tower...self_attn.k_proj`), so a plain
+   leaf-name set can't exclude it. We confine LoRA to the language decoder by
+   emitting its Linear modules' *full paths*.
+
+For dense models the result is the sorted leaf-name set — byte-identical to
+PEFT's own expansion (same trainable parameters).
+"""
+
+import torch.nn as nn
+
+# PEFT's sentinel for "adapt every linear layer except the output head".
+ALL_LINEAR = "all-linear"
+
+
+def _is_multimodal_model(model) -> bool:
+    """True for HF multimodal wrappers — they nest a `vision_config` on their
+    config. A `vision_config` present but `None` reads as not-multimodal."""
+    config = getattr(model, "config", None)
+    if config is None:
+        return False
+    return getattr(config, "vision_config", None) is not None
+
+
+def _language_decoder(model):
+    """The text-decoder submodule to confine LoRA to on a multimodal model, or
+    None when no scoping is needed (dense model, or no usable `get_decoder`).
+    `get_decoder()` is the standard HF handle for the text tower
+    (Gemma3TextModel, Qwen2VLTextModel)."""
+    if not _is_multimodal_model(model):
+        return None
+    if not hasattr(model, "get_decoder"):
+        return None
+    decoder = model.get_decoder()
+    if decoder is None or decoder is model:
+        return None
+    return decoder
+
+
+def _module_prefix(model, target) -> str | None:
+    """The dotted name of `target` within `model` (by identity), or None if it
+    isn't found among the model's submodules."""
+    for name, module in model.named_modules():
+        if module is target:
+            return name
+    return None
+
+
+# Self-attention container segments across the common decoder architectures.
+_ATTENTION_CONTAINERS = (".self_attn.", ".attn.", ".attention.")
+
+
+def _is_moe_model(model) -> bool:
+    """True if the model has routed MoE expert submodules (a `.experts` module).
+
+    A `.pt` adapter that adapts the fused experts can't be served: vLLM's
+    `FusedMoEWithLoRA.set_lora` wants a per-expert tensor *list* (gate/down/up,
+    each `[num_experts, rank, dim]`), while the ScalarLM trainer exports stacked
+    2-D tensors. Rather than reproduce vLLM's PEFT→fused-MoE conversion, we keep
+    LoRA off the experts and adapt attention only — which serves cleanly."""
+    return any(".experts" in name for name, _ in model.named_modules())
+
+
+def _attention_linear_names(model, output_embeddings) -> set[str]:
+    """Leaf names of the attention-projection `nn.Linear` modules (q/k/v/o under
+    a self-attention container). Excludes MLP, MoE experts, the router, and the
+    output head — everything that doesn't serve from a `.pt` MoE adapter."""
+    names: set[str] = set()
+    for module_name, module in model.named_modules():
+        if not isinstance(module, nn.Linear):
+            continue
+        if output_embeddings is not None and module is output_embeddings:
+            continue
+        if any(seg in module_name for seg in _ATTENTION_CONTAINERS):
+            names.add(module_name.split(".")[-1])
+    return names
+
+
+def resolve_target_modules(model, target_modules):
+    """If `target_modules` is the "all-linear" shorthand, resolve it against the
+    live `model`:
+
+    - **multimodal** (config has `vision_config`, `get_decoder()` available):
+      the full dotted paths of every `nn.Linear` under the language decoder,
+      excluding the output head. PEFT matches these exactly, so a vision tower
+      reusing the same leaf names is not adapted.
+    - **MoE** (has routed `.experts` submodules, non-multimodal): the sorted
+      attention-projection leaf names only. The fused-expert LoRA can't be served
+      from a `.pt` adapter (vLLM's `FusedMoEWithLoRA` wants a per-expert tensor
+      list, not stacked tensors), so LoRA is kept off the experts.
+    - **dense**: the sorted set of distinct `nn.Linear` leaf-module names,
+      excluding the output head — identical to PEFT's all-linear expansion.
+
+    Any other value — an explicit list, a non-shorthand string, or None — is
+    returned unchanged for PEFT to interpret itself.
+    """
+    if target_modules != ALL_LINEAR:
+        return target_modules
+
+    # Exclude the output projection. Prefer identity (handles heads not named
+    # "lm_head"); fall back to the conventional leaf name below.
+    output_embeddings = None
+    if hasattr(model, "get_output_embeddings"):
+        output_embeddings = model.get_output_embeddings()
+
+    decoder = _language_decoder(model)
+    if decoder is not None:
+        prefix = _module_prefix(model, decoder)
+        if prefix is not None:
+            return sorted(
+                name
+                for name, module in model.named_modules()
+                if isinstance(module, nn.Linear)
+                and module is not output_embeddings
+                and (name == prefix or name.startswith(prefix + "."))
+            )
+        # get_decoder() returned a module we couldn't locate — fall through to
+        # the dense path rather than silently adapt nothing.
+
+    if _is_moe_model(model):
+        # Attention-only for MoE: the fused-expert LoRA isn't serveable from a
+        # .pt adapter (see _is_moe_model), so confine LoRA to the attention
+        # projections, which load + serve cleanly.
+        attn = _attention_linear_names(model, output_embeddings)
+        if attn:
+            return sorted(attn)
+        # No attention modules matched (unusual arch) — fall through to the dense
+        # path rather than adapt nothing.
+
+    names = set()
+    for module_name, module in model.named_modules():
+        if not isinstance(module, nn.Linear):
+            continue
+        if output_embeddings is not None and module is output_embeddings:
+            continue
+        names.add(module_name.split(".")[-1])
+    names.discard("lm_head")  # belt-and-suspenders when get_output_embeddings()==None
+
+    return sorted(names)

--- a/ml/cray_megatron/megatron/doc_mask.py
+++ b/ml/cray_megatron/megatron/doc_mask.py
@@ -1,0 +1,56 @@
+"""Decide how to handle packed-document attention masking per batch/model.
+
+The trainer packs short documents into one block and builds a 4D
+block-diagonal+causal attention mask ``[B, 1, S, S]`` so packed documents don't
+attend across each other (see ``pack()`` in
+``dataset/load_language_model_dataset.py`` and ``training_step_accumulate`` in
+``training_loop.py``). Plain text decoders (Llama, Qwen, Gemma3ForCausalLM)
+accept the 4D mask.
+
+But some ``...ForConditionalGeneration`` wrappers compute their loss internally
+and index the logits by a *2D* attention_mask. Gemma3ForConditionalGeneration
+does ``shift_logits[shift_attention_mask != 0]`` (transformers
+``modeling_gemma3.py``); handed a 4D mask that index is 4D and raises
+``IndexError: too many indices for tensor of dimension 3`` — the gemma-3-4b-it
+TRAIN_FAILED in the cuda-spark fine-tune sweep. For those models we fall back to
+the 2D padding mask. The documented cost is that packed documents attend across
+each other (identical to the existing seq-len-cap fallback); for the
+single-document memorization sweep the 4D mask is a no-op anyway.
+"""
+
+# Decision outcomes for doc_mask_decision().
+BUILD = "build"                    # construct the 4D block-diagonal+causal mask
+SKIP_MULTIMODAL = "skip_multimodal"  # wrapper masks loss by a 2D mask; keep 2D
+SKIP_SEQLEN = "skip_seqlen"        # mask too large to materialize; keep 2D
+NONE = "none"                      # batch isn't packed (no document_ids)
+
+
+def is_multimodal(model_config) -> bool:
+    """True for HF multimodal wrapper configs (Gemma3/Qwen2-VL/Gemma4, …) — they
+    nest a ``vision_config``. A ``vision_config`` attribute that is present but
+    ``None`` reads as not-multimodal."""
+    if model_config is None:
+        return False
+    return getattr(model_config, "vision_config", None) is not None
+
+
+def doc_mask_decision(batch, seq_len: int, model_config, max_4d_mask_seq_len: int) -> str:
+    """Return how to handle packed-document attention for this batch:
+
+    - ``NONE``            — the batch isn't packed (no ``document_ids``).
+    - ``SKIP_MULTIMODAL`` — a multimodal wrapper that masks its loss by a 2D
+      attention_mask; a 4D mask would break that index. Keep the 2D mask.
+    - ``SKIP_SEQLEN``     — the mask would exceed ``max_4d_mask_seq_len``; keep
+      the 2D mask (legacy fallback).
+    - ``BUILD``           — construct the 4D block-diagonal+causal mask.
+
+    The multimodal check takes precedence over the seq-len cap: both fall back
+    to the 2D mask, but the multimodal reason is the one worth surfacing.
+    """
+    if "document_ids" not in batch:
+        return NONE
+    if is_multimodal(model_config):
+        return SKIP_MULTIMODAL
+    if seq_len > max_4d_mask_seq_len:
+        return SKIP_SEQLEN
+    return BUILD

--- a/ml/cray_megatron/megatron/training_loop.py
+++ b/ml/cray_megatron/megatron/training_loop.py
@@ -10,6 +10,13 @@ from cray_megatron.models.get_latest_checkpoint_path import (
 from cray_megatron.collectives.main_rank_only import main_rank_only, is_main_rank
 from cray_megatron.megatron.training_harness import TrainingHarness
 from cray_megatron.megatron import stop_flag
+from cray_megatron.megatron.doc_mask import (
+    doc_mask_decision,
+    is_multimodal,
+    BUILD,
+    SKIP_SEQLEN,
+    SKIP_MULTIMODAL,
+)
 
 from cray_infra.training.training_job_status import TrainingJobStatus
 from cray_infra.util.get_job_config import get_job_config
@@ -38,6 +45,7 @@ logger = logging.getLogger(__name__)
 # cap: the flex path uses a BlockMask that is O(S/128), not O(S²).
 _MAX_4D_MASK_SEQ_LEN = 16384
 _doc_mask_skip_warned = False
+_doc_mask_multimodal_warned = False
 
 
 def _warn_doc_mask_skipped(seq_len: int) -> None:
@@ -50,6 +58,19 @@ def _warn_doc_mask_skipped(seq_len: int) -> None:
         "Packed documents will attend across each other in this run. "
         "Set attn_implementation='flex_attention' in train_args to lift this limit.",
         seq_len, _MAX_4D_MASK_SEQ_LEN,
+    )
+
+
+def _warn_doc_mask_skipped_multimodal() -> None:
+    global _doc_mask_multimodal_warned
+    if _doc_mask_multimodal_warned:
+        return
+    _doc_mask_multimodal_warned = True
+    logger.warning(
+        "Skipping 4D document mask: multimodal wrapper masks its loss by a 2D "
+        "attention_mask (e.g. Gemma3ForConditionalGeneration indexes shift_logits "
+        "by it), so a 4D mask raises IndexError. Falling back to the 2D mask; "
+        "packed documents will attend across each other in this run."
     )
 
 
@@ -435,35 +456,43 @@ class TrainingLoop:
         # Capped at _MAX_4D_MASK_SEQ_LEN to keep memory bounded — above
         # that the mask is skipped and we fall back to legacy behavior
         # (a flash-attn varlen path is the right long-term fix).
-        if "document_ids" in batch:
-            seq_len = forward_kwargs["input_ids"].shape[-1]
-            if _use_flex_attention() and _FLEX_ATTENTION_AVAILABLE:
+        seq_len = forward_kwargs["input_ids"].shape[-1]
+        model_config = self.training_state.model_info.get("model_config")
+        decision = doc_mask_decision(batch, seq_len, model_config, _MAX_4D_MASK_SEQ_LEN)
+        use_flex = _use_flex_attention() and _FLEX_ATTENTION_AVAILABLE
+        if decision == SKIP_MULTIMODAL:
+            # A ...ForConditionalGeneration wrapper whose internal loss indexes
+            # the logits by a 2D attention_mask (gemma-3-4b-it). Keep the 2D mask
+            # from the batch — a 4D mask (SDPA or flex BlockMask) would IndexError.
+            _warn_doc_mask_skipped_multimodal()
+        elif decision == BUILD or (decision == SKIP_SEQLEN and use_flex):
+            # BUILD, or a sequence past the SDPA cap when flex_attention is on —
+            # the flex BlockMask is O(S/128), so _MAX_4D_MASK_SEQ_LEN doesn't apply.
+            doc_ids = batch["document_ids"].to(device)
+            if use_flex:
                 # flex_attention path: O(S/128) BlockMask, no sequence-length cap.
                 # Requires attn_implementation="flex_attention" in train_args so the
                 # model kernel and the mask format match.
-                doc_ids = batch["document_ids"].to(device)
                 forward_kwargs["attention_mask"] = _build_document_block_mask(doc_ids, device)
-                forward_kwargs["position_ids"] = batch["position_ids"].to(device)
-            elif seq_len <= _MAX_4D_MASK_SEQ_LEN:
-                # SDPA path: materialize the full causal block-diagonal bool mask.
-                # [B, 1, S, S] — 1 byte/cell. Capped at _MAX_4D_MASK_SEQ_LEN to
-                # keep memory bounded (128K² would be 16 GB).
-                doc_ids = batch["document_ids"].to(device)
+            else:
+                # SDPA path: materialize the [B, 1, S, S] causal block-diagonal
+                # bool mask (1 byte/cell, capped at _MAX_4D_MASK_SEQ_LEN).
                 same_doc = doc_ids.unsqueeze(2) == doc_ids.unsqueeze(1)
                 causal = torch.ones(
                     seq_len, seq_len, device=device, dtype=torch.bool
                 ).tril()
                 forward_kwargs["attention_mask"] = (same_doc & causal).unsqueeze(1)
-                forward_kwargs["position_ids"] = batch["position_ids"].to(device)
-            else:
-                _warn_doc_mask_skipped(seq_len)
+            forward_kwargs["position_ids"] = batch["position_ids"].to(device)
+        elif decision == SKIP_SEQLEN:
+            _warn_doc_mask_skipped(seq_len)
+        # decision == NONE: batch isn't packed; leave the 2D mask as-is.
 
         # Multimodal wrappers (Gemma4ForConditionalGeneration, …) require an
         # mm_token_type_ids tensor on every training forward, even when the
         # batch is pure text. The data loader produces text-only batches; pass
         # zeros so non-image tokens are tagged correctly. Detected by the
         # presence of a vision_config on the underlying model config.
-        if _is_multimodal(self.training_state.model_info.get("model_config")):
+        if is_multimodal(model_config):
             forward_kwargs["mm_token_type_ids"] = torch.zeros_like(
                 forward_kwargs["input_ids"]
             )
@@ -799,15 +828,6 @@ def get_gradient_clip_value():
     job_config = get_job_config()
     return job_config.get("gradient_clip_value", 1.0)
 
-
-def _is_multimodal(model_config) -> bool:
-    """True for HF multimodal wrapper configs (Gemma4, etc.) — they nest a
-    `vision_config` and require mm_token_type_ids on every training forward."""
-    if model_config is None:
-        return False
-    return hasattr(model_config, "vision_config") and getattr(
-        model_config, "vision_config"
-    ) is not None
 
 def get_warmup_steps():
     job_config = get_job_config()

--- a/ml/cray_megatron/models/load_model.py
+++ b/ml/cray_megatron/models/load_model.py
@@ -14,6 +14,9 @@ from cray_infra.util.get_config import get_config
 from transformers import AutoConfig
 from transformers import AutoTokenizer
 from transformers import AutoModelForCausalLM
+from transformers import AutoModelForImageTextToText
+
+from cray_megatron.megatron.doc_mask import is_multimodal
 
 import torch
 
@@ -68,11 +71,28 @@ def materialize_model(model_info):
     # attn_implementation; "auto" (the default) means SDPA.
     override = job_config.get("attn_implementation", "auto")
     attn_impl = override if (override and override != "auto") else "sdpa"
-    logger.info("Loading model with attn_implementation=%s", attn_impl)
+
+    # Multimodal wrappers (vision_config present) need the image-text-to-text
+    # AutoModel: AutoModelForCausalLM rejects e.g. Qwen2VLConfig at load
+    # ("Unrecognized configuration class ... for AutoModelForCausalLM"), which
+    # is the Qwen2-VL TRAIN_FAILED in the cuda-spark sweep. AutoModelForImage-
+    # TextToText loads both Qwen2-VL and Gemma3 conditional-generation models;
+    # the text-only training forward works on them (LoRA is confined to the
+    # language tower by resolve_target_modules).
+    model_cls = (
+        AutoModelForImageTextToText
+        if is_multimodal(model_info["model_config"])
+        else AutoModelForCausalLM
+    )
+    logger.info(
+        "Loading model with %s, attn_implementation=%s",
+        model_cls.__name__,
+        attn_impl,
+    )
 
     start_time = time.time()
     try:
-        model_info["model"] = AutoModelForCausalLM.from_pretrained(
+        model_info["model"] = model_cls.from_pretrained(
             model_info["model_name"],
             torch_dtype="auto",  # Use model's native dtype
             attn_implementation=attn_impl,
@@ -93,7 +113,7 @@ def materialize_model(model_info):
                 e,
             )
             attn_impl = "eager"
-            model_info["model"] = AutoModelForCausalLM.from_pretrained(
+            model_info["model"] = model_cls.from_pretrained(
                 model_info["model_name"],
                 torch_dtype="auto",
                 attn_implementation="eager",


### PR DESCRIPTION
## Summary

- **`register_megatron_models`**: scope adapter registry to the served base model — reads `llm_name` from each job's `config.yaml` and skips adapters trained for a different architecture (fail-open when `config.yaml` is missing)
- **`ml/adapters/resolve_target_modules`** (new): custom `all-linear` resolution — PEFT 0.19 + transformers 5.x silently falls back to char-set iteration for Qwen3MoE; multimodal models get full decoder paths to prevent vision-tower leakage; MoE models get attention-only targets (fused-expert LoRA not serveable from `.pt`)
- **`ml/adapters/create_lora_model`**: wire `resolve_target_modules` before `get_peft_model`; dict-copy `lora_config` so we don't mutate the job config in place
- **`ml/cray_megatron/megatron/doc_mask`** (new): per-model mask decision engine (`BUILD` / `SKIP_MULTIMODAL` / `SKIP_SEQLEN` / `NONE`); extracts `is_multimodal()` for reuse in `load_model`
- **`ml/cray_megatron/megatron/training_loop`**: use `doc_mask_decision` instead of inline if-chain; add `SKIP_MULTIMODAL` path with one-shot warning (fixes Gemma3 `IndexError: too many indices for tensor of dimension 3`); remove now-redundant `_is_multimodal`
- **`ml/cray_megatron/models/load_model`**: use `AutoModelForImageTextToText` for multimodal configs (`AutoModelForCausalLM` rejects Qwen2VLConfig/Gemma3 conditional-generation at load)

Authored by Georgi Georgiev, integrated from `georgi/finetune-sweep` branch.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)