### PR TITLE
feat(adapters): adapt dense-MLP LoRA on MoE models, not attention-only

### DIFF
--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -8,7 +8,10 @@ for two reasons:
    some architectures (observed for Qwen3MoeForCausalLM) and PEFT falls back to
    iterating the literal string as a *set of characters*, raising
    `Target modules {'-','l','n','r','i','a','e'} not found` — the `qwen3-moe`
-   TRAIN_FAILED in the cuda-spark sweep.
+   TRAIN_FAILED in the cuda-spark sweep. We also keep LoRA off the routed
+   experts (their fused LoRA isn't `.pt`-serveable) while still adapting the
+   attention and any dense MLP — see `_moe_servable_linear_paths` and
+   `docs/reports/2026-06-30-moe-expert-lora-serving.md`.
 
 2. **Multimodal.** For a `...ForConditionalGeneration` wrapper, "all-linear"
    would also adapt the vision encoder. PEFT matches `target_modules` by name
@@ -60,34 +63,47 @@ def _module_prefix(model, target) -> str | None:
     return None
 
 
-# Self-attention container segments across the common decoder architectures.
-_ATTENTION_CONTAINERS = (".self_attn.", ".attn.", ".attention.")
-
-
 def _is_moe_model(model) -> bool:
     """True if the model has routed MoE expert submodules (a `.experts` module).
 
-    A `.pt` adapter that adapts the fused experts can't be served: vLLM's
+    A `.pt` adapter that adapts the *fused experts* can't be served: vLLM's
     `FusedMoEWithLoRA.set_lora` wants a per-expert tensor *list* (gate/down/up,
     each `[num_experts, rank, dim]`), while the ScalarLM trainer exports stacked
     2-D tensors. Rather than reproduce vLLM's PEFT→fused-MoE conversion, we keep
-    LoRA off the experts and adapt attention only — which serves cleanly."""
+    LoRA off the experts (and the router) and adapt everything else that *does*
+    serve from a `.pt` adapter — see `_moe_servable_linear_paths`."""
     return any(".experts" in name for name, _ in model.named_modules())
 
 
-def _attention_linear_names(model, output_embeddings) -> set[str]:
-    """Leaf names of the attention-projection `nn.Linear` modules (q/k/v/o under
-    a self-attention container). Excludes MLP, MoE experts, the router, and the
-    output head — everything that doesn't serve from a `.pt` MoE adapter."""
-    names: set[str] = set()
+def _moe_servable_linear_paths(model, output_embeddings) -> list[str]:
+    """Full dotted paths of every `nn.Linear` in a MoE model whose LoRA a `.pt`
+    adapter can serve: the attention projections (all layers) and any *dense*
+    MLP — the non-sparse decoder layers, e.g. layer 0 under Qwen3MoE's
+    `decoder_sparse_step`. Excludes:
+
+    - the routed `.experts` (their fused LoRA isn't `.pt`-serveable, see
+      `_is_moe_model`),
+    - the router `gate` (adapting it would perturb expert selection), and
+    - the output head.
+
+    *Full paths* — not leaf names — because the dense-MLP projections
+    (`gate_proj`/`up_proj`/`down_proj`) reuse the SAME leaf names as the expert
+    projections, so a leaf-name set can't include one while excluding the other.
+    PEFT matches these exact paths, so the experts are left untouched."""
+    paths: list[str] = []
     for module_name, module in model.named_modules():
         if not isinstance(module, nn.Linear):
             continue
         if output_embeddings is not None and module is output_embeddings:
             continue
-        if any(seg in module_name for seg in _ATTENTION_CONTAINERS):
-            names.add(module_name.split(".")[-1])
-    return names
+        if module_name.endswith("lm_head"):  # head, when output_embeddings is None
+            continue
+        if ".experts" in module_name:  # routed experts — not .pt-serveable
+            continue
+        if module_name.endswith(".gate") or module_name == "gate":  # MoE router
+            continue
+        paths.append(module_name)
+    return paths
 
 
 def resolve_target_modules(model, target_modules):
@@ -99,9 +115,12 @@ def resolve_target_modules(model, target_modules):
       excluding the output head. PEFT matches these exactly, so a vision tower
       reusing the same leaf names is not adapted.
     - **MoE** (has routed `.experts` submodules, non-multimodal): the sorted
-      attention-projection leaf names only. The fused-expert LoRA can't be served
-      from a `.pt` adapter (vLLM's `FusedMoEWithLoRA` wants a per-expert tensor
-      list, not stacked tensors), so LoRA is kept off the experts.
+      *full paths* of every serveable `nn.Linear` — attention (all layers) plus
+      any dense (non-sparse) MLP — excluding the routed experts, the router
+      `gate`, and the output head. The fused-expert LoRA can't be served from a
+      `.pt` adapter (vLLM's `FusedMoEWithLoRA` wants a per-expert tensor list,
+      not stacked tensors), so LoRA is kept off the experts; full paths (not leaf
+      names) are required because the dense MLP shares the experts' leaf names.
     - **dense**: the sorted set of distinct `nn.Linear` leaf-module names,
       excluding the output head — identical to PEFT's all-linear expansion.
 
@@ -132,14 +151,15 @@ def resolve_target_modules(model, target_modules):
         # the dense path rather than silently adapt nothing.
 
     if _is_moe_model(model):
-        # Attention-only for MoE: the fused-expert LoRA isn't serveable from a
-        # .pt adapter (see _is_moe_model), so confine LoRA to the attention
-        # projections, which load + serve cleanly.
-        attn = _attention_linear_names(model, output_embeddings)
-        if attn:
-            return sorted(attn)
-        # No attention modules matched (unusual arch) — fall through to the dense
-        # path rather than adapt nothing.
+        # MoE: emit full paths for the .pt-serveable linears — attention (all
+        # layers) + any dense (non-sparse) MLP — while excluding the routed
+        # experts (not serveable, see _is_moe_model) and the router. Full paths,
+        # not leaf names, because the dense MLP shares the experts' leaf names.
+        paths = _moe_servable_linear_paths(model, output_embeddings)
+        if paths:
+            return sorted(paths)
+        # Nothing matched (unusual arch) — fall through to the dense path rather
+        # than adapt nothing.
 
     names = set()
     for module_name, module in model.named_modules():

--- a/test/unit/test_resolve_target_modules.py
+++ b/test/unit/test_resolve_target_modules.py
@@ -1,0 +1,280 @@
+"""
+Unit tests for adapters.resolve_target_modules.resolve_target_modules.
+
+PEFT's "all-linear" shorthand fails to expand for some architectures
+(notably MoE: Qwen3MoeForCausalLM under peft 0.19 + transformers 5.x). PEFT
+falls back to iterating the literal string as a set of characters and raises
+`Target modules {'-','l','n','r','i','a','e'} not found in the base model`,
+which is the qwen3-moe TRAIN_FAILED in the cuda-spark sweep. We resolve the
+shorthand ourselves from the live model, so these tests use small synthetic
+nn.Modules rather than HF downloads.
+"""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from adapters.resolve_target_modules import resolve_target_modules
+
+
+class _DenseLike(nn.Module):
+    """A miniature ...ForCausalLM: attention + MLP projections + an output head,
+    with several layers so leaf names repeat (as in a real stacked model)."""
+
+    def __init__(self, n_layers=3):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+class _NoOutputEmbeddings(nn.Module):
+    """A model whose get_output_embeddings() returns None (some configs do);
+    the output head must still be excluded by its conventional leaf name."""
+
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(8, 8, bias=False)
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return None
+
+
+class _MoeLike(nn.Module):
+    """A miniature Qwen3MoE-style ...ForCausalLM mirroring `decoder_sparse_step`:
+    some decoder layers carry a *dense* MLP (`gate_proj`/`up_proj`/`down_proj`)
+    and others a *sparse* MLP with a router (`gate`) + routed `experts`. By
+    default layer 0 is dense and layer 1 is sparse — the real
+    `qwen3-moe-tiny-random` layout (decoder_sparse_step=2). The routed experts
+    and the router can't be served from a .pt adapter, so resolution must adapt
+    attention + the dense MLP only — and by *full path*, since the dense MLP
+    shares leaf names with the experts."""
+
+    def __init__(self, sparse_layers=(1,), n_layers=2, n_experts=4):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _sparse_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate": nn.Linear(8, n_experts, bias=False),  # router
+                    "experts": nn.ModuleList(
+                        nn.ModuleDict(
+                            {
+                                "gate_proj": nn.Linear(8, 8, bias=False),
+                                "up_proj": nn.Linear(8, 8, bias=False),
+                                "down_proj": nn.Linear(8, 8, bias=False),
+                            }
+                        )
+                        for _ in range(n_experts)
+                    ),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mlp": _sparse_mlp() if i in sparse_layers else _dense_mlp(),
+                }
+            )
+            for i in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_moe_adapts_attention_and_dense_mlp_excluding_experts_and_router():
+    # Layer 0 dense, layer 1 sparse (the real qwen3-moe-tiny-random layout).
+    model = _MoeLike(sparse_layers=(1,), n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    # Full paths: attention on every layer + the DENSE MLP (layer 0 only),
+    # but no experts, no router, no head.
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any(".experts." in name for name in result)  # no routed experts
+    assert not any(name.endswith(".gate") for name in result)  # no router
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_moe_all_layers_sparse_adapts_attention_only():
+    # If every layer is sparse (no dense MLP anywhere), only attention survives.
+    model = _MoeLike(sparse_layers=(0, 1), n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any("mlp" in name for name in result)
+
+
+def test_all_linear_expands_to_distinct_leaf_names_minus_head():
+    model = _DenseLike()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == [
+        "down_proj",
+        "gate_proj",
+        "k_proj",
+        "o_proj",
+        "q_proj",
+        "up_proj",
+        "v_proj",
+    ]
+    assert "lm_head" not in resolved
+
+
+def test_repeated_leaf_names_collapse_to_a_set():
+    # 3 layers × 7 projections, but only 7 distinct leaf names survive.
+    model = _DenseLike(n_layers=3)
+    resolved = resolve_target_modules(model, "all-linear")
+    assert len(resolved) == 7
+
+
+def test_output_head_excluded_by_name_when_no_output_embeddings():
+    model = _NoOutputEmbeddings()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == ["q_proj"]
+
+
+class _Decoder(nn.Module):
+    """A miniature language tower: one block of attention + MLP projections."""
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "q_proj": nn.Linear(8, 8, bias=False),
+                        "k_proj": nn.Linear(8, 8, bias=False),
+                        "v_proj": nn.Linear(8, 8, bias=False),
+                        "o_proj": nn.Linear(8, 8, bias=False),
+                    }
+                )
+            ]
+        )
+
+
+class _VisionTower(nn.Module):
+    """A vision encoder that REUSES the language tower's leaf names — the
+    Gemma3 case that defeats plain leaf-name targeting."""
+
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.ModuleDict(
+            {
+                "q_proj": nn.Linear(8, 8, bias=False),
+                "k_proj": nn.Linear(8, 8, bias=False),
+            }
+        )
+
+
+class _MultimodalModel(nn.Module):
+    """A ...ForConditionalGeneration-shaped wrapper: a `vision_config` on the
+    config, `get_decoder()` returning the language tower, a vision tower whose
+    linears share leaf names with the language tower, and a tied output head."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+        self.language_model = _Decoder()
+        self.vision_tower = _VisionTower()
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_multimodal_targets_full_paths_under_language_decoder_only():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    # Every target is a full path inside the language tower...
+    assert resolved == [
+        "language_model.layers.0.k_proj",
+        "language_model.layers.0.o_proj",
+        "language_model.layers.0.q_proj",
+        "language_model.layers.0.v_proj",
+    ]
+    # ...and nothing in the vision tower, despite the shared k_proj/q_proj names.
+    assert not any("vision_tower" in name for name in resolved)
+
+
+def test_multimodal_resolution_excludes_output_head():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert not any(name.endswith("lm_head") for name in resolved)
+
+
+def test_explicit_list_is_passed_through_unchanged():
+    model = _DenseLike()
+    explicit = ["q_proj", "v_proj"]
+    assert resolve_target_modules(model, explicit) is explicit
+
+
+def test_explicit_non_shorthand_string_passes_through():
+    model = _DenseLike()
+    # A regex/string that isn't the "all-linear" shorthand is PEFT's own
+    # to interpret — we must not touch it.
+    assert resolve_target_modules(model, "q_proj") == "q_proj"
+
+
+def test_none_passes_through():
+    model = _DenseLike()
+    assert resolve_target_modules(model, None) is None


### PR DESCRIPTION
resolve_target_modules kept LoRA off *all* MLP on a routed-MoE model and adapted attention only, because the fused-expert LoRA can't be served from a .pt adapter (vLLM's FusedMoEWithLoRA wants a per-expert tensor list, not the trainer's stacked 2-D tensors). But that also excluded the *dense* (non-sparse) MLP layers that some MoE arches carry (e.g. Qwen3MoE's decoder_sparse_step leaves early layers dense) — those linears serve fine from a .pt adapter and were being left unadapted.

Emit the full dotted paths of every .pt-serveable nn.Linear — attention on all layers plus any dense MLP — while still excluding the routed .experts, the router gate, and the output head. Full paths (not leaf names) are required because the dense MLP reuses the experts' leaf names (gate_proj/up_proj/down_proj), so a leaf-name set can't include one while excluding the other; PEFT matches these exact paths, leaving experts untouched. A fully-sparse model (no dense MLP) still resolves to attention only, unchanged.

Adds test/unit/test_resolve_target_modules.py (previously untested): covers the dense+sparse mix (real qwen3-moe-tiny-random layout), the all-sparse fallback, and the multimodal / dense paths.