### PR TITLE
fix(api): preserve OpenAI chat semantics across inference queue

### DIFF
--- a/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/build_chat_completion_response.py
@@ -27,7 +27,6 @@ accurate even if the split is approximate.
 import time
 from typing import Any
 
-
 CHAT_COMPLETION_OBJECT = "chat.completion"
 
 
@@ -51,11 +50,23 @@ def build_chat_completion_response(
     result = _unwrap_group_dict(result)
 
     error = result.get("error")
-    content = "" if error else (result.get("response") or "")
+    tool_calls = None if error else result.get("tool_calls")
+    content: str | None = "" if error else (result.get("response") or "")
+    reasoning = None if error else result.get("reasoning")
+
+    # OpenAI represents a tool-call-only assistant turn with null content.
+    if tool_calls and not content:
+        content = None
 
     chat_id = _build_chat_id(result.get("request_id"))
     finish_reason = "stop" if not error else "error"
     prompt_tokens, completion_tokens, total_tokens = _resolve_usage(result)
+
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if reasoning is not None:
+        message["reasoning"] = reasoning
+    if tool_calls is not None:
+        message["tool_calls"] = tool_calls
 
     response: dict[str, Any] = {
         "id": chat_id,
@@ -65,11 +76,8 @@ def build_chat_completion_response(
         "choices": [
             {
                 "index": 0,
-                "message": {
-                    "role": "assistant",
-                    "content": content,
-                },
-                "finish_reason": finish_reason,
+                "message": message,
+                "finish_reason": result.get("finish_reason") or finish_reason,
                 "logprobs": None,
             }
         ],

--- a/infra/cray_infra/api/fastapi/chat_completions/check_request_length.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/check_request_length.py
@@ -9,8 +9,8 @@ followed by a timeout. This helper rejects them up front so the
 client gets HTTP 400 with a clear reason instead.
 
 The check is a pure threshold computation; the handler is responsible
-for getting `prompt_tokens` from a tokenizer it already loaded for
-chat-template rendering. Splitting concerns this way keeps the
+for getting both `prompt_tokens` and `max_model_length` from vLLM's
+authoritative runtime renderer. Splitting concerns this way keeps the
 threshold logic trivially unit-testable without a real tokenizer.
 """
 

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -7,7 +7,7 @@ queue. See docs/openai-chat-completions-queue.md §3.1.
 
 The handler is a thin orchestrator over four foundation pieces:
 
-  1. render_chat_template — turns `messages: [...]` into a prompt str
+  1. vLLM /tokenize — performs the authoritative runtime render for admission
   2. is_over_high_water + WaitEstimator — admission decision and 429
      Retry-After hint
   3. ResultRouter — registers a correlation_id before submission so
@@ -44,17 +44,19 @@ from cray_infra.api.fastapi.chat_completions.heartbeat import (
     stream_with_heartbeat,
 )
 from cray_infra.api.fastapi.chat_completions.render_chat_template import (
-    count_prompt_tokens,
     render_chat_template,
 )
-from cray_infra.api.fastapi.chat_completions.resolve_max_model_length import (
-    resolve_max_model_length,
+from cray_infra.api.fastapi.chat_completions.tokenize_chat_for_admission import (
+    VLLMTokenizeRequestError,
+    tokenize_chat_for_admission,
 )
 from cray_infra.api.fastapi.chat_completions.result_router import (
     ResultRouter,
     get_result_router,
 )
-from cray_infra.api.fastapi.routers.openai_v1_helpers import _filter_chat_params
+from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _chat_params_from_request,
+)
 from cray_infra.generate.metrics import get_metrics
 from cray_infra.util.get_config import get_config
 
@@ -103,8 +105,7 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     # 401. Mirrors `/v1/generate`'s resolution (generate.py:50-63).
     model = _resolve_model(getattr(request, "model", None), config)
 
-    raw_chat_request = request.model_dump(mode="json", exclude_none=True)
-    chat_request = _filter_chat_params(raw_chat_request)
+    chat_request = _chat_params_from_request(request)
 
     # vLLM gives the newer max_completion_tokens field precedence over the
     # deprecated max_tokens field. Resolve that same effective budget before
@@ -119,45 +120,49 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         effective_max_tokens = int(config.get("default_max_output_tokens", 128))
         chat_request["max_tokens"] = effective_max_tokens
 
-    rendered_prompt = render_chat_template(
-        model=model,
-        messages=request.messages,
-        prompt=None,
-        chat_template_kwargs=chat_request.get("chat_template_kwargs"),
-        tools=chat_request.get("tools"),
-        reasoning_effort=chat_request.get("reasoning_effort"),
-    )
+    # Resolve these fields before either renderer sees the request.
+    chat_request.update({"model": model, "stream": False})
 
-    # Pre-admission length check: vLLM doesn't reject prompts that
-    # exceed the per-request KV budget — the scheduler queues them
-    # and the request stalls forever. Reject up front with a clear
-    # 400 so the client can shorten or split. Tokenizer is the
-    # cached one render_chat_template already loaded, so this is a
-    # microsecond-scale check on the hot path. The cap comes from
-    # vLLM's runtime config (per-model, cached) rather than the
-    # cray-config knob — that knob default is 256 and tends to drift
-    # stale after operator-side model changes. resolve_max_model_length
-    # falls back to the config value when vLLM is unreachable, and
-    # treats <= 0 as "no cap" so we don't block requests on transient
-    # vLLM unavailability.
-    max_model_length = await resolve_max_model_length(model)
-    if max_model_length > 0:
+    # Ask vLLM to render and tokenize with its actual runtime renderer. The
+    # API pod cannot reproduce a --chat-template supplied only through the
+    # vLLM pod's SCALARLM_VLLM_ARGS, and specialized renderers may not match
+    # transformers.apply_chat_template either. /tokenize uses the configured
+    # template and OnlineRenderer in both vLLM 0.26 and 0.27.
+    try:
+        tokenization = await tokenize_chat_for_admission(
+            model=model,
+            chat_request=chat_request,
+        )
+    except VLLMTokenizeRequestError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    if tokenization is not None:
         try:
             check_request_length(
-                prompt_tokens=count_prompt_tokens(rendered_prompt, model=model),
+                prompt_tokens=tokenization.prompt_tokens,
                 max_tokens=effective_max_tokens,
-                max_model_length=max_model_length,
+                max_model_length=tokenization.max_model_length,
             )
         except RequestTooLongError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
+
+    # Keep a string prompt for origin/main workers during an API-first rolling
+    # upgrade. This is deliberately computed *after* authoritative runtime
+    # tokenization: the API tokenizer may lack a template supplied only to the
+    # vLLM pod via --chat-template. Such a local mismatch must not reject an
+    # otherwise valid request. Current workers ignore this compatibility field
+    # and rehydrate ``chat_request`` through vLLM's chat serving path.
+    rendered_prompt = _render_legacy_worker_prompt(
+        model=model,
+        messages=request.messages,
+        chat_request=chat_request,
+    )
 
     # Preserve the validated, JSON-safe chat request across the queue
     # boundary so the worker can invoke vLLM's chat-completions serving path.
     # The pre-rendered prompt remains useful for admission and inspection,
     # but feeding it to /v1/completions bypasses vLLM's reasoning and tool
     # parsers and collapses their structured output into visible text.
-    chat_request.update({"model": model, "stream": False})
-
     correlation_id = str(uuid4())
     future = router.register(correlation_id)
     get_metrics().record_chat_admitted(correlation_id)
@@ -168,7 +173,10 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         "max_tokens": effective_max_tokens,
         "temperature": getattr(request, "temperature", None),
         "chat_request": chat_request,
-        "request_type": "chat_completions",
+        # Keep the origin/main discriminator so a rolling upgrade does not
+        # feed an old worker an unknown request type. New workers identify the
+        # chat path from the presence of ``chat_request``.
+        "request_type": "generate",
         "correlation_id": correlation_id,
     }
 
@@ -178,6 +186,73 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         _stream_and_unregister(future, correlation_id, router, model),
         media_type="application/json",
     )
+
+
+def _render_legacy_worker_prompt(
+    *, model: str, messages: list[Any], chat_request: dict[str, Any]
+) -> str:
+    """Best-effort string prompt for an old worker during rolling upgrades.
+
+    The structured ``chat_request`` is authoritative. If the API pod cannot
+    reproduce vLLM's server-only template, fall back to a plain text transcript
+    instead of preempting a request that the runtime renderer already accepted.
+    Non-text multimodal parts become short placeholders so data URLs are not
+    duplicated into the compatibility prompt.
+    """
+    try:
+        return render_chat_template(
+            model=model,
+            messages=messages,
+            prompt=None,
+            chat_template_kwargs=chat_request.get("chat_template_kwargs"),
+            tools=chat_request.get("tools"),
+            reasoning_effort=chat_request.get("reasoning_effort"),
+        )
+    except Exception as exc:
+        logger.warning(
+            "Local compatibility prompt render failed for model %s (%s); "
+            "using a plain transcript for legacy workers",
+            model,
+            type(exc).__name__,
+        )
+        return _plain_chat_transcript(chat_request.get("messages", []))
+
+
+def _plain_chat_transcript(messages: list[Any]) -> str:
+    lines: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            lines.append(f"unknown: {message}")
+            continue
+        role = message.get("role") or "unknown"
+        lines.append(f"{role}: {_plain_message_content(message.get('content'))}")
+    lines.append("assistant:")
+    return "\n".join(lines)
+
+
+def _plain_message_content(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if content is None:
+        return ""
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    for part in content:
+        if isinstance(part, str):
+            parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            parts.append("[content]")
+            continue
+        part_type = part.get("type")
+        text = part.get("text")
+        if part_type in {"text", "input_text"} and isinstance(text, str):
+            parts.append(text)
+        else:
+            parts.append(f"[{part_type or 'content'}]")
+    return " ".join(parts)
 
 
 def _resolve_model(requested: Any, config: dict) -> str:

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -54,6 +54,7 @@ from cray_infra.api.fastapi.chat_completions.result_router import (
     ResultRouter,
     get_result_router,
 )
+from cray_infra.api.fastapi.routers.openai_v1_helpers import _filter_chat_params
 from cray_infra.generate.metrics import get_metrics
 from cray_infra.util.get_config import get_config
 
@@ -102,10 +103,14 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     # 401. Mirrors `/v1/generate`'s resolution (generate.py:50-63).
     model = _resolve_model(getattr(request, "model", None), config)
 
+    raw_chat_request = request.model_dump(mode="json", exclude_none=True)
+    chat_request = _filter_chat_params(raw_chat_request)
+
     rendered_prompt = render_chat_template(
         model=model,
         messages=request.messages,
         prompt=None,
+        chat_template_kwargs=chat_request.get("chat_template_kwargs"),
     )
 
     # Pre-admission length check: vLLM doesn't reject prompts that
@@ -146,6 +151,19 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         else int(config.get("default_max_output_tokens", 128))
     )
 
+    # Preserve the validated, JSON-safe chat request across the queue
+    # boundary so the worker can invoke vLLM's chat-completions serving path.
+    # The pre-rendered prompt remains useful for admission and inspection,
+    # but feeding it to /v1/completions bypasses vLLM's reasoning and tool
+    # parsers and collapses their structured output into visible text.
+    chat_request.update(
+        {
+            "model": model,
+            "max_tokens": effective_max_tokens,
+            "stream": False,
+        }
+    )
+
     correlation_id = str(uuid4())
     future = router.register(correlation_id)
     get_metrics().record_chat_admitted(correlation_id)
@@ -155,14 +173,8 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         "model": model,
         "max_tokens": effective_max_tokens,
         "temperature": getattr(request, "temperature", None),
-        # The worker's dispatcher (`async_generate_task` in
-        # create_generate_worker.py) only recognises "generate". The
-        # rendered_prompt is a string, so it routes through
-        # `async_completion_task` to /v1/completions in vLLM — which
-        # is what we want, because the chat template is already
-        # applied. We rewrap the worker's response into a
-        # ChatCompletion shape below.
-        "request_type": "generate",
+        "chat_request": chat_request,
+        "request_type": "chat_completions",
         "correlation_id": correlation_id,
     }
 
@@ -293,5 +305,3 @@ def get_queue_depth() -> int:
     from cray_infra.generate.metrics import get_metrics
 
     return get_metrics().queue_depth
-
-

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -106,11 +106,26 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     raw_chat_request = request.model_dump(mode="json", exclude_none=True)
     chat_request = _filter_chat_params(raw_chat_request)
 
+    # vLLM gives the newer max_completion_tokens field precedence over the
+    # deprecated max_tokens field. Resolve that same effective budget before
+    # admission and preserve the original field on the queued request.
+    requested_max_completion_tokens = chat_request.get("max_completion_tokens")
+    requested_max_tokens = chat_request.get("max_tokens")
+    if requested_max_completion_tokens is not None:
+        effective_max_tokens = int(requested_max_completion_tokens)
+    elif requested_max_tokens is not None:
+        effective_max_tokens = int(requested_max_tokens)
+    else:
+        effective_max_tokens = int(config.get("default_max_output_tokens", 128))
+        chat_request["max_tokens"] = effective_max_tokens
+
     rendered_prompt = render_chat_template(
         model=model,
         messages=request.messages,
         prompt=None,
         chat_template_kwargs=chat_request.get("chat_template_kwargs"),
+        tools=chat_request.get("tools"),
+        reasoning_effort=chat_request.get("reasoning_effort"),
     )
 
     # Pre-admission length check: vLLM doesn't reject prompts that
@@ -130,39 +145,18 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
         try:
             check_request_length(
                 prompt_tokens=count_prompt_tokens(rendered_prompt, model=model),
-                max_tokens=getattr(request, "max_tokens", None),
+                max_tokens=effective_max_tokens,
                 max_model_length=max_model_length,
             )
         except RequestTooLongError as exc:
             raise HTTPException(status_code=400, detail=str(exc))
-
-    # Default max_tokens before the request hits the worker. vLLM's
-    # CompletionResponse builder asserts non-None
-    # (vllm/entrypoints/openai/completion/serving.py:481), so passing
-    # None all the way through generates the response — and then
-    # crashes building it with a bare `AssertionError` whose
-    # `str()` is empty. The OpenAI SDK lets clients omit max_tokens;
-    # we plug in `default_max_output_tokens` here so the queue path
-    # has a real number to hand vLLM.
-    requested_max_tokens = getattr(request, "max_tokens", None)
-    effective_max_tokens = (
-        requested_max_tokens
-        if requested_max_tokens is not None
-        else int(config.get("default_max_output_tokens", 128))
-    )
 
     # Preserve the validated, JSON-safe chat request across the queue
     # boundary so the worker can invoke vLLM's chat-completions serving path.
     # The pre-rendered prompt remains useful for admission and inspection,
     # but feeding it to /v1/completions bypasses vLLM's reasoning and tool
     # parsers and collapses their structured output into visible text.
-    chat_request.update(
-        {
-            "model": model,
-            "max_tokens": effective_max_tokens,
-            "stream": False,
-        }
-    )
+    chat_request.update({"model": model, "stream": False})
 
     correlation_id = str(uuid4())
     future = router.register(correlation_id)

--- a/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
@@ -50,6 +50,8 @@ def render_chat_template(
     messages: Optional[List[ChatMessage]],
     prompt: Optional[str],
     chat_template_kwargs: Optional[Dict[str, Any]] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    reasoning_effort: Optional[str] = None,
 ) -> str:
     """
     Render one request entry into a prompt string.
@@ -61,8 +63,12 @@ def render_chat_template(
     downstream.
 
     `chat_template_kwargs` is restricted to ScalarLM's shared safe
-    allowlist before it is passed to the tokenizer. Raw prompts bypass
-    template rendering, so the kwargs are ignored for that input shape.
+    allowlist before it is passed to the tokenizer. vLLM derives
+    `enable_thinking` from an explicit reasoning effort when the caller
+    did not already set it; mirror that rule here so admission counts the
+    prompt vLLM will actually serve. Tool definitions are likewise part
+    of many model chat templates. Raw prompts bypass template rendering,
+    so these values are ignored for that input shape.
     """
     has_messages = bool(messages)
     has_prompt = bool(prompt)
@@ -79,12 +85,19 @@ def render_chat_template(
         return prompt  # type: ignore[return-value]
 
     tokenizer = _load_tokenizer(model)
-    return tokenizer.apply_chat_template(
-        messages,
-        tokenize=False,
-        add_generation_prompt=True,
-        **_sanitize_chat_template_kwargs(chat_template_kwargs),
-    )
+    template_kwargs = _sanitize_chat_template_kwargs(chat_template_kwargs)
+    if reasoning_effort is not None:
+        template_kwargs.setdefault("enable_thinking", reasoning_effort != "none")
+
+    render_kwargs: Dict[str, Any] = {
+        "tokenize": False,
+        "add_generation_prompt": True,
+        **template_kwargs,
+    }
+    if tools is not None:
+        render_kwargs["tools"] = tools
+
+    return tokenizer.apply_chat_template(messages, **render_kwargs)
 
 
 def _load_tokenizer(model: str) -> Any:

--- a/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
@@ -14,6 +14,10 @@ See docs/openai-chat-completions-queue.md §4.
 import os
 from typing import Any, Dict, List, Optional
 
+from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _sanitize_chat_template_kwargs,
+)
+
 ChatMessage = Dict[str, Any]
 
 
@@ -45,6 +49,7 @@ def render_chat_template(
     model: str,
     messages: Optional[List[ChatMessage]],
     prompt: Optional[str],
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
 ) -> str:
     """
     Render one request entry into a prompt string.
@@ -54,6 +59,10 @@ def render_chat_template(
     misconfigurations on the caller's side surface as a clear
     ValueError rather than an opaque tokenizer or vLLM error
     downstream.
+
+    `chat_template_kwargs` is restricted to ScalarLM's shared safe
+    allowlist before it is passed to the tokenizer. Raw prompts bypass
+    template rendering, so the kwargs are ignored for that input shape.
     """
     has_messages = bool(messages)
     has_prompt = bool(prompt)
@@ -74,6 +83,7 @@ def render_chat_template(
         messages,
         tokenize=False,
         add_generation_prompt=True,
+        **_sanitize_chat_template_kwargs(chat_template_kwargs),
     )
 
 
@@ -133,9 +143,7 @@ def _resolve_tokenizer_source(model: str) -> str:
         candidate_path = os.path.join(training_dir, model)
         if os.path.isdir(candidate_path):
             source = (
-                candidate_path
-                if _has_tokenizer_files(candidate_path)
-                else base_model
+                candidate_path if _has_tokenizer_files(candidate_path) else base_model
             )
             _source_cache[model] = source
             return source

--- a/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/render_chat_template.py
@@ -15,7 +15,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from cray_infra.api.fastapi.routers.openai_v1_helpers import (
-    _sanitize_chat_template_kwargs,
+    _chat_template_kwargs_for_render,
 )
 
 ChatMessage = Dict[str, Any]
@@ -85,9 +85,9 @@ def render_chat_template(
         return prompt  # type: ignore[return-value]
 
     tokenizer = _load_tokenizer(model)
-    template_kwargs = _sanitize_chat_template_kwargs(chat_template_kwargs)
-    if reasoning_effort is not None:
-        template_kwargs.setdefault("enable_thinking", reasoning_effort != "none")
+    template_kwargs = _chat_template_kwargs_for_render(
+        chat_template_kwargs, reasoning_effort
+    )
 
     render_kwargs: Dict[str, Any] = {
         "tokenize": False,

--- a/infra/cray_infra/api/fastapi/chat_completions/tokenize_chat_for_admission.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/tokenize_chat_for_admission.py
@@ -1,0 +1,159 @@
+"""Ask the running vLLM server for the authoritative chat prompt length.
+
+ScalarLM's API and vLLM can run in separate pods. In particular, a vLLM-only
+pod can receive ``--chat-template`` through ``SCALARLM_VLLM_ARGS`` while the
+API pod neither sees that argument nor necessarily has the same renderer
+state. Both supported vLLM lines (0.26 and 0.27) expose ``POST /tokenize``;
+that handler uses the same configured template and OnlineRenderer as chat
+inference and returns both the token count and runtime context window.
+
+The payload is deliberately constructed from a small allowlist. A caller can
+influence the validated messages, tools, and two safe template variables, but
+can never supply the endpoint's top-level ``chat_template`` override.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from typing import Any
+
+from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
+from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _chat_template_kwargs_for_render,
+)
+from cray_infra.util.get_config import get_config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AdmissionTokenization:
+    prompt_tokens: int
+    max_model_length: int
+
+
+class VLLMTokenizeRequestError(Exception):
+    """A deterministic 4xx from vLLM's tokenization endpoint."""
+
+    def __init__(self, *, status_code: int, detail: str):
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(detail)
+
+
+async def tokenize_chat_for_admission(
+    *, model: str, chat_request: dict[str, Any]
+) -> AdmissionTokenization | None:
+    """Return vLLM's rendered prompt count and context window.
+
+    Network errors, 5xx responses, and malformed success payloads fail open:
+    the handler skips its optional pre-admission length check and lets vLLM
+    validate the queued request. A 4xx is deterministic for this request, so
+    it is surfaced to the client instead of enqueuing work that will fail in
+    the same renderer moments later.
+    """
+    payload = _build_tokenize_payload(model=model, chat_request=chat_request)
+    url = get_config()["vllm_api_url"] + "/tokenize"
+
+    try:
+        session = get_global_session()
+        async with session.post(url, json=payload) as response:
+            if response.status == 200:
+                body = await response.json()
+                parsed = _parse_tokenize_response(body)
+                if parsed is None:
+                    logger.warning(
+                        "vLLM /tokenize returned an invalid success payload; "
+                        "skipping pre-admission length check"
+                    )
+                return parsed
+
+            detail = await _response_error_detail(response)
+            if 400 <= response.status < 500:
+                raise VLLMTokenizeRequestError(
+                    status_code=response.status,
+                    detail=detail,
+                )
+
+            logger.warning(
+                "vLLM /tokenize returned %s; skipping pre-admission length check",
+                response.status,
+            )
+            return None
+    except VLLMTokenizeRequestError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "HTTP error querying vLLM /tokenize at %s: %s; skipping "
+            "pre-admission length check",
+            url,
+            exc,
+        )
+        return None
+
+
+def _build_tokenize_payload(
+    *, model: str, chat_request: dict[str, Any]
+) -> dict[str, Any]:
+    """Build the safe subset shared by vLLM 0.26/0.27 TokenizeChatRequest."""
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": chat_request["messages"],
+        "add_generation_prompt": True,
+        "continue_final_message": False,
+        "add_special_tokens": False,
+    }
+
+    tools = chat_request.get("tools")
+    if tools is not None:
+        payload["tools"] = tools
+
+    template_kwargs = _chat_template_kwargs_for_render(
+        chat_request.get("chat_template_kwargs"),
+        chat_request.get("reasoning_effort"),
+    )
+    if template_kwargs:
+        payload["chat_template_kwargs"] = template_kwargs
+
+    return payload
+
+
+def _parse_tokenize_response(value: Any) -> AdmissionTokenization | None:
+    if not isinstance(value, dict):
+        return None
+    count = value.get("count")
+    max_model_len = value.get("max_model_len")
+    if (
+        not isinstance(count, int)
+        or isinstance(count, bool)
+        or count < 0
+        or not isinstance(max_model_len, int)
+        or isinstance(max_model_len, bool)
+        or max_model_len <= 0
+    ):
+        return None
+    return AdmissionTokenization(
+        prompt_tokens=count,
+        max_model_length=max_model_len,
+    )
+
+
+async def _response_error_detail(response: Any) -> str:
+    try:
+        body = await response.json()
+    except Exception:
+        try:
+            text = await response.text()
+        except Exception:
+            text = ""
+        return text or f"vLLM /tokenize returned HTTP {response.status}"
+
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, dict) and isinstance(error.get("message"), str):
+            return error["message"]
+        detail = body.get("detail")
+        if isinstance(detail, str):
+            return detail
+    return str(body)

--- a/infra/cray_infra/api/fastapi/chat_completions/tokenize_chat_for_admission.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/tokenize_chat_for_admission.py
@@ -14,6 +14,7 @@ can never supply the endpoint's top-level ``chat_template`` override.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import logging
 from typing import Any
@@ -25,6 +26,13 @@ from cray_infra.api.fastapi.routers.openai_v1_helpers import (
 from cray_infra.util.get_config import get_config
 
 logger = logging.getLogger(__name__)
+
+# The shared aiohttp session otherwise uses its five-minute default. This call
+# runs on every queued chat admission, so a half-open vLLM connection must not
+# hold an API request for minutes. Large prompts can still take several seconds
+# to tokenize; on timeout we deliberately fail open and let the worker/runtime
+# perform the authoritative validation.
+_TOKENIZE_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -58,29 +66,30 @@ async def tokenize_chat_for_admission(
 
     try:
         session = get_global_session()
-        async with session.post(url, json=payload) as response:
-            if response.status == 200:
-                body = await response.json()
-                parsed = _parse_tokenize_response(body)
-                if parsed is None:
-                    logger.warning(
-                        "vLLM /tokenize returned an invalid success payload; "
-                        "skipping pre-admission length check"
+        async with asyncio.timeout(_TOKENIZE_TIMEOUT_SECONDS):
+            async with session.post(url, json=payload) as response:
+                if response.status == 200:
+                    body = await response.json()
+                    parsed = _parse_tokenize_response(body)
+                    if parsed is None:
+                        logger.warning(
+                            "vLLM /tokenize returned an invalid success payload; "
+                            "skipping pre-admission length check"
+                        )
+                    return parsed
+
+                detail = await _response_error_detail(response)
+                if 400 <= response.status < 500:
+                    raise VLLMTokenizeRequestError(
+                        status_code=response.status,
+                        detail=detail,
                     )
-                return parsed
 
-            detail = await _response_error_detail(response)
-            if 400 <= response.status < 500:
-                raise VLLMTokenizeRequestError(
-                    status_code=response.status,
-                    detail=detail,
+                logger.warning(
+                    "vLLM /tokenize returned %s; skipping pre-admission length check",
+                    response.status,
                 )
-
-            logger.warning(
-                "vLLM /tokenize returned %s; skipping pre-admission length check",
-                response.status,
-            )
-            return None
+                return None
     except VLLMTokenizeRequestError:
         raise
     except Exception as exc:

--- a/infra/cray_infra/api/fastapi/generate/finish_work.py
+++ b/infra/cray_infra/api/fastapi/generate/finish_work.py
@@ -52,8 +52,16 @@ async def finish_work(requests: FinishWorkRequests):
             result["prompt_tokens"] = request.prompt_tokens
         if request.completion_tokens is not None:
             result["completion_tokens"] = request.completion_tokens
+        if request.reasoning is not None:
+            result["reasoning"] = request.reasoning
+        if request.tool_calls is not None:
+            result["tool_calls"] = request.tool_calls
+        if request.finish_reason is not None:
+            result["finish_reason"] = request.finish_reason
 
-        await update_and_ack(inference_work_queue, request_id=request.request_id, item=result)
+        await update_and_ack(
+            inference_work_queue, request_id=request.request_id, item=result
+        )
 
         metrics = get_metrics()
 

--- a/infra/cray_infra/api/fastapi/generate/get_work.py
+++ b/infra/cray_infra/api/fastapi/generate/get_work.py
@@ -3,7 +3,10 @@ from cray_infra.api.work_queue.get_work_item import get_work_item, get_work_item
 
 
 from cray_infra.api.fastapi.generate.get_adaptors import get_adaptors
-from cray_infra.generate.clear_acked_requests_from_queue import worker_ready, worker_not_ready
+from cray_infra.generate.clear_acked_requests_from_queue import (
+    worker_ready,
+    worker_not_ready,
+)
 
 from cray_infra.api.fastapi.routers.request_types.get_work_request import GetWorkRequest
 from cray_infra.api.fastapi.routers.request_types.get_work_response import (
@@ -33,7 +36,9 @@ async def get_work(request: GetWorkRequest):
         await worker_not_ready()
 
         if first_request is None:
-            return GetWorkResponses(requests=[], new_adaptors=await get_adaptors(request))
+            return GetWorkResponses(
+                requests=[], new_adaptors=await get_adaptors(request)
+            )
 
         requests.append(
             GetWorkResponse(
@@ -42,6 +47,7 @@ async def get_work(request: GetWorkRequest):
                 model=first_request["model"],
                 request_type=first_request["request_type"],
                 max_tokens=first_request.get("max_tokens", None),
+                chat_request=first_request.get("chat_request"),
             )
         )
 
@@ -59,6 +65,7 @@ async def get_work(request: GetWorkRequest):
                     model=next_request["model"],
                     request_type=next_request["request_type"],
                     max_tokens=next_request.get("max_tokens", None),
+                    chat_request=next_request.get("chat_request"),
                 )
             )
 
@@ -67,6 +74,8 @@ async def get_work(request: GetWorkRequest):
         logger.error(traceback.format_exc())
         await asyncio.sleep(1)
 
-    logger.info(f"Got the following request ids: {[req.request_id for req in requests]}")
+    logger.info(
+        f"Got the following request ids: {[req.request_id for req in requests]}"
+    )
 
     return GetWorkResponses(requests=requests, new_adaptors=await get_adaptors(request))

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -8,7 +8,7 @@ re-exports these names.
 from __future__ import annotations
 
 import json
-from typing import Optional
+from typing import Any, Optional
 
 # Tail-window for sniffing the upstream payload for `usage`. The terminal
 # usage event in an OpenAI SSE stream is on the order of a few hundred
@@ -83,9 +83,38 @@ def _sanitize_chat_template_kwargs(value: object) -> dict:
     }
 
 
+def _chat_template_kwargs_for_render(
+    value: object, reasoning_effort: object = None
+) -> dict:
+    """Build the template kwargs vLLM derives from a chat request.
+
+    vLLM 0.26 and 0.27 expose the validated effort to the template as
+    ``reasoning_effort`` and also translate it into ``enable_thinking`` unless
+    the caller supplied that safe template knob directly. Keep that rule in
+    one dependency-light helper so the local rolling-upgrade fallback and
+    vLLM's authoritative ``/tokenize`` request use identical request-level
+    kwargs.
+    """
+    kwargs = _sanitize_chat_template_kwargs(value)
+    if reasoning_effort is not None:
+        kwargs["reasoning_effort"] = reasoning_effort
+        kwargs.setdefault("enable_thinking", reasoning_effort != "none")
+    return kwargs
+
+
 def _filter_chat_params(raw: dict) -> dict:
-    """Filter a chat request and constrain its nested template kwargs."""
-    params = _filter_params(raw, _CHAT_ALLOWED_KEYS)
+    """Filter a chat request and constrain its nested template kwargs.
+
+    ``tool_choice: null`` is presence-sensitive in vLLM: omitted means that
+    the request validator may choose ``auto`` when tools are present, while an
+    explicit null remains disabled. Preserve that one null-valued field while
+    continuing to drop unrelated ``None`` defaults.
+    """
+    params = {
+        key: value
+        for key, value in raw.items()
+        if key in _CHAT_ALLOWED_KEYS and (value is not None or key == "tool_choice")
+    }
     if "chat_template_kwargs" in params:
         kwargs = _sanitize_chat_template_kwargs(params["chat_template_kwargs"])
         if kwargs:
@@ -93,6 +122,22 @@ def _filter_chat_params(raw: dict) -> dict:
         else:
             params.pop("chat_template_kwargs")
     return params
+
+
+def _chat_params_from_request(request: Any) -> dict:
+    """Serialize a validated vLLM chat request for an HTTP/queue boundary.
+
+    ``by_alias=True`` is required for nested OpenAI wire aliases such as the
+    JSON-schema wrapper's ``schema`` key. Pydantic's ``exclude_none`` is useful
+    for the many optional defaults, but it erases the semantic distinction for
+    an explicitly null ``tool_choice``; restore that key only when the original
+    model says the caller set it.
+    """
+    raw = request.model_dump(mode="json", exclude_none=True, by_alias=True)
+    fields_set = getattr(request, "model_fields_set", set())
+    if "tool_choice" in fields_set and getattr(request, "tool_choice", None) is None:
+        raw["tool_choice"] = None
+    return _filter_chat_params(raw)
 
 
 def _ensure_usage_reported(params: dict) -> None:

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -41,6 +41,7 @@ _CHAT_ALLOWED_KEYS = (
     "temperature",
     "messages",
     "max_tokens",
+    "max_completion_tokens",
     "stream",
     "stream_options",
     "tools",
@@ -55,7 +56,9 @@ _CHAT_ALLOWED_KEYS = (
     # must preserve the literal False used by include_reasoning.
     "include_reasoning",
     "reasoning_effort",
+    "thinking_token_budget",
     "top_k",
+    "parallel_tool_calls",
     "chat_template_kwargs",
     "presence_penalty",
     "frequency_penalty",

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_helpers.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import json
 from typing import Optional
 
-
 # Tail-window for sniffing the upstream payload for `usage`. The terminal
 # usage event in an OpenAI SSE stream is on the order of a few hundred
 # bytes and always sits at the very end; 64 KB is more than enough
@@ -50,13 +49,47 @@ _CHAT_ALLOWED_KEYS = (
     "top_p",
     "stop",
     "seed",
+    # vLLM chat extensions. Keep these on the shared allowlist so both
+    # the direct streaming proxy and queue-backed non-streaming path honor
+    # the same reasoning and sampling controls. In particular, filtering
+    # must preserve the literal False used by include_reasoning.
+    "include_reasoning",
+    "reasoning_effort",
+    "top_k",
+    "chat_template_kwargs",
     "presence_penalty",
     "frequency_penalty",
 )
 
+# Only template variables that ScalarLM has explicitly validated are accepted
+# from callers. This is shared by the direct proxy, queue payload, and local
+# accounting render so all three paths see the same request semantics.
+_ALLOWED_CHAT_TEMPLATE_KWARGS = frozenset({"enable_thinking", "reasoning_strength"})
+
 
 def _filter_params(raw: dict, allowed: tuple) -> dict:
     return {k: v for k, v in raw.items() if v is not None and k in allowed}
+
+
+def _sanitize_chat_template_kwargs(value: object) -> dict:
+    """Return only explicitly supported, JSON-safe template variables."""
+    if not isinstance(value, dict):
+        return {}
+    return {
+        key: item for key, item in value.items() if key in _ALLOWED_CHAT_TEMPLATE_KWARGS
+    }
+
+
+def _filter_chat_params(raw: dict) -> dict:
+    """Filter a chat request and constrain its nested template kwargs."""
+    params = _filter_params(raw, _CHAT_ALLOWED_KEYS)
+    if "chat_template_kwargs" in params:
+        kwargs = _sanitize_chat_template_kwargs(params["chat_template_kwargs"])
+        if kwargs:
+            params["chat_template_kwargs"] = kwargs
+        else:
+            params.pop("chat_template_kwargs")
+    return params
 
 
 def _ensure_usage_reported(params: dict) -> None:
@@ -112,7 +145,8 @@ def _extract_token_count(payload: bytes) -> Optional[int]:
         last: Optional[int] = None
         for event in normalized.split("\n\n"):
             data_lines = [
-                line[5:].lstrip() for line in event.splitlines()
+                line[5:].lstrip()
+                for line in event.splitlines()
                 if line.startswith("data:")
             ]
             if not data_lines:

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -23,11 +23,11 @@ from cray_infra.api.fastapi.chat_completions.tee_streaming_to_disk import (
     write_response_artifact,
 )
 from cray_infra.api.fastapi.routers.openai_v1_helpers import (
-    _CHAT_ALLOWED_KEYS,
     _COMPLETION_ALLOWED_KEYS,
     _USAGE_SCAN_TAIL_BYTES,
     _ensure_usage_reported,
     _extract_token_count,
+    _filter_chat_params,
     _filter_params,
     _read_total_tokens,
 )
@@ -64,7 +64,9 @@ async def list_models():
 async def create_completions(request: CompletionRequest, raw_request: Request):
     """Create completions - proxy to vLLM server."""
     config = get_config()
-    params = _filter_params(request.model_dump(mode="json", exclude_none=True), _COMPLETION_ALLOWED_KEYS)
+    params = _filter_params(
+        request.model_dump(mode="json", exclude_none=True), _COMPLETION_ALLOWED_KEYS
+    )
     _ensure_usage_reported(params)
     logger.info("Received completions request: %s", params)
     return _proxy_streaming(
@@ -88,7 +90,7 @@ async def create_chat_completions(request: ChatCompletionRequest, raw_request: R
     """
     if getattr(request, "stream", False):
         config = get_config()
-        params = _filter_params(request.model_dump(mode="json", exclude_none=True), _CHAT_ALLOWED_KEYS)
+        params = _filter_chat_params(request.model_dump(mode="json", exclude_none=True))
         _ensure_usage_reported(params)
         logger.info("Received streaming chat completions request: %s", params)
         return _proxy_streaming(
@@ -127,7 +129,9 @@ def _proxy_streaming(
     # depend on disk.
     request_hash = compute_request_hash(params)
     write_request_artifacts(
-        request_hash=request_hash, params=params, endpoint_label=endpoint_label,
+        request_hash=request_hash,
+        params=params,
+        endpoint_label=endpoint_label,
     )
 
     async def upstream():
@@ -135,7 +139,10 @@ def _proxy_streaming(
             if resp.status != 200:
                 error_text = await resp.text()
                 logger.error(
-                    "vLLM %s error (%s): %s", endpoint_label, resp.status, error_text,
+                    "vLLM %s error (%s): %s",
+                    endpoint_label,
+                    resp.status,
+                    error_text,
                 )
                 yield (
                     f'data: {{"error": "Failed to create {endpoint_label}: {error_text}"}}\n\n'
@@ -203,5 +210,3 @@ async def _wrap_with_metrics(source, *, request_hash: Optional[str] = None):
                 request_hash=request_hash,
                 sse_text=bytes(full_capture).decode("utf-8", errors="replace"),
             )
-
-

--- a/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_v1_router.py
@@ -27,7 +27,7 @@ from cray_infra.api.fastapi.routers.openai_v1_helpers import (
     _USAGE_SCAN_TAIL_BYTES,
     _ensure_usage_reported,
     _extract_token_count,
-    _filter_chat_params,
+    _chat_params_from_request,
     _filter_params,
     _read_total_tokens,
 )
@@ -90,7 +90,7 @@ async def create_chat_completions(request: ChatCompletionRequest, raw_request: R
     """
     if getattr(request, "stream", False):
         config = get_config()
-        params = _filter_chat_params(request.model_dump(mode="json", exclude_none=True))
+        params = _chat_params_from_request(request)
         _ensure_usage_reported(params)
         logger.info("Received streaming chat completions request: %s", params)
         return _proxy_streaming(

--- a/infra/cray_infra/api/fastapi/routers/request_types/finish_work_request.py
+++ b/infra/cray_infra/api/fastapi/routers/request_types/finish_work_request.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 
 class FinishWorkRequest(BaseModel):
@@ -11,6 +11,11 @@ class FinishWorkRequest(BaseModel):
     prompt_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
     flop_count: Optional[int] = None
+    # Structured chat-completion fields returned by vLLM's reasoning/tool
+    # parsers. Optional so legacy generate workers remain wire-compatible.
+    reasoning: Optional[str] = None
+    tool_calls: Optional[list[dict[str, Any]]] = None
+    finish_reason: Optional[str] = None
 
 
 class FinishWorkRequests(BaseModel):

--- a/infra/cray_infra/api/fastapi/routers/request_types/get_work_response.py
+++ b/infra/cray_infra/api/fastapi/routers/request_types/get_work_response.py
@@ -3,9 +3,10 @@ from cray_infra.api.fastapi.routers.request_types.get_adaptors_response import (
     GetAdaptorsResponse,
 )
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 PromptType = Union[str, dict[str, Union[str, list[str]]]]
+
 
 class GetWorkResponse(BaseModel):
     prompt: PromptType
@@ -13,6 +14,9 @@ class GetWorkResponse(BaseModel):
     request_type: str
     model: Optional[str] = None
     max_tokens: Optional[int] = None
+    # Present for queue-backed /v1/chat/completions requests. ``prompt``
+    # remains available for admission/accounting and request inspection.
+    chat_request: Optional[dict[str, Any]] = None
 
 
 class GetWorkResponses(BaseModel):

--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -64,6 +64,7 @@ class _InflightCounter:
     to vLLM but not yet seen finish_work for. A plain int doesn't work
     because nested coroutines need a shared reference.
     """
+
     __slots__ = ("count",)
 
     def __init__(self):
@@ -96,7 +97,9 @@ async def create_generate_worker(server_status):
     # capacity (the cache peek doesn't reflect requests sitting in vLLM's
     # waiting queue). Without this cap the loop flood-pulls from the
     # SQLiteAckQueue in tight iterations. See default_config.py for the knob.
-    max_inflight = int(config.get("max_inflight_requests", config["generate_batch_size"]))
+    max_inflight = int(
+        config.get("max_inflight_requests", config["generate_batch_size"])
+    )
     inflight = _InflightCounter()
 
     try:
@@ -415,7 +418,9 @@ async def pass_receive() -> NoReturn:
 
 
 async def async_generate_task(request, app):
-    if request["request_type"] == "generate":
+    if request["request_type"] == "chat_completions":
+        return await async_chat_completion_task(request, app)
+    elif request["request_type"] == "generate":
         if is_chat_completion_task(request):
             return await async_chat_completion_task(request, app)
         else:
@@ -432,17 +437,31 @@ def is_chat_completion_task(request):
 
 
 async def async_chat_completion_task(request, app):
-    completion_request = ChatCompletionRequest(
-        model=request["model"],
-        messages=convert_prompt_to_openai_format(request["prompt"]),
-        max_tokens=request["max_tokens"],
-        tools=request.get("tools"),
-        tool_choice=request.get("tool_choice"),
-        **sampling_params_for(app, request),
-    )
+    chat_request = request.get("chat_request")
+    if chat_request is not None:
+        # The public handler validated the payload before enqueueing it.
+        # Re-validate at the worker boundary so malformed or stale rows fail
+        # clearly rather than reaching serving internals as arbitrary dicts.
+        completion_request = ChatCompletionRequest(**chat_request)
+    else:
+        # Backward compatibility for /v1/generate's historical multimodal
+        # prompt-dict path.
+        completion_request = ChatCompletionRequest(
+            model=request["model"],
+            messages=convert_prompt_to_openai_format(request["prompt"]),
+            max_tokens=request["max_tokens"],
+            tools=request.get("tools"),
+            tool_choice=request.get("tool_choice"),
+            **sampling_params_for(app, request),
+        )
 
     raw_request = Request(
-        scope={"app": app, "type": "http", "headers": {}, "path": "/v1/completions"},
+        scope={
+            "app": app,
+            "type": "http",
+            "headers": {},
+            "path": "/v1/chat/completions",
+        },
         receive=pass_receive,
     )
 
@@ -457,7 +476,20 @@ async def async_chat_completion_task(request, app):
     }
 
     if "choices" in response_data:
-        response["response"] = response_data["choices"][0]["message"]["content"]
+        choice = response_data["choices"][0]
+        message = choice["message"]
+        response["response"] = message.get("content") or ""
+        if message.get("reasoning") is not None:
+            response["reasoning"] = message["reasoning"]
+        if message.get("tool_calls") is not None:
+            response["tool_calls"] = message["tool_calls"]
+        if choice.get("finish_reason") is not None:
+            response["finish_reason"] = choice["finish_reason"]
+    elif "error" in response_data:
+        error = response_data["error"]
+        response["error"] = (
+            error.get("message", repr(error)) if isinstance(error, dict) else str(error)
+        )
     elif response_data.get("object") == "error":
         response["error"] = response_data.get("message", repr(response_data))
     else:

--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -1,6 +1,5 @@
 import asyncio
 import aiohttp
-import copy
 import json
 import os
 import sys
@@ -393,23 +392,71 @@ async def _run_and_finish_one(request, app, inflight=None):
             inflight.count -= 1
 
 
+_LOG_STRING_LIMIT = 100
+_LOG_COLLECTION_LIMIT = 20
+_LOG_REDACTED_KEYS = frozenset(
+    {
+        "arguments",
+        "audio_url",
+        "content",
+        "image_url",
+        "input_audio",
+        "prompt",
+    }
+)
+
+
 def truncate_fields(data):
-    # Limit the length of the data to 100 characters
-    # Data is a dict with a field called requests which is a list of dicts
+    """Return a bounded, recursively sanitized copy for debug logging.
 
-    data = copy.deepcopy(data)
-
-    for request in data["requests"]:
-        truncate_dict(request)
-    return data
+    Queue-backed chat adds nested message and tool lists. The historical
+    dict-only walker skipped every string inside those lists, so large data
+    URLs and complete conversations reached DEBUG logs. Bound collection
+    sizes, recurse through lists/tuples, and redact content-bearing fields.
+    """
+    return _sanitize_log_value(data)
 
 
 def truncate_dict(d):
-    for key, value in d.items():
-        if isinstance(value, str) and len(value) > 100:
-            d[key] = value[:100] + "..."
-        if isinstance(value, dict):
-            truncate_dict(value)
+    """Backward-compatible in-place wrapper for existing callers."""
+    sanitized = _sanitize_log_value(d)
+    d.clear()
+    d.update(sanitized)
+
+
+def _sanitize_log_value(value, *, key=None):
+    if key in _LOG_REDACTED_KEYS:
+        try:
+            size = len(value)
+        except TypeError:
+            size = 1
+        unit = "chars" if isinstance(value, str) else "items"
+        return f"<redacted {size} {unit}>"
+
+    if isinstance(value, str):
+        if value.startswith("data:"):
+            return f"<redacted {len(value)} chars>"
+        if len(value) > _LOG_STRING_LIMIT:
+            return value[:_LOG_STRING_LIMIT] + "..."
+        return value
+
+    if isinstance(value, dict):
+        items = list(value.items())
+        sanitized = {
+            item_key: _sanitize_log_value(item_value, key=str(item_key))
+            for item_key, item_value in items[:_LOG_COLLECTION_LIMIT]
+        }
+        if len(items) > _LOG_COLLECTION_LIMIT:
+            sanitized["<truncated>"] = f"{len(items) - _LOG_COLLECTION_LIMIT} keys"
+        return sanitized
+
+    if isinstance(value, (list, tuple)):
+        items = [_sanitize_log_value(item) for item in value[:_LOG_COLLECTION_LIMIT]]
+        if len(value) > _LOG_COLLECTION_LIMIT:
+            items.append(f"<truncated {len(value) - _LOG_COLLECTION_LIMIT} items>")
+        return items
+
+    return value
 
 
 async def pass_receive() -> NoReturn:
@@ -421,7 +468,7 @@ async def async_generate_task(request, app):
     if request["request_type"] == "chat_completions":
         return await async_chat_completion_task(request, app)
     elif request["request_type"] == "generate":
-        if is_chat_completion_task(request):
+        if request.get("chat_request") is not None or is_chat_completion_task(request):
             return await async_chat_completion_task(request, app)
         else:
             return await async_completion_task(request, app)
@@ -543,7 +590,6 @@ def convert_prompt_to_openai_format(
 
 
 def compute_flop_count(model_config):
-
     # The intermediate size is the size of the feedforward layer
     vocab_size = model_config.get_vocab_size()
     hidden_size = model_config.get_hidden_size()

--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -1,5 +1,6 @@
 import asyncio
 import aiohttp
+from itertools import islice
 import json
 import os
 import sys
@@ -329,7 +330,8 @@ async def process_requests(app, requests, inflight=None):
 
 async def process_requests_task(app, requests, inflight=None):
     logger.info(f"Processing {len(requests)} requests")
-    logger.debug("Got work: %s", truncate_fields({"requests": requests}))
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Got work: %s", truncate_fields({"requests": requests}))
 
     per_request = [_run_and_finish_one(req, app, inflight) for req in requests]
     # return_exceptions=True so one sub-coroutine failing doesn't abort
@@ -394,6 +396,7 @@ async def _run_and_finish_one(request, app, inflight=None):
 
 _LOG_STRING_LIMIT = 100
 _LOG_COLLECTION_LIMIT = 20
+_LOG_DEPTH_LIMIT = 12
 _LOG_REDACTED_KEYS = frozenset(
     {
         "arguments",
@@ -424,7 +427,7 @@ def truncate_dict(d):
     d.update(sanitized)
 
 
-def _sanitize_log_value(value, *, key=None):
+def _sanitize_log_value(value, *, key=None, depth=0):
     if key in _LOG_REDACTED_KEYS:
         try:
             size = len(value)
@@ -432,6 +435,9 @@ def _sanitize_log_value(value, *, key=None):
             size = 1
         unit = "chars" if isinstance(value, str) else "items"
         return f"<redacted {size} {unit}>"
+
+    if depth >= _LOG_DEPTH_LIMIT and isinstance(value, (dict, list, tuple)):
+        return "<truncated nested value>"
 
     if isinstance(value, str):
         if value.startswith("data:"):
@@ -441,17 +447,26 @@ def _sanitize_log_value(value, *, key=None):
         return value
 
     if isinstance(value, dict):
-        items = list(value.items())
         sanitized = {
-            item_key: _sanitize_log_value(item_value, key=str(item_key))
-            for item_key, item_value in items[:_LOG_COLLECTION_LIMIT]
+            item_key: _sanitize_log_value(
+                item_value,
+                key=str(item_key),
+                depth=depth + 1,
+            )
+            for item_key, item_value in islice(
+                value.items(),
+                _LOG_COLLECTION_LIMIT,
+            )
         }
-        if len(items) > _LOG_COLLECTION_LIMIT:
-            sanitized["<truncated>"] = f"{len(items) - _LOG_COLLECTION_LIMIT} keys"
+        if len(value) > _LOG_COLLECTION_LIMIT:
+            sanitized["<truncated>"] = f"{len(value) - _LOG_COLLECTION_LIMIT} keys"
         return sanitized
 
     if isinstance(value, (list, tuple)):
-        items = [_sanitize_log_value(item) for item in value[:_LOG_COLLECTION_LIMIT]]
+        items = [
+            _sanitize_log_value(item, depth=depth + 1)
+            for item in value[:_LOG_COLLECTION_LIMIT]
+        ]
         if len(value) > _LOG_COLLECTION_LIMIT:
             items.append(f"<truncated {len(value) - _LOG_COLLECTION_LIMIT} items>")
         return items

--- a/test/unit/test_build_chat_completion_response.py
+++ b/test/unit/test_build_chat_completion_response.py
@@ -76,6 +76,50 @@ def test_missing_response_field_yields_empty_content_not_none():
     assert out["usage"]["total_tokens"] == 5
 
 
+def test_preserves_structured_reasoning_from_vllm_chat_worker():
+    result = {
+        "request_id": "reasoning-1",
+        "response": "OK",
+        "reasoning": "I should answer briefly.",
+        "finish_reason": "stop",
+    }
+
+    out = build_chat_completion_response(result=result, model="reasoning-model")
+
+    message = out["choices"][0]["message"]
+    assert message["content"] == "OK"
+    assert message["reasoning"] == "I should answer briefly."
+    assert out["choices"][0]["finish_reason"] == "stop"
+
+
+def test_preserves_structured_tool_calls_from_vllm_chat_worker():
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city":"Helsinki"}',
+            },
+        }
+    ]
+    result = {
+        "request_id": "tool-1",
+        "response": "",
+        "reasoning": "I need the weather tool.",
+        "tool_calls": tool_calls,
+        "finish_reason": "tool_calls",
+    }
+
+    out = build_chat_completion_response(result=result, model="tool-model")
+
+    choice = out["choices"][0]
+    assert choice["message"]["content"] is None
+    assert choice["message"]["reasoning"] == "I need the weather tool."
+    assert choice["message"]["tool_calls"] == tool_calls
+    assert choice["finish_reason"] == "tool_calls"
+
+
 def test_prompt_completion_split_preferred_over_token_count():
     """When the worker propagates the prompt/completion split (the
     normal post-fix path), surface it on `usage` and recompute

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -7,7 +7,8 @@ by the heartbeat helper. Tests mock the singletons so the flow can be
 exercised without uvicorn / SQLite / a real model.
 
 Contract (see docs/openai-chat-completions-queue.md §5):
-- Renders the request via render_chat_template before queueing.
+- Uses vLLM's runtime /tokenize renderer for admission before constructing the
+  old-worker compatibility prompt.
 - 429 with Retry-After when admission threshold is exceeded.
 - Registers a correlation_id with the result router *before*
   submitting to the coalescer so the worker can never resolve a cid
@@ -26,6 +27,13 @@ from fastapi.responses import StreamingResponse
 from cray_infra.api.fastapi.chat_completions import handler as h
 from cray_infra.api.fastapi.chat_completions.admission import WaitEstimator
 from cray_infra.api.fastapi.chat_completions.result_router import ResultRouter
+from cray_infra.api.fastapi.chat_completions.tokenize_chat_for_admission import (
+    AdmissionTokenization,
+    VLLMTokenizeRequestError,
+)
+
+
+_UNSET = object()
 
 
 def _request(messages=None, prompt_text=None, stream=False, **overrides):
@@ -41,7 +49,8 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
     req.temperature = overrides.get("temperature", 0.7)
     req.stream = stream
     req.tools = overrides.get("tools")
-    req.tool_choice = overrides.get("tool_choice")
+    tool_choice = overrides.get("tool_choice", _UNSET)
+    req.tool_choice = None if tool_choice is _UNSET else tool_choice
     req.chat_template_kwargs = overrides.get("chat_template_kwargs")
     req.include_reasoning = overrides.get("include_reasoning")
     req.reasoning_effort = overrides.get("reasoning_effort")
@@ -59,7 +68,6 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
     }
     for key in (
         "tools",
-        "tool_choice",
         "chat_template_kwargs",
         "include_reasoning",
         "reasoning_effort",
@@ -70,6 +78,9 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
         value = getattr(req, key)
         if value is not None:
             raw[key] = value
+    if tool_choice is not _UNSET:
+        raw["tool_choice"] = tool_choice
+    req.model_fields_set = set(raw)
     req.model_dump.return_value = raw
     return req
 
@@ -100,20 +111,21 @@ def patched_components(fresh_router, fresh_estimator):
         "chat_admit_factor": 4,
     }
 
-    with patch.object(h, "get_result_router", return_value=fresh_router), patch.object(
-        h, "get_coalescer", return_value=coalescer
-    ), patch.object(
-        h, "get_wait_estimator", return_value=fresh_estimator
-    ), patch.object(
-        h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]
-    ), patch.object(
-        h, "get_config", return_value=fake_config
-    ), patch.object(
-        h, "_resolve_model", side_effect=lambda req, cfg: req or "test-model"
-    ), patch.object(
-        h, "resolve_max_model_length", AsyncMock(return_value=0)
-    ) as max_len, patch.object(
-        h, "render_chat_template", return_value="rendered-prompt"
+    with (
+        patch.object(h, "get_result_router", return_value=fresh_router),
+        patch.object(h, "get_coalescer", return_value=coalescer),
+        patch.object(h, "get_wait_estimator", return_value=fresh_estimator),
+        patch.object(
+            h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]
+        ),
+        patch.object(h, "get_config", return_value=fake_config),
+        patch.object(
+            h, "_resolve_model", side_effect=lambda req, cfg: req or "test-model"
+        ),
+        patch.object(
+            h, "tokenize_chat_for_admission", AsyncMock(return_value=None)
+        ) as tokenize,
+        patch.object(h, "render_chat_template", return_value="rendered-prompt"),
     ):
         yield {
             "coalescer": coalescer,
@@ -121,7 +133,7 @@ def patched_components(fresh_router, fresh_estimator):
             "router": fresh_router,
             "estimator": fresh_estimator,
             "config": fake_config,
-            "max_model_length": max_len,
+            "tokenize_chat": tokenize,
         }
 
 
@@ -227,9 +239,33 @@ async def test_correlation_id_passed_to_coalescer_matches_request_payload(
     req, cid = captured[0]
     assert req["correlation_id"] == cid
     assert req["prompt"] == "rendered"
-    assert req["request_type"] == "chat_completions"
+    assert req["request_type"] == "generate"
     assert req["chat_request"]["messages"] == [{"role": "user", "content": "hi"}]
     assert req["chat_request"]["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_queue_payload_is_compatible_with_origin_main_worker(
+    patched_components,
+):
+    """Old workers accept only ``generate`` and ignore the new chat payload.
+
+    Keeping a rendered string prompt lets one finish in the legacy completion
+    path during an API-first rolling upgrade instead of failing immediately on
+    an unknown discriminator. Current workers detect ``chat_request`` first.
+    """
+    captured = []
+
+    async def capture(request, _correlation_id):
+        captured.append(request)
+
+    patched_components["coalescer"].submit = AsyncMock(side_effect=capture)
+    await h.chat_completions_via_queue(_request())
+
+    queued = captured[0]
+    assert queued["request_type"] == "generate"
+    assert isinstance(queued["prompt"], str)
+    assert queued["chat_request"]["messages"]
 
 
 @pytest.mark.asyncio
@@ -409,15 +445,15 @@ async def test_400_when_prompt_plus_max_tokens_exceeds_max_model_length(
     """
     A request whose prompt + max_tokens > max_model_length must be
     rejected up front with HTTP 400. Without this check vLLM queues
-    it forever — the production stuck-request symptom. The cap comes
-    from resolve_max_model_length (vLLM's runtime), not the
-    cray-config knob.
+    it forever — the production stuck-request symptom. Both values come
+    from vLLM's runtime /tokenize renderer, not the cray-config knob.
     """
-    patched_components["max_model_length"].return_value = 100
+    patched_components["tokenize_chat"].return_value = AdmissionTokenization(
+        prompt_tokens=80, max_model_length=100
+    )
 
-    with patch.object(h, "count_prompt_tokens", return_value=80):
-        with pytest.raises(HTTPException) as exc_info:
-            await h.chat_completions_via_queue(_request(max_tokens=50))
+    with pytest.raises(HTTPException) as exc_info:
+        await h.chat_completions_via_queue(_request(max_tokens=50))
 
     assert exc_info.value.status_code == 400
     detail = exc_info.value.detail
@@ -428,13 +464,14 @@ async def test_400_when_prompt_plus_max_tokens_exceeds_max_model_length(
 async def test_length_check_uses_max_completion_tokens_precedence(
     patched_components,
 ):
-    patched_components["max_model_length"].return_value = 100
+    patched_components["tokenize_chat"].return_value = AdmissionTokenization(
+        prompt_tokens=80, max_model_length=100
+    )
 
-    with patch.object(h, "count_prompt_tokens", return_value=80):
-        with pytest.raises(HTTPException) as exc_info:
-            await h.chat_completions_via_queue(
-                _request(max_tokens=5, max_completion_tokens=30)
-            )
+    with pytest.raises(HTTPException) as exc_info:
+        await h.chat_completions_via_queue(
+            _request(max_tokens=5, max_completion_tokens=30)
+        )
 
     assert exc_info.value.status_code == 400
     assert "max_tokens=30" in exc_info.value.detail
@@ -446,12 +483,13 @@ async def test_too_long_request_does_not_register_correlation_id(
 ):
     """The 400 path must leak nothing into the router or coalescer —
     same contract as the 429 over-capacity path."""
-    patched_components["max_model_length"].return_value = 100
+    patched_components["tokenize_chat"].return_value = AdmissionTokenization(
+        prompt_tokens=200, max_model_length=100
+    )
     coalescer = patched_components["coalescer"]
 
-    with patch.object(h, "count_prompt_tokens", return_value=200):
-        with pytest.raises(HTTPException):
-            await h.chat_completions_via_queue(_request(max_tokens=10))
+    with pytest.raises(HTTPException):
+        await h.chat_completions_via_queue(_request(max_tokens=10))
 
     assert patched_components["router"].in_flight_count == 0
     coalescer.submit.assert_not_called()
@@ -460,51 +498,134 @@ async def test_too_long_request_does_not_register_correlation_id(
 @pytest.mark.asyncio
 async def test_length_check_passes_when_within_threshold(patched_components):
     """Boundary case: prompt + max_tokens == max_model_length is fine."""
-    patched_components["max_model_length"].return_value = 100
+    patched_components["tokenize_chat"].return_value = AdmissionTokenization(
+        prompt_tokens=80, max_model_length=100
+    )
 
-    with patch.object(h, "count_prompt_tokens", return_value=80):
-        response = await h.chat_completions_via_queue(_request(max_tokens=20))
+    response = await h.chat_completions_via_queue(_request(max_tokens=20))
 
     # No exception → got the StreamingResponse back.
     assert response is not None
 
 
 @pytest.mark.asyncio
-async def test_length_check_skipped_when_resolver_returns_zero(
+async def test_length_check_skipped_when_runtime_tokenize_is_unavailable(
     patched_components,
 ):
     """
-    When the resolver can't determine the cap (vLLM unreachable AND
-    no config fallback), it returns 0 → handler treats as "no cap"
-    and skips the check entirely. This protects against transient
-    vLLM unavailability rejecting every request.
+    Runtime tokenization fails open so transient vLLM unavailability does not
+    make the API reject every request using an inexact local render.
     """
-    # Default fixture already returns 0 for resolve_max_model_length.
-    with patch.object(h, "count_prompt_tokens") as count:
-        await h.chat_completions_via_queue(_request())
-
-    count.assert_not_called()
+    # Default fixture returns None from tokenize_chat_for_admission.
+    await h.chat_completions_via_queue(_request())
 
 
 @pytest.mark.asyncio
-async def test_length_check_uses_vllm_reported_cap_not_config(
+async def test_length_check_uses_vllm_tokenize_count_and_cap_not_local_config(
     patched_components,
 ):
     """
-    The resolver — not the cray-config knob — is the source of truth.
-    A stale config value of 256 must not reject a 4096-token request
-    when vLLM is happy with 64k. Pin the contract: the handler reads
-    from the resolver and ignores config["max_model_length"] for the
-    purpose of admission.
+    The runtime endpoint applies vLLM's configured server template and
+    specialized renderer. Its count and context window are authoritative;
+    neither the API pod's local tokenizer nor a stale config knob may replace
+    them.
     """
     patched_components["config"]["max_model_length"] = 256
-    patched_components["max_model_length"].return_value = 65536
+    patched_components["tokenize_chat"].return_value = AdmissionTokenization(
+        prompt_tokens=4096, max_model_length=65536
+    )
 
-    with patch.object(h, "count_prompt_tokens", return_value=4096):
-        # 4096 + 1000 = 5096 < 65536 → admit, even though config says 256.
-        response = await h.chat_completions_via_queue(_request(max_tokens=1000))
+    # 4096 + 1000 = 5096 < 65536 → admit, even though config says 256.
+    response = await h.chat_completions_via_queue(_request(max_tokens=1000))
 
     assert response is not None
+
+
+@pytest.mark.asyncio
+async def test_runtime_tokenize_receives_sanitized_chat_request(patched_components):
+    await h.chat_completions_via_queue(
+        _request(
+            reasoning_effort="high",
+            chat_template_kwargs={
+                "enable_thinking": False,
+                "chat_template": "{{ untrusted }}",
+            },
+        )
+    )
+
+    kwargs = patched_components["tokenize_chat"].await_args.kwargs
+    assert kwargs["model"] == "test-model"
+    assert kwargs["chat_request"]["messages"] == [{"role": "user", "content": "hi"}]
+    assert kwargs["chat_request"]["chat_template_kwargs"] == {"enable_thinking": False}
+    assert "chat_template" not in kwargs["chat_request"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_tokenize_4xx_is_returned_without_enqueue(
+    patched_components,
+):
+    patched_components["tokenize_chat"].side_effect = VLLMTokenizeRequestError(
+        status_code=400,
+        detail="template rejected messages",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await h.chat_completions_via_queue(_request())
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "template rejected messages"
+    patched_components["coalescer"].submit.assert_not_awaited()
+    assert patched_components["router"].in_flight_count == 0
+
+
+@pytest.mark.asyncio
+async def test_server_only_template_is_not_preempted_by_local_render(
+    patched_components,
+):
+    """A vLLM-only --chat-template may be absent from the API tokenizer.
+
+    Once the authoritative runtime renderer accepts the request, failure of the
+    local rolling-upgrade render must neither reject nor precede it. Current
+    workers consume the intact structured request; old workers get a plain text
+    fallback with non-text data replaced by a short placeholder.
+    """
+    events = []
+    captured = []
+
+    async def runtime_tokenize(**_kwargs):
+        events.append("runtime-tokenize")
+        return AdmissionTokenization(prompt_tokens=12, max_model_length=4096)
+
+    def local_render(**_kwargs):
+        events.append("local-render")
+        raise ValueError("tokenizer has no bundled chat template")
+
+    async def capture(request, _correlation_id):
+        captured.append(request)
+
+    patched_components["tokenize_chat"].side_effect = runtime_tokenize
+    patched_components["coalescer"].submit = AsyncMock(side_effect=capture)
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe this"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,secret"},
+                },
+            ],
+        }
+    ]
+
+    with patch.object(h, "render_chat_template", side_effect=local_render):
+        response = await h.chat_completions_via_queue(_request(messages=messages))
+
+    assert response is not None
+    assert events == ["runtime-tokenize", "local-render"]
+    assert captured[0]["chat_request"]["messages"] == messages
+    assert captured[0]["prompt"] == "user: describe this [image_url]\nassistant:"
+    assert "base64" not in captured[0]["prompt"]
 
 
 # ---------------------------------------------------------------------------
@@ -545,12 +666,15 @@ def test_resolve_model_latest_uses_get_latest_model():
     cfg = {"model": "default-m"}
     fake_manager = MagicMock()
     fake_manager.find_model.return_value = "training-job-abc"
-    with patch(
-        "cray_infra.training.get_latest_model.get_latest_model",
-        return_value="training-job-abc",
-    ), patch(
-        "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
-        return_value=fake_manager,
+    with (
+        patch(
+            "cray_infra.training.get_latest_model.get_latest_model",
+            return_value="training-job-abc",
+        ),
+        patch(
+            "cray_infra.training.vllm_model_manager.get_vllm_model_manager",
+            return_value=fake_manager,
+        ),
     ):
         assert h._resolve_model("latest", cfg) == "training-job-abc"
 

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -37,6 +37,7 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
     req.model = overrides.get("model", "test-model")
     req.messages = messages
     req.max_tokens = overrides.get("max_tokens", 64)
+    req.max_completion_tokens = overrides.get("max_completion_tokens")
     req.temperature = overrides.get("temperature", 0.7)
     req.stream = stream
     req.tools = overrides.get("tools")
@@ -44,12 +45,15 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
     req.chat_template_kwargs = overrides.get("chat_template_kwargs")
     req.include_reasoning = overrides.get("include_reasoning")
     req.reasoning_effort = overrides.get("reasoning_effort")
+    req.thinking_token_budget = overrides.get("thinking_token_budget")
     req.top_k = overrides.get("top_k")
+    req.parallel_tool_calls = overrides.get("parallel_tool_calls")
 
     raw = {
         "model": req.model,
         "messages": messages,
         "max_tokens": req.max_tokens,
+        "max_completion_tokens": req.max_completion_tokens,
         "temperature": req.temperature,
         "stream": stream,
     }
@@ -59,7 +63,9 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
         "chat_template_kwargs",
         "include_reasoning",
         "reasoning_effort",
+        "thinking_token_budget",
         "top_k",
+        "parallel_tool_calls",
     ):
         value = getattr(req, key)
         if value is not None:
@@ -139,6 +145,8 @@ async def test_renders_messages_through_chat_template(patched_components):
     assert kwargs["model"] == "test-model"
     assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
     assert kwargs["prompt"] is None
+    assert kwargs["tools"] is None
+    assert kwargs["reasoning_effort"] is None
 
 
 @pytest.mark.asyncio
@@ -146,13 +154,21 @@ async def test_safe_template_kwargs_are_used_for_accounting_render(
     patched_components,
 ):
     with patch.object(h, "render_chat_template", return_value="rendered") as render:
+        tools = [
+            {
+                "type": "function",
+                "function": {"name": "lookup", "parameters": {"type": "object"}},
+            }
+        ]
         await h.chat_completions_via_queue(
             _request(
+                tools=tools,
+                reasoning_effort="high",
                 chat_template_kwargs={
                     "enable_thinking": False,
                     "reasoning_strength": "low",
                     "chat_template": "untrusted override",
-                }
+                },
             )
         )
 
@@ -160,6 +176,8 @@ async def test_safe_template_kwargs_are_used_for_accounting_render(
         "enable_thinking": False,
         "reasoning_strength": "low",
     }
+    assert render.call_args.kwargs["tools"] == tools
+    assert render.call_args.kwargs["reasoning_effort"] == "high"
 
 
 @pytest.mark.asyncio
@@ -235,7 +253,9 @@ async def test_vllm_chat_controls_survive_queue_submission(patched_components):
         _request(
             include_reasoning=False,
             reasoning_effort="low",
+            thinking_token_budget=512,
             top_k=64,
+            parallel_tool_calls=False,
             tools=tools,
             tool_choice="auto",
             chat_template_kwargs={
@@ -248,7 +268,9 @@ async def test_vllm_chat_controls_survive_queue_submission(patched_components):
     chat_request = captured[0]["chat_request"]
     assert chat_request["include_reasoning"] is False
     assert chat_request["reasoning_effort"] == "low"
+    assert chat_request["thinking_token_budget"] == 512
     assert chat_request["top_k"] == 64
+    assert chat_request["parallel_tool_calls"] is False
     assert chat_request["tools"] == tools
     assert chat_request["tool_choice"] == "auto"
     assert chat_request["chat_template_kwargs"] == {"reasoning_strength": "low"}
@@ -279,11 +301,10 @@ async def test_max_tokens_defaults_when_client_omits(patched_components):
 
     coalescer.submit = AsyncMock(side_effect=capture)
 
-    req = _request()
-    req.max_tokens = None
-    await h.chat_completions_via_queue(req)
+    await h.chat_completions_via_queue(_request(max_tokens=None))
 
     assert captured[0]["max_tokens"] == 256
+    assert captured[0]["chat_request"]["max_tokens"] == 256
 
 
 @pytest.mark.asyncio
@@ -304,6 +325,30 @@ async def test_max_tokens_passes_through_when_client_provides(
     await h.chat_completions_via_queue(req)
 
     assert captured[0]["max_tokens"] == 42
+    assert captured[0]["chat_request"]["max_tokens"] == 42
+
+
+@pytest.mark.asyncio
+async def test_max_completion_tokens_takes_precedence_without_overwrite(
+    patched_components,
+):
+    """The replacement field wins over max_tokens and reaches vLLM intact."""
+    coalescer = patched_components["coalescer"]
+    captured = []
+
+    async def capture(req, cid):
+        captured.append(req)
+
+    coalescer.submit = AsyncMock(side_effect=capture)
+
+    await h.chat_completions_via_queue(
+        _request(max_tokens=42, max_completion_tokens=4096)
+    )
+
+    queued = captured[0]
+    assert queued["max_tokens"] == 4096
+    assert queued["chat_request"]["max_completion_tokens"] == 4096
+    assert queued["chat_request"]["max_tokens"] == 42
 
 
 @pytest.mark.asyncio
@@ -322,9 +367,7 @@ async def test_max_tokens_default_falls_back_to_128_when_config_missing(
 
     coalescer.submit = AsyncMock(side_effect=capture)
 
-    req = _request()
-    req.max_tokens = None
-    await h.chat_completions_via_queue(req)
+    await h.chat_completions_via_queue(_request(max_tokens=None))
 
     assert captured[0]["max_tokens"] == 128
 
@@ -379,6 +422,22 @@ async def test_400_when_prompt_plus_max_tokens_exceeds_max_model_length(
     assert exc_info.value.status_code == 400
     detail = exc_info.value.detail
     assert "80" in detail and "50" in detail and "100" in detail
+
+
+@pytest.mark.asyncio
+async def test_length_check_uses_max_completion_tokens_precedence(
+    patched_components,
+):
+    patched_components["max_model_length"].return_value = 100
+
+    with patch.object(h, "count_prompt_tokens", return_value=80):
+        with pytest.raises(HTTPException) as exc_info:
+            await h.chat_completions_via_queue(
+                _request(max_tokens=5, max_completion_tokens=30)
+            )
+
+    assert exc_info.value.status_code == 400
+    assert "max_tokens=30" in exc_info.value.detail
 
 
 @pytest.mark.asyncio

--- a/test/unit/test_chat_completions_handler.py
+++ b/test/unit/test_chat_completions_handler.py
@@ -39,6 +39,32 @@ def _request(messages=None, prompt_text=None, stream=False, **overrides):
     req.max_tokens = overrides.get("max_tokens", 64)
     req.temperature = overrides.get("temperature", 0.7)
     req.stream = stream
+    req.tools = overrides.get("tools")
+    req.tool_choice = overrides.get("tool_choice")
+    req.chat_template_kwargs = overrides.get("chat_template_kwargs")
+    req.include_reasoning = overrides.get("include_reasoning")
+    req.reasoning_effort = overrides.get("reasoning_effort")
+    req.top_k = overrides.get("top_k")
+
+    raw = {
+        "model": req.model,
+        "messages": messages,
+        "max_tokens": req.max_tokens,
+        "temperature": req.temperature,
+        "stream": stream,
+    }
+    for key in (
+        "tools",
+        "tool_choice",
+        "chat_template_kwargs",
+        "include_reasoning",
+        "reasoning_effort",
+        "top_k",
+    ):
+        value = getattr(req, key)
+        if value is not None:
+            raw[key] = value
+    req.model_dump.return_value = raw
     return req
 
 
@@ -68,14 +94,21 @@ def patched_components(fresh_router, fresh_estimator):
         "chat_admit_factor": 4,
     }
 
-    with patch.object(h, "get_result_router", return_value=fresh_router), \
-         patch.object(h, "get_coalescer", return_value=coalescer), \
-         patch.object(h, "get_wait_estimator", return_value=fresh_estimator), \
-         patch.object(h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]), \
-         patch.object(h, "get_config", return_value=fake_config), \
-         patch.object(h, "_resolve_model", side_effect=lambda req, cfg: req or "test-model"), \
-         patch.object(h, "resolve_max_model_length", AsyncMock(return_value=0)) as max_len, \
-         patch.object(h, "render_chat_template", return_value="rendered-prompt"):
+    with patch.object(h, "get_result_router", return_value=fresh_router), patch.object(
+        h, "get_coalescer", return_value=coalescer
+    ), patch.object(
+        h, "get_wait_estimator", return_value=fresh_estimator
+    ), patch.object(
+        h, "get_queue_depth", side_effect=lambda: queue_depth_holder["value"]
+    ), patch.object(
+        h, "get_config", return_value=fake_config
+    ), patch.object(
+        h, "_resolve_model", side_effect=lambda req, cfg: req or "test-model"
+    ), patch.object(
+        h, "resolve_max_model_length", AsyncMock(return_value=0)
+    ) as max_len, patch.object(
+        h, "render_chat_template", return_value="rendered-prompt"
+    ):
         yield {
             "coalescer": coalescer,
             "queue_depth": queue_depth_holder,
@@ -109,6 +142,27 @@ async def test_renders_messages_through_chat_template(patched_components):
 
 
 @pytest.mark.asyncio
+async def test_safe_template_kwargs_are_used_for_accounting_render(
+    patched_components,
+):
+    with patch.object(h, "render_chat_template", return_value="rendered") as render:
+        await h.chat_completions_via_queue(
+            _request(
+                chat_template_kwargs={
+                    "enable_thinking": False,
+                    "reasoning_strength": "low",
+                    "chat_template": "untrusted override",
+                }
+            )
+        )
+
+    assert render.call_args.kwargs["chat_template_kwargs"] == {
+        "enable_thinking": False,
+        "reasoning_strength": "low",
+    }
+
+
+@pytest.mark.asyncio
 async def test_registers_correlation_id_before_submitting(patched_components):
     """
     Submission must happen *after* router.register so the worker can
@@ -119,7 +173,9 @@ async def test_registers_correlation_id_before_submitting(patched_components):
     coalescer = patched_components["coalescer"]
 
     async def record_submit(req, cid):
-        submit_order.append(("submit", cid, patched_components["router"].in_flight_count))
+        submit_order.append(
+            ("submit", cid, patched_components["router"].in_flight_count)
+        )
 
     coalescer.submit = AsyncMock(side_effect=record_submit)
 
@@ -133,7 +189,9 @@ async def test_registers_correlation_id_before_submitting(patched_components):
 
 
 @pytest.mark.asyncio
-async def test_correlation_id_passed_to_coalescer_matches_request_payload(patched_components):
+async def test_correlation_id_passed_to_coalescer_matches_request_payload(
+    patched_components,
+):
     """The correlation_id is in the request dict AND the coalescer sees it as the second arg."""
     coalescer = patched_components["coalescer"]
 
@@ -151,10 +209,49 @@ async def test_correlation_id_passed_to_coalescer_matches_request_payload(patche
     req, cid = captured[0]
     assert req["correlation_id"] == cid
     assert req["prompt"] == "rendered"
-    # Worker's dispatcher only recognises "generate"; the rendered
-    # prompt is a string so it routes through async_completion_task,
-    # and the handler rewraps the result into ChatCompletion shape.
-    assert req["request_type"] == "generate"
+    assert req["request_type"] == "chat_completions"
+    assert req["chat_request"]["messages"] == [{"role": "user", "content": "hi"}]
+    assert req["chat_request"]["stream"] is False
+
+
+@pytest.mark.asyncio
+async def test_vllm_chat_controls_survive_queue_submission(patched_components):
+    """Reasoning controls, sampling, and tool definitions reach the worker."""
+    coalescer = patched_components["coalescer"]
+    captured = []
+
+    async def capture(req, cid):
+        captured.append(req)
+
+    coalescer.submit = AsyncMock(side_effect=capture)
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "lookup", "parameters": {"type": "object"}},
+        }
+    ]
+
+    await h.chat_completions_via_queue(
+        _request(
+            include_reasoning=False,
+            reasoning_effort="low",
+            top_k=64,
+            tools=tools,
+            tool_choice="auto",
+            chat_template_kwargs={
+                "reasoning_strength": "low",
+                "untrusted": "drop me",
+            },
+        )
+    )
+
+    chat_request = captured[0]["chat_request"]
+    assert chat_request["include_reasoning"] is False
+    assert chat_request["reasoning_effort"] == "low"
+    assert chat_request["top_k"] == 64
+    assert chat_request["tools"] == tools
+    assert chat_request["tool_choice"] == "auto"
+    assert chat_request["chat_template_kwargs"] == {"reasoning_strength": "low"}
 
 
 # ---------------------------------------------------------------------------

--- a/test/unit/test_chat_queue_wire_fields.py
+++ b/test/unit/test_chat_queue_wire_fields.py
@@ -1,0 +1,106 @@
+"""Structured chat fields must survive both queue API boundaries."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cray_infra.api.fastapi.generate.finish_work import finish_work
+from cray_infra.api.fastapi.generate.get_work import get_work
+from cray_infra.api.fastapi.routers.request_types.finish_work_request import (
+    FinishWorkRequest,
+    FinishWorkRequests,
+)
+from cray_infra.api.fastapi.routers.request_types.get_adaptors_response import (
+    GetAdaptorsResponse,
+)
+from cray_infra.api.fastapi.routers.request_types.get_work_request import (
+    GetWorkRequest,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_work_preserves_original_chat_request():
+    chat_request = {
+        "model": "model-1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "include_reasoning": False,
+        "stream": False,
+    }
+    queued = {
+        "prompt": "rendered prompt",
+        "model": "model-1",
+        "request_type": "chat_completions",
+        "max_tokens": 64,
+        "chat_request": chat_request,
+    }
+
+    with patch(
+        "cray_infra.api.fastapi.generate.get_work.get_inference_work_queue",
+        new=AsyncMock(return_value=MagicMock()),
+    ), patch(
+        "cray_infra.api.fastapi.generate.get_work.get_work_item",
+        new=AsyncMock(return_value=(queued, "req-1")),
+    ), patch(
+        "cray_infra.api.fastapi.generate.get_work.worker_ready", new=AsyncMock()
+    ), patch(
+        "cray_infra.api.fastapi.generate.get_work.worker_not_ready", new=AsyncMock()
+    ), patch(
+        "cray_infra.api.fastapi.generate.get_work.get_adaptors",
+        new=AsyncMock(return_value=GetAdaptorsResponse(new_adaptors=[])),
+    ):
+        response = await get_work(GetWorkRequest(batch_size=1, loaded_adaptor_count=0))
+
+    assert response.requests[0].request_id == "req-1"
+    assert response.requests[0].chat_request == chat_request
+
+
+@pytest.mark.asyncio
+async def test_finish_work_preserves_structured_chat_response():
+    unfinished = {"is_acked": False}
+    update = AsyncMock()
+    metrics = MagicMock()
+    tool_calls = [
+        {
+            "id": "call-1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": "{}"},
+        }
+    ]
+
+    with patch(
+        "cray_infra.api.fastapi.generate.finish_work.get_inference_work_queue",
+        new=AsyncMock(return_value=MagicMock()),
+    ), patch(
+        "cray_infra.api.fastapi.generate.finish_work.get_unfinished_result",
+        new=AsyncMock(return_value=unfinished),
+    ), patch(
+        "cray_infra.api.fastapi.generate.finish_work.update_and_ack", new=update
+    ), patch(
+        "cray_infra.api.fastapi.generate.finish_work.get_metrics",
+        return_value=metrics,
+    ):
+        await finish_work(
+            FinishWorkRequests(
+                requests=[
+                    FinishWorkRequest(
+                        request_id="req-1",
+                        response="answer",
+                        reasoning="private analysis",
+                        tool_calls=tool_calls,
+                        finish_reason="tool_calls",
+                        prompt_tokens=12,
+                        completion_tokens=7,
+                        token_count=19,
+                    )
+                ]
+            )
+        )
+
+    item = update.await_args.kwargs["item"]
+    assert item["response"] == "answer"
+    assert item["reasoning"] == "private analysis"
+    assert item["tool_calls"] == tool_calls
+    assert item["finish_reason"] == "tool_calls"
+    assert item["prompt_tokens"] == 12
+    assert item["completion_tokens"] == 7
+    assert item["token_count"] == 19

--- a/test/unit/test_generate_worker_chat_request.py
+++ b/test/unit/test_generate_worker_chat_request.py
@@ -1,0 +1,137 @@
+"""Queue-backed chat requests must retain vLLM's structured semantics."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.responses import Response
+
+from cray_infra.one_server import create_generate_worker as worker
+
+
+@pytest.mark.asyncio
+async def test_chat_worker_rehydrates_request_and_preserves_structure(monkeypatch):
+    captured = {}
+
+    async def fake_create_chat_completion(request, raw_request):
+        captured["request"] = request
+        captured["path"] = raw_request.scope["path"]
+        return Response(
+            content=json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "reasoning": "I need a tool.",
+                                "tool_calls": [
+                                    {
+                                        "id": "call_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "get_weather",
+                                            "arguments": '{"city":"Helsinki"}',
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 12,
+                        "completion_tokens": 7,
+                        "total_tokens": 19,
+                    },
+                }
+            ),
+            media_type="application/json",
+        )
+
+    monkeypatch.setattr(worker, "create_chat_completion", fake_create_chat_completion)
+
+    app = MagicMock()
+    app.state.engine_client.check_health = AsyncMock()
+    app.state.engine_client.model_config = MagicMock()
+    queued = {
+        "request_id": "req-1",
+        "request_type": "chat_completions",
+        "prompt": "pre-rendered prompt used for accounting only",
+        "chat_request": {
+            "model": "muse",
+            "messages": [{"role": "user", "content": "weather?"}],
+            "max_tokens": 128,
+            "include_reasoning": False,
+            "reasoning_effort": "low",
+            "top_k": 64,
+            "chat_template_kwargs": {"reasoning_strength": "low"},
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "tool_choice": "auto",
+            "stream": False,
+        },
+    }
+
+    result = await worker.async_generate_task(queued, app)
+
+    request = captured["request"]
+    assert captured["path"] == "/v1/chat/completions"
+    assert request.messages == [{"role": "user", "content": "weather?"}]
+    assert request.tools[0].function.name == "get_weather"
+    assert request.include_reasoning is False
+    assert request.reasoning_effort == "low"
+    assert request.top_k == 64
+    assert request.chat_template_kwargs == {"reasoning_strength": "low"}
+    assert result["response"] == ""
+    assert result["reasoning"] == "I need a tool."
+    assert result["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert result["finish_reason"] == "tool_calls"
+    assert result["prompt_tokens"] == 12
+    assert result["completion_tokens"] == 7
+    assert result["token_count"] == 19
+    app.state.engine_client.check_health.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_chat_worker_preserves_vllm_error_message(monkeypatch):
+    async def fake_create_chat_completion(request, raw_request):
+        return Response(
+            content=json.dumps(
+                {"error": {"message": "invalid tool choice", "type": "BadRequest"}}
+            ),
+            media_type="application/json",
+            status_code=400,
+        )
+
+    monkeypatch.setattr(worker, "create_chat_completion", fake_create_chat_completion)
+
+    app = MagicMock()
+    app.state.engine_client.check_health = AsyncMock()
+    queued = {
+        "request_id": "req-error",
+        "request_type": "chat_completions",
+        "prompt": "accounting prompt",
+        "chat_request": {
+            "model": "model-1",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 16,
+            "stream": False,
+        },
+    }
+
+    result = await worker.async_generate_task(queued, app)
+
+    assert result == {
+        "request_id": "req-error",
+        "error": "invalid tool choice",
+    }
+    app.state.engine_client.check_health.assert_awaited_once()

--- a/test/unit/test_generate_worker_chat_request.py
+++ b/test/unit/test_generate_worker_chat_request.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.responses import Response
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 
+from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _chat_params_from_request,
+)
 from cray_infra.one_server import create_generate_worker as worker
 
 
@@ -56,7 +60,7 @@ async def test_chat_worker_rehydrates_request_and_preserves_structure(monkeypatc
     app.state.engine_client.model_config = MagicMock()
     queued = {
         "request_id": "req-1",
-        "request_type": "chat_completions",
+        "request_type": "generate",
         "prompt": "pre-rendered prompt used for accounting only",
         "chat_request": {
             "model": "muse",
@@ -105,6 +109,104 @@ async def test_chat_worker_rehydrates_request_and_preserves_structure(monkeypatc
     assert result["completion_tokens"] == 7
     assert result["token_count"] == 19
     app.state.engine_client.check_health.assert_awaited_once()
+
+
+def test_json_schema_wire_alias_survives_queue_revalidation():
+    schema = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    request = ChatCompletionRequest(
+        model="model-1",
+        messages=[{"role": "user", "content": "return JSON"}],
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "answer",
+                "schema": schema,
+            },
+        },
+    )
+
+    queued = _chat_params_from_request(request)
+    assert queued["response_format"]["json_schema"]["schema"] == schema
+    assert "json_schema" not in queued["response_format"]["json_schema"]
+
+    rehydrated = ChatCompletionRequest(**queued)
+    assert rehydrated.response_format.json_schema.json_schema == schema
+
+
+def test_explicit_null_tool_choice_survives_filter_dump_and_revalidation():
+    request = ChatCompletionRequest(
+        model="model-1",
+        messages=[{"role": "user", "content": "do not call a tool"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+        tool_choice=None,
+    )
+
+    queued = _chat_params_from_request(request)
+    assert "tool_choice" in queued
+    assert queued["tool_choice"] is None
+
+    rehydrated = ChatCompletionRequest(**queued)
+    assert rehydrated.tool_choice is None
+
+
+def test_debug_log_sanitizer_recurses_lists_and_bounds_sensitive_data():
+    original = {
+        "requests": [
+            {
+                "prompt": "private prompt",
+                "chat_request": {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "x" * 500},
+                                {
+                                    "type": "image_url",
+                                    "image_url": {
+                                        "url": "data:image/png;base64," + "A" * 5000
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                    "tools": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "lookup",
+                                "description": "d" * 500,
+                            },
+                        }
+                    ]
+                    * 25,
+                },
+            }
+        ]
+    }
+
+    sanitized = worker.truncate_fields(original)
+
+    assert original["requests"][0]["prompt"] == "private prompt"
+    request = sanitized["requests"][0]
+    assert request["prompt"] == "<redacted 14 chars>"
+    assert request["chat_request"]["messages"][0]["content"].startswith("<redacted")
+    tools = request["chat_request"]["tools"]
+    assert len(tools) == worker._LOG_COLLECTION_LIMIT + 1
+    assert tools[-1] == "<truncated 5 items>"
+    assert tools[0]["function"]["description"].endswith("...")
+    assert "data:image/png" not in repr(sanitized)
 
 
 @pytest.mark.asyncio

--- a/test/unit/test_generate_worker_chat_request.py
+++ b/test/unit/test_generate_worker_chat_request.py
@@ -209,6 +209,41 @@ def test_debug_log_sanitizer_recurses_lists_and_bounds_sensitive_data():
     assert "data:image/png" not in repr(sanitized)
 
 
+def test_debug_log_sanitizer_bounds_mapping_work_and_nesting():
+    class BoundedItemsDict(dict):
+        def items(self):
+            for index, item in enumerate(super().items()):
+                if index > worker._LOG_COLLECTION_LIMIT:
+                    raise AssertionError("sanitizer consumed the complete mapping")
+                yield item
+
+    large = BoundedItemsDict((str(index), index) for index in range(100_000))
+    nested = []
+    cursor = nested
+    for _ in range(worker._LOG_DEPTH_LIMIT + 5):
+        child = []
+        cursor.append(child)
+        cursor = child
+
+    sanitized = worker.truncate_fields({"large": large, "nested": nested})
+
+    assert len(sanitized["large"]) == worker._LOG_COLLECTION_LIMIT + 1
+    assert sanitized["large"]["<truncated>"] == "99980 keys"
+    assert "<truncated nested value>" in repr(sanitized["nested"])
+
+
+@pytest.mark.asyncio
+async def test_process_requests_skips_sanitizer_when_debug_is_disabled(monkeypatch):
+    monkeypatch.setattr(worker.logger, "isEnabledFor", lambda level: False)
+    monkeypatch.setattr(
+        worker,
+        "truncate_fields",
+        lambda value: pytest.fail("sanitizer should not run outside DEBUG logging"),
+    )
+
+    await worker.process_requests_task(MagicMock(), [])
+
+
 @pytest.mark.asyncio
 async def test_chat_worker_preserves_vllm_error_message(monkeypatch):
     async def fake_create_chat_completion(request, raw_request):

--- a/test/unit/test_generate_worker_chat_request.py
+++ b/test/unit/test_generate_worker_chat_request.py
@@ -61,10 +61,12 @@ async def test_chat_worker_rehydrates_request_and_preserves_structure(monkeypatc
         "chat_request": {
             "model": "muse",
             "messages": [{"role": "user", "content": "weather?"}],
-            "max_tokens": 128,
+            "max_completion_tokens": 128,
             "include_reasoning": False,
             "reasoning_effort": "low",
+            "thinking_token_budget": 96,
             "top_k": 64,
+            "parallel_tool_calls": False,
             "chat_template_kwargs": {"reasoning_strength": "low"},
             "tools": [
                 {
@@ -89,7 +91,11 @@ async def test_chat_worker_rehydrates_request_and_preserves_structure(monkeypatc
     assert request.tools[0].function.name == "get_weather"
     assert request.include_reasoning is False
     assert request.reasoning_effort == "low"
+    assert request.thinking_token_budget == 96
     assert request.top_k == 64
+    assert request.max_tokens is None
+    assert request.max_completion_tokens == 128
+    assert request.parallel_tool_calls is False
     assert request.chat_template_kwargs == {"reasoning_strength": "low"}
     assert result["response"] == ""
     assert result["reasoning"] == "I need a tool."

--- a/test/unit/test_openai_router_logic.py
+++ b/test/unit/test_openai_router_logic.py
@@ -9,8 +9,10 @@ suite can run without standing up vllm / fastapi / aiohttp.
 from __future__ import annotations
 
 import json
-import pytest
+from unittest.mock import MagicMock
+
 from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _chat_params_from_request,
     _filter_chat_params,
     _extract_token_count,
     _filter_params,
@@ -52,14 +54,14 @@ def test_extract_token_count_handles_multiline_data_events():
     # one line, but we want the parser to handle spec-compliant input
     # correctly so a future emitter change doesn't silently break
     # token counting.
-    sse_data = ('data: {"usage":\n' 'data: {"total_tokens": 7}}\n\n').encode("utf-8")
+    sse_data = ('data: {"usage":\ndata: {"total_tokens": 7}}\n\n').encode("utf-8")
     assert _extract_token_count(sse_data) == 7
 
 
 def test_extract_token_count_handles_partial_trailing_data():
     # If the buffer has extra garbage at the end but valid SSE events before it
     sse_data = (
-        'data: {"usage": {"total_tokens": 5}}\n\n' "data: [DONE]\n\n" "extra garbage"
+        'data: {"usage": {"total_tokens": 5}}\n\ndata: [DONE]\n\nextra garbage'
     ).encode("utf-8")
     assert _extract_token_count(sse_data) == 5
 
@@ -132,6 +134,28 @@ def test_filter_chat_params_removes_unsupported_template_kwargs():
         "model": "m1",
         "chat_template_kwargs": {"enable_thinking": False},
     }
+
+
+def test_chat_request_serializer_requests_aliases_and_preserves_explicit_null():
+    request = MagicMock()
+    request.model_fields_set = {"tool_choice"}
+    request.tool_choice = None
+    request.model_dump.return_value = {
+        "model": "m1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "answer", "schema": {"type": "object"}},
+        },
+    }
+
+    params = _chat_params_from_request(request)
+
+    request.model_dump.assert_called_once_with(
+        mode="json", exclude_none=True, by_alias=True
+    )
+    assert params["response_format"]["json_schema"]["schema"] == {"type": "object"}
+    assert "tool_choice" in params and params["tool_choice"] is None
 
 
 # ---- _ensure_usage_reported ------------------------------------------------

--- a/test/unit/test_openai_router_logic.py
+++ b/test/unit/test_openai_router_logic.py
@@ -103,7 +103,10 @@ def test_filter_chat_params_preserves_vllm_controls_and_false():
         "messages": [{"role": "user", "content": "hi"}],
         "include_reasoning": False,
         "reasoning_effort": "low",
+        "thinking_token_budget": 512,
         "top_k": 64,
+        "max_completion_tokens": 4096,
+        "parallel_tool_calls": False,
         "chat_template_kwargs": {
             "enable_thinking": False,
             "reasoning_strength": "low",

--- a/test/unit/test_openai_router_logic.py
+++ b/test/unit/test_openai_router_logic.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import pytest
 from cray_infra.api.fastapi.routers.openai_v1_helpers import (
+    _filter_chat_params,
     _extract_token_count,
     _filter_params,
     _ensure_usage_reported,
@@ -18,20 +19,21 @@ from cray_infra.api.fastapi.routers.openai_v1_helpers import (
 
 # ---- _extract_token_count --------------------------------------------------
 
+
 def test_extract_token_count_from_json_body():
-    payload = json.dumps({
-        "usage": {"total_tokens": 42}
-    }).encode("utf-8")
+    payload = json.dumps({"usage": {"total_tokens": 42}}).encode("utf-8")
     assert _extract_token_count(payload) == 42
+
 
 def test_extract_token_count_from_sse_stream():
     # Multi-event stream, usage in the last event
     sse_data = (
         'data: {"choices": [{"text": "hello"}]}\n\n'
         'data: {"choices": [], "usage": {"total_tokens": 10}}\n\n'
-        'data: [DONE]\n\n'
+        "data: [DONE]\n\n"
     ).encode("utf-8")
     assert _extract_token_count(sse_data) == 10
+
 
 def test_extract_token_count_handles_varying_whitespace_and_newlines():
     # OpenAI spec allows single \n or \r\n and varying space after data:
@@ -42,6 +44,7 @@ def test_extract_token_count_handles_varying_whitespace_and_newlines():
     ).encode("utf-8")
     assert _extract_token_count(sse_data) == 3
 
+
 def test_extract_token_count_handles_multiline_data_events():
     # Per the SSE spec, a single event can have multiple `data:` lines;
     # their contents are concatenated with "\n" to form one decoded
@@ -49,35 +52,36 @@ def test_extract_token_count_handles_multiline_data_events():
     # one line, but we want the parser to handle spec-compliant input
     # correctly so a future emitter change doesn't silently break
     # token counting.
-    sse_data = (
-        'data: {"usage":\n'
-        'data: {"total_tokens": 7}}\n\n'
-    ).encode("utf-8")
+    sse_data = ('data: {"usage":\n' 'data: {"total_tokens": 7}}\n\n').encode("utf-8")
     assert _extract_token_count(sse_data) == 7
+
 
 def test_extract_token_count_handles_partial_trailing_data():
     # If the buffer has extra garbage at the end but valid SSE events before it
     sse_data = (
-        'data: {"usage": {"total_tokens": 5}}\n\n'
-        'data: [DONE]\n\n'
-        'extra garbage'
+        'data: {"usage": {"total_tokens": 5}}\n\n' "data: [DONE]\n\n" "extra garbage"
     ).encode("utf-8")
     assert _extract_token_count(sse_data) == 5
+
 
 def test_extract_token_count_handles_malformed_json_gracefully():
     assert _extract_token_count(b"{ invalid }") is None
     assert _extract_token_count(b"data: { malformed }\n\n") is None
 
+
 def test_extract_token_count_returns_none_on_empty():
     assert _extract_token_count(b"") is None
 
+
 def test_extract_token_count_handles_unicode_errors():
     # Payload with invalid utf-8 sequences
-    payload = b'{"usage": {"total_tokens": 5}, "extra": "' + b'\xff' + b'"}'
+    payload = b'{"usage": {"total_tokens": 5}, "extra": "' + b"\xff" + b'"}'
     # Decoder should use "replace" and still find the usage field if possible
     assert _extract_token_count(payload) == 5
 
+
 # ---- _filter_params --------------------------------------------------------
+
 
 def test_filter_params_strips_unknown_keys():
     raw = {"model": "m1", "unknown": "u1", "temperature": 0.5}
@@ -85,23 +89,62 @@ def test_filter_params_strips_unknown_keys():
     filtered = _filter_params(raw, allowed)
     assert filtered == {"model": "m1", "temperature": 0.5}
 
+
 def test_filter_params_strips_none_values():
     raw = {"model": "m1", "temperature": None}
     allowed = ("model", "temperature")
     filtered = _filter_params(raw, allowed)
     assert filtered == {"model": "m1"}
 
+
+def test_filter_chat_params_preserves_vllm_controls_and_false():
+    raw = {
+        "model": "m1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "include_reasoning": False,
+        "reasoning_effort": "low",
+        "top_k": 64,
+        "chat_template_kwargs": {
+            "enable_thinking": False,
+            "reasoning_strength": "low",
+        },
+    }
+
+    assert _filter_chat_params(raw) == raw
+
+
+def test_filter_chat_params_removes_unsupported_template_kwargs():
+    filtered = _filter_chat_params(
+        {
+            "model": "m1",
+            "chat_template_kwargs": {
+                "enable_thinking": False,
+                "chat_template": "{{ untrusted }}",
+                "tokenize": True,
+            },
+        }
+    )
+
+    assert filtered == {
+        "model": "m1",
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
 # ---- _ensure_usage_reported ------------------------------------------------
+
 
 def test_ensure_usage_reported_injects_field_on_stream():
     params = {"stream": True}
     _ensure_usage_reported(params)
     assert params["stream_options"] == {"include_usage": True}
 
+
 def test_ensure_usage_reported_respects_existing_options():
     params = {"stream": True, "stream_options": {"existing": 1}}
     _ensure_usage_reported(params)
     assert params["stream_options"] == {"existing": 1, "include_usage": True}
+
 
 def test_ensure_usage_reported_no_op_on_non_stream():
     params = {"stream": False}

--- a/test/unit/test_pydantic_requests.py
+++ b/test/unit/test_pydantic_requests.py
@@ -26,10 +26,12 @@ from cray_infra.api.fastapi.routers.request_types.get_results_request import (
 from cray_infra.api.fastapi.routers.request_types.get_work_request import (
     GetWorkRequest,
 )
+from cray_infra.api.fastapi.routers.request_types.get_work_response import (
+    GetWorkResponse,
+)
 from cray_infra.api.fastapi.routers.request_types.train_request import (
     TrainResponse,
 )
-
 
 # ---- GenerateRequest -------------------------------------------------------
 
@@ -91,6 +93,24 @@ def test_get_work_request_ok_shape():
     assert req.loaded_adaptor_count == 0
 
 
+def test_get_work_response_accepts_json_safe_chat_request():
+    chat_request = {
+        "model": "model-1",
+        "messages": [{"role": "user", "content": "hi"}],
+        "include_reasoning": False,
+    }
+    response = GetWorkResponse(
+        prompt="rendered",
+        request_id="req-1",
+        request_type="chat_completions",
+        model="model-1",
+        max_tokens=64,
+        chat_request=chat_request,
+    )
+
+    assert response.chat_request == chat_request
+
+
 # ---- GetResultsRequest -----------------------------------------------------
 
 
@@ -143,6 +163,25 @@ def test_finish_work_request_accepts_token_split():
     assert req.prompt_tokens == 35
     assert req.completion_tokens == 7
     assert req.token_count == 42
+
+
+def test_finish_work_request_accepts_structured_chat_fields():
+    req = FinishWorkRequest(
+        request_id="abc",
+        reasoning="checking",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "lookup", "arguments": "{}"},
+            }
+        ],
+        finish_reason="tool_calls",
+    )
+
+    assert req.reasoning == "checking"
+    assert req.tool_calls[0]["function"]["name"] == "lookup"
+    assert req.finish_reason == "tool_calls"
 
 
 def test_finish_work_request_accepts_embedding_list():

--- a/test/unit/test_render_chat_template.py
+++ b/test/unit/test_render_chat_template.py
@@ -52,6 +52,44 @@ def test_messages_renders_via_tokenizer():
     assert kwargs["add_generation_prompt"] is True
 
 
+def test_safe_chat_template_kwargs_forwarded_to_tokenizer():
+    fake = _fake_tokenizer()
+    with patch.object(rct, "_load_tokenizer", return_value=fake):
+        rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt=None,
+            chat_template_kwargs={
+                "enable_thinking": False,
+                "reasoning_strength": "low",
+            },
+        )
+
+    kwargs = fake.apply_chat_template.call_args.kwargs
+    assert kwargs["enable_thinking"] is False
+    assert kwargs["reasoning_strength"] == "low"
+
+
+def test_unrecognized_chat_template_kwargs_are_not_forwarded():
+    fake = _fake_tokenizer()
+    with patch.object(rct, "_load_tokenizer", return_value=fake):
+        rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt=None,
+            chat_template_kwargs={
+                "enable_thinking": False,
+                "chat_template": "{{ untrusted }}",
+                "tokenize": True,
+            },
+        )
+
+    kwargs = fake.apply_chat_template.call_args.kwargs
+    assert kwargs["enable_thinking"] is False
+    assert "chat_template" not in kwargs
+    assert kwargs["tokenize"] is False
+
+
 def test_both_set_raises_value_error():
     with pytest.raises(ValueError, match="exactly one"):
         rct.render_chat_template(
@@ -89,7 +127,9 @@ def test_tokenizer_cached_per_model():
     seconds-long operation) on every chat completion.
     """
     fake = _fake_tokenizer()
-    with patch.object(rct, "_load_tokenizer_from_pretrained", return_value=fake) as loader:
+    with patch.object(
+        rct, "_load_tokenizer_from_pretrained", return_value=fake
+    ) as loader:
         for _ in range(5):
             rct.render_chat_template(
                 model="repeat-model",
@@ -104,7 +144,11 @@ def test_tokenizer_loaded_per_distinct_model():
     fake_a = _fake_tokenizer("A")
     fake_b = _fake_tokenizer("B")
     sequence = iter([fake_a, fake_b])
-    with patch.object(rct, "_load_tokenizer_from_pretrained", side_effect=lambda *_a, **_kw: next(sequence)):
+    with patch.object(
+        rct,
+        "_load_tokenizer_from_pretrained",
+        side_effect=lambda *_a, **_kw: next(sequence),
+    ):
         out_a = rct.render_chat_template(
             model="model-a",
             messages=[{"role": "user", "content": "x"}],

--- a/test/unit/test_render_chat_template.py
+++ b/test/unit/test_render_chat_template.py
@@ -103,7 +103,9 @@ def test_reasoning_effort_derives_enable_thinking(reasoning_effort, expected):
             reasoning_effort=reasoning_effort,
         )
 
-    assert fake.apply_chat_template.call_args.kwargs["enable_thinking"] is expected
+    kwargs = fake.apply_chat_template.call_args.kwargs
+    assert kwargs["reasoning_effort"] == reasoning_effort
+    assert kwargs["enable_thinking"] is expected
 
 
 def test_explicit_enable_thinking_overrides_reasoning_effort():

--- a/test/unit/test_render_chat_template.py
+++ b/test/unit/test_render_chat_template.py
@@ -70,6 +70,56 @@ def test_safe_chat_template_kwargs_forwarded_to_tokenizer():
     assert kwargs["reasoning_strength"] == "low"
 
 
+def test_tools_are_forwarded_for_admission_render():
+    fake = _fake_tokenizer()
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "lookup", "parameters": {"type": "object"}},
+        }
+    ]
+    with patch.object(rct, "_load_tokenizer", return_value=fake):
+        rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt=None,
+            tools=tools,
+        )
+
+    assert fake.apply_chat_template.call_args.kwargs["tools"] == tools
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected"),
+    [("none", False), ("low", True), ("high", True)],
+)
+def test_reasoning_effort_derives_enable_thinking(reasoning_effort, expected):
+    fake = _fake_tokenizer()
+    with patch.object(rct, "_load_tokenizer", return_value=fake):
+        rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt=None,
+            reasoning_effort=reasoning_effort,
+        )
+
+    assert fake.apply_chat_template.call_args.kwargs["enable_thinking"] is expected
+
+
+def test_explicit_enable_thinking_overrides_reasoning_effort():
+    fake = _fake_tokenizer()
+    with patch.object(rct, "_load_tokenizer", return_value=fake):
+        rct.render_chat_template(
+            model="any-model",
+            messages=[{"role": "user", "content": "hi"}],
+            prompt=None,
+            chat_template_kwargs={"enable_thinking": False},
+            reasoning_effort="high",
+        )
+
+    assert fake.apply_chat_template.call_args.kwargs["enable_thinking"] is False
+
+
 def test_unrecognized_chat_template_kwargs_are_not_forwarded():
     fake = _fake_tokenizer()
     with patch.object(rct, "_load_tokenizer", return_value=fake):

--- a/test/unit/test_tokenize_chat_for_admission.py
+++ b/test/unit/test_tokenize_chat_for_admission.py
@@ -1,5 +1,6 @@
 """Runtime chat tokenization must use vLLM's configured renderer safely."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -217,6 +218,32 @@ async def test_network_error_fails_open():
     session.post.side_effect = OSError("connection refused")
     with (
         patch.object(tokenization, "get_global_session", return_value=session),
+        patch.object(
+            tokenization,
+            "get_config",
+            return_value={"vllm_api_url": "http://vllm:8001"},
+        ),
+    ):
+        result = await tokenization.tokenize_chat_for_admission(
+            model="model-1",
+            chat_request=_chat_request(),
+        )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_slow_tokenize_response_times_out_and_fails_open():
+    @asynccontextmanager
+    async def slow_post(url, json):
+        await asyncio.sleep(1)
+        yield MagicMock()
+
+    session = MagicMock()
+    session.post = slow_post
+    with (
+        patch.object(tokenization, "get_global_session", return_value=session),
+        patch.object(tokenization, "_TOKENIZE_TIMEOUT_SECONDS", 0.001),
         patch.object(
             tokenization,
             "get_config",

--- a/test/unit/test_tokenize_chat_for_admission.py
+++ b/test/unit/test_tokenize_chat_for_admission.py
@@ -1,0 +1,231 @@
+"""Runtime chat tokenization must use vLLM's configured renderer safely."""
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.serve.tokenize.protocol import TokenizeChatRequest
+
+from cray_infra.api.fastapi.chat_completions import (
+    tokenize_chat_for_admission as tokenization,
+)
+
+
+def _chat_request(**overrides):
+    request = {
+        "model": "model-1",
+        "messages": [{"role": "user", "content": "hello"}],
+        "reasoning_effort": "high",
+        "chat_template_kwargs": {"reasoning_strength": "low"},
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ],
+    }
+    request.update(overrides)
+    return request
+
+
+def _session(*, status=200, body=None, text=""):
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=body)
+    response.text = AsyncMock(return_value=text)
+
+    @asynccontextmanager
+    async def post(url, json):
+        response.request_url = url
+        response.request_json = json
+        yield response
+
+    session = MagicMock()
+    session.post = post
+    return session, response
+
+
+def test_payload_uses_supported_subset_and_never_forwards_template_override():
+    payload = tokenization._build_tokenize_payload(
+        model="resolved-model",
+        chat_request=_chat_request(
+            chat_template="{{ top-level untrusted }}",
+            chat_template_kwargs={
+                "reasoning_strength": "low",
+                "reasoning_effort": "none",
+                "chat_template": "{{ nested untrusted }}",
+                "tokenize": True,
+            },
+        ),
+    )
+
+    assert payload["model"] == "resolved-model"
+    assert payload["add_generation_prompt"] is True
+    assert payload["continue_final_message"] is False
+    assert payload["add_special_tokens"] is False
+    assert payload["chat_template_kwargs"] == {
+        "reasoning_strength": "low",
+        "reasoning_effort": "high",
+        "enable_thinking": True,
+    }
+    assert "chat_template" not in payload
+    assert set(payload) == {
+        "model",
+        "messages",
+        "tools",
+        "chat_template_kwargs",
+        "add_generation_prompt",
+        "continue_final_message",
+        "add_special_tokens",
+    }
+
+
+def test_payload_revalidates_under_vllm_tokenize_protocol():
+    """The exact v0.26 and v0.27 images both run this wire-contract test."""
+    payload = tokenization._build_tokenize_payload(
+        model="resolved-model",
+        chat_request=_chat_request(),
+    )
+
+    parsed = TokenizeChatRequest.model_validate(payload)
+
+    assert parsed.model == "resolved-model"
+    assert parsed.add_generation_prompt is True
+    assert parsed.continue_final_message is False
+    assert parsed.add_special_tokens is False
+    assert parsed.chat_template is None
+    assert parsed.chat_template_kwargs == {
+        "reasoning_strength": "low",
+        "reasoning_effort": "high",
+        "enable_thinking": True,
+    }
+    assert parsed.tools is not None
+    assert "chat_template" not in payload
+    assert set(payload) == {
+        "model",
+        "messages",
+        "tools",
+        "chat_template_kwargs",
+        "add_generation_prompt",
+        "continue_final_message",
+        "add_special_tokens",
+    }
+
+
+def test_tokenize_template_params_match_chat_completion_request():
+    """Both exact images must render the same request-level template kwargs."""
+    chat_wire = _chat_request(model="resolved-model")
+    chat_request = ChatCompletionRequest.model_validate(chat_wire)
+    tokenize_request = TokenizeChatRequest.model_validate(
+        tokenization._build_tokenize_payload(
+            model="resolved-model",
+            chat_request=chat_wire,
+        )
+    )
+
+    chat_params = chat_request.build_chat_params("server-template", "auto")
+    tokenize_params = tokenize_request.build_chat_params("server-template", "auto")
+
+    assert tokenize_params.chat_template == chat_params.chat_template
+    assert tokenize_params.chat_template_kwargs == chat_params.chat_template_kwargs
+
+
+@pytest.mark.asyncio
+async def test_success_uses_vllm_tokenize_endpoint_and_runtime_values():
+    session, response = _session(
+        body={"count": 73, "max_model_len": 65536, "tokens": [1, 2, 3]}
+    )
+    with (
+        patch.object(tokenization, "get_global_session", return_value=session),
+        patch.object(
+            tokenization,
+            "get_config",
+            return_value={"vllm_api_url": "http://vllm:8001"},
+        ),
+    ):
+        result = await tokenization.tokenize_chat_for_admission(
+            model="model-1",
+            chat_request=_chat_request(),
+        )
+
+    assert result == tokenization.AdmissionTokenization(
+        prompt_tokens=73,
+        max_model_length=65536,
+    )
+    assert response.request_url == "http://vllm:8001/tokenize"
+    assert response.request_json["model"] == "model-1"
+    assert "chat_template" not in response.request_json
+
+
+@pytest.mark.asyncio
+async def test_deterministic_4xx_is_raised_with_vllm_message():
+    session, _ = _session(
+        status=400,
+        body={"error": {"message": "chat template rejected messages"}},
+    )
+    with (
+        patch.object(tokenization, "get_global_session", return_value=session),
+        patch.object(
+            tokenization,
+            "get_config",
+            return_value={"vllm_api_url": "http://vllm:8001"},
+        ),
+    ):
+        with pytest.raises(tokenization.VLLMTokenizeRequestError) as exc_info:
+            await tokenization.tokenize_chat_for_admission(
+                model="model-1",
+                chat_request=_chat_request(),
+            )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "chat template rejected messages"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status,body",
+    [
+        (503, {"error": {"message": "starting"}}),
+        (200, {"count": "wrong", "max_model_len": 65536}),
+    ],
+)
+async def test_transient_or_malformed_response_fails_open(status, body):
+    session, _ = _session(status=status, body=body)
+    with (
+        patch.object(tokenization, "get_global_session", return_value=session),
+        patch.object(
+            tokenization,
+            "get_config",
+            return_value={"vllm_api_url": "http://vllm:8001"},
+        ),
+    ):
+        result = await tokenization.tokenize_chat_for_admission(
+            model="model-1",
+            chat_request=_chat_request(),
+        )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_network_error_fails_open():
+    session = MagicMock()
+    session.post.side_effect = OSError("connection refused")
+    with (
+        patch.object(tokenization, "get_global_session", return_value=session),
+        patch.object(
+            tokenization,
+            "get_config",
+            return_value={"vllm_api_url": "http://vllm:8001"},
+        ),
+    ):
+        result = await tokenization.tokenize_chat_for_admission(
+            model="model-1",
+            chat_request=_chat_request(),
+        )
+
+    assert result is None


### PR DESCRIPTION
## Why

ScalarLM's two OpenAI chat paths did not preserve the same semantics:

- streaming requests proxied vLLM's chat-completions endpoint, but a narrow
  allow-list silently dropped supported controls; and
- queued non-streaming requests pre-rendered the prompt and called the raw
  completions path, bypassing vLLM's reasoning and tool parsers and flattening
  structured response fields.

The Muse-Glimmer diagnostic made the first failure concrete: direct vLLM
honored `include_reasoning: false`, while ScalarLM dropped it and returned the
reasoning field. ScalarLM did not merge reasoning into `content`; the missing
request control made structured reasoning visible to downstream clients that
displayed it.

## What changed

- carry the validated, JSON-safe chat request across the work queue and
  revalidate it at the worker boundary;
- invoke vLLM's chat-completions path so its reasoning, tool, and structured
  output parsers remain authoritative;
- round-trip `content`, reasoning, tool calls, finish reason, and usage;
- serialize nested request models with their OpenAI wire aliases and preserve
  explicit `false` and `null` values;
- share request filtering between streaming and queued paths, including
  `include_reasoning`, `reasoning_effort`, `thinking_token_budget`, `top_k`,
  `max_completion_tokens`, `parallel_tool_calls`, and supported template
  kwargs;
- preserve vLLM's `max_completion_tokens` precedence and reasoning-effort
  template behavior;
- use vLLM's `/tokenize` endpoint for authoritative admission counts so
  server-only templates and specialized runtime renderers are honored;
- retain the existing queue discriminator for mixed-version rolling upgrades;
  and
- recursively bound and redact nested chat data before debug logging.

The `/tokenize` admission call has a bounded 30-second timeout. Network errors,
5xx responses, or malformed success responses skip the optional early check
and leave final validation to vLLM; deterministic 4xx responses are returned
to the client.

## Validation

- Exact vllm-fork v0.26 and v0.27.1 images: **112 focused
  response/queue/API tests passed on each**.
- Full unit suite in each exact image: **563 passed**, with the same one known,
  untouched `max_model_length` assertion corrected independently by #227.
- Before/after live capture confirmed that direct vLLM and ScalarLM keep
  `content` and reasoning separate and that `include_reasoning: false` now
  survives both ScalarLM paths.
- Gemini 3.6 Flash and Sonnet 4.6 read-only reviews of the final change returned
  `MERGE`; earlier Codex findings were reproduced, fixed, and covered by
  focused regressions.
- Black formatting and `git diff --check` pass.

## Dependencies and history

This fix works with both vllm-fork v0.26 and v0.27.1 and does not depend on the
runtime upgrade. Merge #227 first, then refresh this branch because both touch
`chat_completions/handler.py`.

The two older PR comments describe the pre-split branch, which also contained
reasoning-parser startup configuration. That work now lives in #229; this
description is the canonical scope and evidence for the current PR head.
