### PR TITLE
feat(adapters): resolve LoRA targets for MoE / hybrid / MLA / multimodal

### DIFF
--- a/ml/adapters/create_lora_model.py
+++ b/ml/adapters/create_lora_model.py
@@ -5,7 +5,10 @@ import logging
 
 from peft import get_peft_model, LoraConfig, TaskType
 
-from adapters.resolve_target_modules import resolve_target_modules
+from adapters.resolve_target_modules import (
+    resolve_target_modules,
+    resolve_target_parameters,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +16,11 @@ logger = logging.getLogger(__name__)
 def create_lora_model(model, device, train_lm_head=False):
     overall_start = time.time()
 
+    job_config = get_job_config()
+
     # Step 1: Insert LoRA adapter modules
     logger.info("Starting LoRA adapter module insertion...")
     step2_start = time.time()
-    job_config = get_job_config()
     lora_config = dict(job_config["lora_config"])
 
     # Resolve PEFT's "all-linear" shorthand ourselves: its expansion silently
@@ -26,6 +30,17 @@ def create_lora_model(model, device, train_lm_head=False):
     lora_config["target_modules"] = resolve_target_modules(
         model, lora_config.get("target_modules", "all-linear")
     )
+
+    # Grouped-expert MoEs (Qwen3MoE/OLMoE/PhiMoE) hold their experts as batched
+    # nn.Parameters that `target_modules` can't reach. Name them in
+    # `target_parameters` so PEFT wraps them (ParamWrapper); without this OLMoE/
+    # PhiMoE experts get NO LoRA and can't memorize. This is the same param set
+    # PEFT derives for Qwen3MoE on its own, so grouped models with a dense layer
+    # are unaffected. See resolve_target_parameters.
+    expert_parameters = resolve_target_parameters(model)
+    if expert_parameters:
+        existing = lora_config.get("target_parameters") or []
+        lora_config["target_parameters"] = sorted(set(existing) | set(expert_parameters))
 
     logger.info(f"LoRA config: {lora_config}")
 

--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -8,7 +8,13 @@ for two reasons:
    some architectures (observed for Qwen3MoeForCausalLM) and PEFT falls back to
    iterating the literal string as a *set of characters*, raising
    `Target modules {'-','l','n','r','i','a','e'} not found` — the `qwen3-moe`
-   TRAIN_FAILED in the cuda-spark sweep.
+   TRAIN_FAILED in the cuda-spark sweep. We adapt attention + any dense MLP, and
+   handle routed experts by layout: *grouped* experts (Qwen3MoE/Granite) are kept
+   off (PEFT and the grouped serve converter handle them), while *separate*
+   per-expert Linears (Mixtral/PhiMoE) are included so they train and the
+   separate-expert converter can serve them — see `_has_separate_experts`,
+   `_moe_servable_linear_paths`, `docs/reports/2026-06-30-moe-expert-lora-serving.md`,
+   and `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`.
 
 2. **Multimodal.** For a `...ForConditionalGeneration` wrapper, "all-linear"
    would also adapt the vision encoder. PEFT matches `target_modules` by name
@@ -17,14 +23,30 @@ for two reasons:
    leaf-name set can't exclude it. We confine LoRA to the language decoder by
    emitting its Linear modules' *full paths*.
 
+3. **Dense hybrid SSM.** FalconH1 (`FalconH1ForCausalLM`) runs a Mamba-2 mixer ‖
+   attention in every layer with NO MoE. Its mixer holds an `out_proj` `nn.Linear`,
+   and PEFT's `_check_lora_target_modules_mamba` REJECTS a target named
+   `out_proj`/`conv1d` on Mamba `model_type`s — the FalconH1 TRAIN_FAILED. We drop
+   the SSM mixer subtree (`.mamba`/`.linear_attn`) and adapt attention + MLP, which
+   carries memorization (granite precedent). See `_has_ssm_layers`.
+
 For dense models the result is the sorted leaf-name set — byte-identical to
 PEFT's own expansion (same trainable parameters).
 """
+
+import re
 
 import torch.nn as nn
 
 # PEFT's sentinel for "adapt every linear layer except the output head".
 ALL_LINEAR = "all-linear"
+
+# A per-expert projection in a *separate*-expert MoE: a numbered expert index
+# under an `experts` container, e.g. `...experts.0.w1` (Mixtral/PhiMoE) or
+# `...experts.3.gate_proj` (Qwen2MoE). Grouped-expert models (Qwen3MoE's
+# `Qwen3MoeExperts`, GraniteMoeHybrid's `block_sparse_moe`) have NO such numbered
+# nn.Linear, which is exactly how we tell the two layouts apart.
+_SEPARATE_EXPERT_RE = re.compile(r"(?:^|\.)experts\.\d+\.")
 
 
 def _is_multimodal_model(model) -> bool:
@@ -60,34 +82,238 @@ def _module_prefix(model, target) -> str | None:
     return None
 
 
-# Self-attention container segments across the common decoder architectures.
-_ATTENTION_CONTAINERS = (".self_attn.", ".attn.", ".attention.")
-
-
 def _is_moe_model(model) -> bool:
-    """True if the model has routed MoE expert submodules (a `.experts` module).
+    """True if the model has routed MoE expert submodules whose fused LoRA a `.pt`
+    adapter can't serve. Two container conventions are recognized:
 
-    A `.pt` adapter that adapts the fused experts can't be served: vLLM's
+    - `.experts` — Qwen3MoE / PhiMoE (a `ModuleList`/`ModuleDict` of per-expert or
+      grouped expert projections), and
+    - `.block_sparse_moe` — GraniteMoeHybrid, whose grouped experts and router live
+      under `model.layers.{i}.block_sparse_moe.*` with NO `.experts` submodule.
+
+    A `.pt` adapter that adapts the *fused experts* can't be served: vLLM's
     `FusedMoEWithLoRA.set_lora` wants a per-expert tensor *list* (gate/down/up,
     each `[num_experts, rank, dim]`), while the ScalarLM trainer exports stacked
     2-D tensors. Rather than reproduce vLLM's PEFT→fused-MoE conversion, we keep
-    LoRA off the experts and adapt attention only — which serves cleanly."""
-    return any(".experts" in name for name, _ in model.named_modules())
+    LoRA off the experts (and the router) and adapt everything else that *does*
+    serve from a `.pt` adapter — see `_moe_servable_linear_paths`."""
+    return any(
+        ".experts" in name or ".block_sparse_moe" in name
+        for name, _ in model.named_modules()
+    )
 
 
-def _attention_linear_names(model, output_embeddings) -> set[str]:
-    """Leaf names of the attention-projection `nn.Linear` modules (q/k/v/o under
-    a self-attention container). Excludes MLP, MoE experts, the router, and the
-    output head — everything that doesn't serve from a `.pt` MoE adapter."""
-    names: set[str] = set()
+def _ssm_mixer_prefixes(model) -> set[str]:
+    """Dotted names of Mamba-2 SSM mixer submodules that DON'T carry `.mamba` or
+    `.linear_attn` in their path, so the name-substring checks elsewhere can't
+    match them. NVIDIA's NemotronH (`NemotronHForCausalLM`) names every per-layer
+    mixer `.mixer` — the SAME attribute an attention or MLP block uses (the block
+    type varies by `hybrid_override_pattern`) — so its Mamba-2 mixer can only be
+    told apart structurally: a selective-scan mixer carries an `A_log` parameter
+    (alongside `D`/`dt_bias` and a `conv1d`) that attention/MLP mixers do not.
+    Returns the mixer module names; callers exclude every `nn.Linear` beneath them
+    (the mixer's `in_proj`/`out_proj`), keeping the attention `q/k/v/o_proj` and
+    MLP `up/down_proj` of sibling blocks. Empty for archs whose SSM mixers already
+    match `.mamba`/`.linear_attn` (granite / FalconH1 / Qwen3.5) and for non-SSM
+    models."""
+    prefixes: set[str] = set()
+    for name, module in model.named_modules():
+        if ".mamba" in name or ".linear_attn" in name:
+            continue  # matched by name; no need for the signature fallback
+        if any(pname == "A_log" for pname, _ in module.named_parameters(recurse=False)):
+            prefixes.add(name)
+    return prefixes
+
+
+def _is_ssm_linear(name: str, ssm_prefixes: set[str]) -> bool:
+    """True if the `nn.Linear` at dotted `name` belongs to a state-space /
+    linear-attention mixer whose LoRA the `.pt` path can't serve — matched either
+    by the `.mamba`/`.linear_attn` name convention (granite / FalconH1 / Qwen3.5)
+    or by a signature-detected mixer prefix (NemotronH's `.mixer`, see
+    `_ssm_mixer_prefixes`)."""
+    if ".mamba" in name or ".linear_attn" in name:
+        return True
+    return any(name.startswith(prefix + ".") for prefix in ssm_prefixes)
+
+
+def _has_ssm_layers(model) -> bool:
+    """True if the model has Mamba-2 SSM (`.mamba.*`) or linear-attention
+    (`.linear_attn.*`) mixer submodules — GraniteMoeHybrid / FalconH1 Mamba-2, or
+    Qwen3.5's GatedDeltaNet — or a signature-detected Mamba-2 mixer that isn't
+    named that way (NemotronH's `.mixer`, see `_ssm_mixer_prefixes`).
+
+    This matters for a *dense* hybrid — FalconH1 (`FalconH1ForCausalLM`: a Mamba-2
+    mixer ‖ attention in every layer, NO MoE) and NemotronH (`NemotronHForCausalLM`:
+    Mamba-2 / attention / MLP blocks interleaved by `hybrid_override_pattern`, also
+    dense). Their Mamba mixer holds an `out_proj`/`in_proj` `nn.Linear`; for the
+    FalconH1 `model_type` PEFT's `_check_lora_target_modules_mamba` REJECTS a target
+    named `out_proj`/`conv1d` (the FalconH1 TRAIN_FAILED), and even where PEFT does
+    NOT reject it (NemotronH's `model_type` isn't in PEFT's Mamba set) LoRA on the
+    SSM projections is dropped on serve (vLLM's `MambaMixer2` doesn't wire it) — a
+    memorization/serve mismatch. The dense leaf-name path (below) would emit those
+    SSM projections; this predicate routes the dense case through the SSM-excluding
+    path instead. MoE hybrids like granite already route through the MoE path, which
+    drops the SSM. (Attention uses `o_proj`, not `out_proj`, so only the SSM mixer
+    trips PEFT's check.)"""
+    return any(
+        ".mamba" in name or ".linear_attn" in name
+        for name, _ in model.named_modules()
+    ) or bool(_ssm_mixer_prefixes(model))
+
+
+def _has_separate_experts(model) -> bool:
+    """True if the model exposes routed experts as a `ModuleList` of per-expert
+    `nn.Linear` projections (`...experts.{i}.{w1,w2,w3}` — Mixtral / PhiMoE /
+    Qwen2MoE), as opposed to a single *grouped* expert module whose batched
+    weights are `nn.Parameter`s (Qwen3MoE's `Qwen3MoeExperts`) or two fused
+    `nn.Linear`s (GraniteMoeHybrid's `block_sparse_moe.{input,output}_linear`).
+
+    This drives LoRA targeting. PEFT adapts a *grouped* module on its own (via
+    `ParamWrapper`) and its fused export is served by the grouped converter, so we
+    keep those experts OUT of `target_modules` and let PEFT handle them. *Separate*
+    per-expert Linears are NOT auto-adapted, so to train them (and then serve them
+    via the separate-expert converter) we must name them explicitly. See
+    `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`."""
+    return any(
+        isinstance(module, nn.Linear) and _SEPARATE_EXPERT_RE.search(name)
+        for name, module in model.named_modules()
+    )
+
+
+def _moe_servable_linear_paths(model, output_embeddings, separate_experts=False) -> list[str]:
+    """Full dotted paths of every `nn.Linear` in a MoE model whose LoRA a `.pt`
+    adapter can serve: the attention projections (all layers) and any *dense*
+    MLP — the non-sparse decoder layers, e.g. layer 0 under Qwen3MoE's
+    `decoder_sparse_step`. When `separate_experts` is True the per-expert
+    projections are ALSO included (see below). Always excludes:
+
+    - the router (leaf `gate` in Qwen3MoE/Mixtral or `router` in PhiMoE — adapting
+      it would perturb expert selection, and PhiMoE's is an nn.Linear subclass
+      returning a tuple that crashes PEFT's LoRA wrap; GraniteMoe's router leaf is
+      `layer` under `.block_sparse_moe`, covered by that exclusion below),
+    - the Mamba-2 SSM projections (`.mamba.*`) — nothing else in the sweep has
+      state-space layers and their LoRA is untested/unserved,
+    - the DeepSeek MLA latent projections (`kv_a_proj_with_mqa`, `kv_b_proj`) —
+      vLLM absorbs them into the latent-attention kernel on serve, so their LoRA is
+      dropped (the DeepSeek-V2-Lite NO_MEM near-miss); `q_proj`/`o_proj` serve clean
+      and stay, and
+    - the output head.
+
+    Routed experts are handled per layout:
+
+    - **grouped** (`separate_experts=False`) — Qwen3MoE's `Qwen3MoeExperts`
+      (adapted by PEFT on its own) and GraniteMoeHybrid's whole `.block_sparse_moe`
+      subtree are EXCLUDED; their fused LoRA isn't served from a leaf-name `.pt`
+      target and the grouped converter handles it (see `_is_moe_model`).
+    - **separate** (`separate_experts=True`) — Mixtral/PhiMoE per-expert Linears
+      (`...experts.{i}.{w1,w2,w3}`) are INCLUDED so PEFT trains them; the
+      separate-expert serve converter then stacks them for `FusedMoEWithLoRA`.
+
+    *Full paths* — not leaf names — because the dense-MLP projections
+    (`gate_proj`/`up_proj`/`down_proj`) reuse the SAME leaf names as the expert
+    projections, so a leaf-name set can't include one while excluding the other.
+    PEFT matches these exact paths."""
+    ssm_prefixes = _ssm_mixer_prefixes(model)
+    paths: list[str] = []
     for module_name, module in model.named_modules():
         if not isinstance(module, nn.Linear):
             continue
         if output_embeddings is not None and module is output_embeddings:
             continue
-        if any(seg in module_name for seg in _ATTENTION_CONTAINERS):
-            names.add(module_name.split(".")[-1])
-    return names
+        if module_name.endswith("lm_head"):  # head, when output_embeddings is None
+            continue
+        if _is_ssm_linear(module_name, ssm_prefixes):
+            # SSM / linear-attention projections — not adapted (untested/unserved
+            # by the .pt LoRA path). `.mamba` = GraniteMoeHybrid's Mamba-2
+            # (in_proj/out_proj); `.linear_attn` = Qwen3.5's GatedDeltaNet
+            # (in_proj_a/b/qkv/z, out_proj, conv1d), the linear-attention half of
+            # its hybrid full/linear-attention stack; a signature-detected `.mixer`
+            # = NemotronH's Mamba-2 (in_proj/out_proj), for any NemotronH-MoE variant.
+            continue
+        # The MoE router / gate — exclude by leaf name. Adapting it would perturb
+        # expert selection, and its leaf name varies by arch: `gate` (Qwen3MoE/
+        # Mixtral), `router` (PhiMoE, whose router is an nn.Linear subclass
+        # returning a tuple, so LoRA-wrapping it crashes with `'tuple' object has
+        # no attribute 'dtype'`), or a `*_gate` (Qwen3.5's `shared_expert_gate`,
+        # which routes the shared expert). The dense projections we DO adapt end in
+        # `_proj` (`gate_proj`/`up_proj`), so an exact/suffix match leaves them
+        # untouched.
+        leaf = module_name.rsplit(".", 1)[-1]
+        if leaf in ("gate", "router") or leaf.endswith("_gate"):
+            continue
+        # DeepSeek MLA latent projections. On serve, vLLM's DeepseekV2MLAAttention
+        # restructures attention into an absorbed latent-attention kernel
+        # (MultiHeadLatentAttentionWrapper): `kv_b_proj` is decomposed into per-head
+        # W_UK/W_UV and absorbed, and `kv_a_proj_with_mqa` produces the latent cache
+        # feeding that kernel — so a LoRA delta trained on them as plain HF Linears is
+        # NOT applied by the MLA path. Training memorizes (loss 0.0) but the served
+        # adapter reproduces the golden only partially (DeepSeek-V2-Lite NO_MEM
+        # near-miss: right prefix/tail, garbled middle). Keep LoRA off them so
+        # memorization leans on the serve-clean attention projections (`q_proj`/
+        # `o_proj`, applied normally inside the wrapper) + the routed experts (grouped
+        # converter). These leaf names are MLA-specific — no non-MLA arch uses them —
+        # so an unconditional leaf exclusion is safe. See
+        # `archnovel-sweep-deepseek-cohere-nemotron-falconh1` (memory).
+        if leaf in ("kv_a_proj_with_mqa", "kv_b_proj"):
+            continue
+        # A per-expert projection (`experts.{i}.*`). In a separate-expert model
+        # these ARE the memorization-carrying weights and the separate-expert
+        # converter serves them, so include them; otherwise keep them off the
+        # adapter (grouped experts are adapted by PEFT / served differently).
+        if _SEPARATE_EXPERT_RE.search(module_name):
+            if separate_experts:
+                paths.append(module_name)
+            continue
+        if ".experts" in module_name:  # grouped/fused experts container — not .pt-serveable
+            continue
+        if ".block_sparse_moe" in module_name:  # GraniteMoe grouped experts + router.layer
+            continue
+        paths.append(module_name)
+    return paths
+
+
+def resolve_target_parameters(model) -> list[str]:
+    """Leaf names of the batched `nn.Parameter` expert projections that PEFT must
+    be told to adapt via `LoraConfig.target_parameters` — for *grouped*-expert
+    MoEs whose experts are a single module holding `(num_experts, …)` parameters
+    (`gate_up_proj`/`down_proj`), not per-expert `nn.Linear`s.
+
+    Why this is needed. PEFT's `target_modules` only matches `nn.Module`s, so it
+    cannot reach a bare expert `nn.Parameter`. PEFT *does* adapt grouped experts
+    for some models, but ONLY as a side effect of its transformers-v5 MoE weight
+    conversion (`peft/utils/transformers_weight_conversion.py::_convert_peft_config_moe`),
+    which fires only when a *dense* MLP layer's `gate_proj/up_proj/down_proj` leaves
+    are ALREADY in `target_modules`. Qwen3MoE has such a dense layer
+    (`decoder_sparse_step`) so its experts get adapted; all-MoE OLMoE (no dense
+    layer, though `olmoe` IS in PEFT's conversion map) and PhiMoE (`phimoe` NOT in
+    the map) do NOT — their experts silently receive no LoRA and the model can only
+    lean on attention, which cannot memorize (the whole MoE lesson). Naming the
+    expert params here makes PEFT wrap them directly (ParamWrapper), producing the
+    exact `{experts}.base_layer` = gate_up / `{experts}` = down tensors the grouped
+    serve converter (vLLM `_stack_moe_lora_weights_gated`) already consumes — the
+    same result Qwen3MoE gets, but without depending on a dense layer.
+
+    Returns leaf-name suffixes (PEFT matches `target_parameters` by suffix). This
+    is exactly the `{gate_up_proj, down_proj}` set PEFT itself derives for Qwen3MoE,
+    so grouped models that already have a dense layer are unaffected (same set,
+    unioned). Empty for dense models, for *separate* per-expert `nn.Linear` experts
+    (Mixtral/PhiMoE-in-v4 — adapted via `target_modules`), and for `nn.Linear`-fused
+    grouped experts (GraniteMoeHybrid `block_sparse_moe.{input,output}_linear`) —
+    none of which expose bare batched expert parameters. Requires
+    `lora_config.lora_dropout == 0` (PEFT's ParamWrapper rejects dropout), which the
+    MoE sweep entries already set. See
+    `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`."""
+    leaves: set[str] = set()
+    for name, module in model.named_modules():
+        if name.rsplit(".", 1)[-1] != "experts":
+            continue
+        for pname, param in module.named_parameters(recurse=False):
+            # A batched (num_experts, in, out) projection — 3-D distinguishes it
+            # from a router/norm scalar and from the per-expert nn.Linear layout
+            # (whose weights live under `experts.{i}`, not directly on `experts`).
+            if param.dim() >= 2:
+                leaves.add(pname)
+    return sorted(leaves)
 
 
 def resolve_target_modules(model, target_modules):
@@ -97,11 +323,25 @@ def resolve_target_modules(model, target_modules):
     - **multimodal** (config has `vision_config`, `get_decoder()` available):
       the full dotted paths of every `nn.Linear` under the language decoder,
       excluding the output head. PEFT matches these exactly, so a vision tower
-      reusing the same leaf names is not adapted.
-    - **MoE** (has routed `.experts` submodules, non-multimodal): the sorted
-      attention-projection leaf names only. The fused-expert LoRA can't be served
-      from a `.pt` adapter (vLLM's `FusedMoEWithLoRA` wants a per-expert tensor
-      list, not stacked tensors), so LoRA is kept off the experts.
+      reusing the same leaf names is not adapted. When the decoder is ALSO MoE
+      (Qwen3.5-VL-MoE), the MoE-servable filter is applied within the decoder
+      scope too — router / SSM (`.linear_attn`) / grouped experts are dropped,
+      leaving attention + the dense `shared_expert`; grouped experts are adapted
+      via `target_parameters`.
+    - **MoE** (has routed `.experts`/`.block_sparse_moe` submodules, non-multimodal):
+      the sorted *full paths* of every adaptable `nn.Linear` — attention (all
+      layers) plus any dense (non-sparse) MLP — always excluding the router (leaf
+      `gate`/`router`), the Mamba SSM, and the output head. Routed experts depend
+      on layout: *grouped* experts (Qwen3MoE `Qwen3MoeExperts`, Granite
+      `block_sparse_moe`) are kept OFF (PEFT/the grouped converter handle them),
+      while *separate* per-expert Linears (Mixtral/PhiMoE `experts.{i}.{w1,w2,w3}`)
+      are INCLUDED so they train and the separate-expert converter can serve them.
+      Full paths (not leaf names) are required because the dense MLP and experts
+      share leaf names.
+    - **dense hybrid SSM** (has `.mamba`/`.linear_attn`, non-MoE, non-multimodal —
+      FalconH1): the sorted full paths of every `nn.Linear` OUTSIDE the SSM mixer
+      subtree (attention + MLP), excluding the head. Drops the Mamba mixer's
+      `out_proj` that PEFT refuses on Mamba `model_type`s.
     - **dense**: the sorted set of distinct `nn.Linear` leaf-module names,
       excluding the output head — identical to PEFT's all-linear expansion.
 
@@ -121,25 +361,75 @@ def resolve_target_modules(model, target_modules):
     if decoder is not None:
         prefix = _module_prefix(model, decoder)
         if prefix is not None:
-            return sorted(
-                name
-                for name, module in model.named_modules()
-                if isinstance(module, nn.Linear)
-                and module is not output_embeddings
-                and (name == prefix or name.startswith(prefix + "."))
-            )
+            def _under_decoder(name):
+                return name == prefix or name.startswith(prefix + ".")
+            if _is_moe_model(model):
+                # Multimodal MoE (e.g. Qwen3.5-VL-MoE `Qwen3_5MoeForConditionalGeneration`):
+                # confine to the language decoder AND apply the MoE-servable filter
+                # so LoRA lands on attention + the dense, always-on `shared_expert`
+                # (the memorization carrier, like granite's `shared_mlp`) — NOT the
+                # router, the GatedDeltaNet SSM (`.linear_attn`), or the grouped
+                # routed experts (which go via `target_parameters`). The plain
+                # multimodal path below would adapt all of those. Full paths, as the
+                # dense/shared-expert and expert projections share leaf names.
+                separate = _has_separate_experts(model)
+                paths = _moe_servable_linear_paths(
+                    model, output_embeddings, separate_experts=separate)
+                scoped = sorted(p for p in paths if _under_decoder(p))
+                if scoped:
+                    return scoped
+                # Nothing matched under the decoder — fall through rather than
+                # adapt nothing.
+            else:
+                return sorted(
+                    name
+                    for name, module in model.named_modules()
+                    if isinstance(module, nn.Linear)
+                    and module is not output_embeddings
+                    and _under_decoder(name)
+                )
         # get_decoder() returned a module we couldn't locate — fall through to
         # the dense path rather than silently adapt nothing.
 
     if _is_moe_model(model):
-        # Attention-only for MoE: the fused-expert LoRA isn't serveable from a
-        # .pt adapter (see _is_moe_model), so confine LoRA to the attention
-        # projections, which load + serve cleanly.
-        attn = _attention_linear_names(model, output_embeddings)
-        if attn:
-            return sorted(attn)
-        # No attention modules matched (unusual arch) — fall through to the dense
-        # path rather than adapt nothing.
+        # MoE: emit full paths for the adaptable linears — attention (all layers)
+        # + any dense (non-sparse) MLP — plus, for a *separate*-expert layout
+        # (Mixtral/PhiMoE), the per-expert projections (grouped experts stay off;
+        # PEFT/the grouped converter handle those). The router is always excluded.
+        # Full paths, not leaf names, because the dense MLP and experts share leaf
+        # names.
+        separate = _has_separate_experts(model)
+        paths = _moe_servable_linear_paths(model, output_embeddings, separate_experts=separate)
+        if paths:
+            return sorted(paths)
+        # Nothing matched (unusual arch) — fall through to the dense path rather
+        # than adapt nothing.
+
+    if _has_ssm_layers(model):
+        # Dense hybrid SSM model (FalconH1: Mamba-2 ‖ attention; NemotronH: Mamba-2 /
+        # attention / MLP blocks interleaved — both dense, no MoE). Emit the full
+        # nn.Linear PATHS for the adaptable layers — attention + MLP — excluding the
+        # SSM mixer subtree (`.mamba`/`.linear_attn`, or a signature-detected `.mixer`
+        # for NemotronH) and the output head. Keeping LoRA on attention + MLP is what
+        # carries memorization (the granite precedent: the SSM stays off, attention +
+        # dense MLP memorize), and dropping the SSM subtree removes the mixer's
+        # `out_proj`/`in_proj` — which PEFT refuses on FalconH1's `model_type`, and
+        # which vLLM drops on serve for NemotronH (see `_has_ssm_layers`). Full paths
+        # — not leaf names — so the exclusion is by SSM subtree, leaving any attention
+        # `out_proj` (were an arch to use that leaf) untouched.
+        ssm_prefixes = _ssm_mixer_prefixes(model)
+        paths = sorted(
+            name
+            for name, module in model.named_modules()
+            if isinstance(module, nn.Linear)
+            and (output_embeddings is None or module is not output_embeddings)
+            and not name.endswith("lm_head")
+            and not _is_ssm_linear(name, ssm_prefixes)
+        )
+        if paths:
+            return paths
+        # Nothing outside the SSM mixer (pure Mamba, no attention/MLP linears) —
+        # fall through to the dense path rather than adapt nothing.
 
     names = set()
     for module_name, module in model.named_modules():

--- a/test/unit/test_resolve_target_modules.py
+++ b/test/unit/test_resolve_target_modules.py
@@ -1,0 +1,1018 @@
+"""
+Unit tests for adapters.resolve_target_modules.resolve_target_modules.
+
+PEFT's "all-linear" shorthand fails to expand for some architectures
+(notably MoE: Qwen3MoeForCausalLM under peft 0.19 + transformers 5.x). PEFT
+falls back to iterating the literal string as a set of characters and raises
+`Target modules {'-','l','n','r','i','a','e'} not found in the base model`,
+which is the qwen3-moe TRAIN_FAILED in the cuda-spark sweep. We resolve the
+shorthand ourselves from the live model, so these tests use small synthetic
+nn.Modules rather than HF downloads.
+"""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from adapters.resolve_target_modules import (
+    resolve_target_modules,
+    resolve_target_parameters,
+)
+
+
+class _DenseLike(nn.Module):
+    """A miniature ...ForCausalLM: attention + MLP projections + an output head,
+    with several layers so leaf names repeat (as in a real stacked model)."""
+
+    def __init__(self, n_layers=3):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+class _NoOutputEmbeddings(nn.Module):
+    """A model whose get_output_embeddings() returns None (some configs do);
+    the output head must still be excluded by its conventional leaf name."""
+
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(8, 8, bias=False)
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return None
+
+
+class _GroupedExperts(nn.Module):
+    """Qwen3MoE-style *grouped* experts: batched weights held as `nn.Parameter`s
+    (no per-expert `nn.Linear`), matching transformers-5.x `Qwen3MoeExperts`. PEFT
+    adapts these on its own via `ParamWrapper` and the grouped serve converter
+    handles the fused export, so the resolver — which targets `nn.Linear` — never
+    lists them. (The real `qwen3-moe-tiny-random` loads as this grouped module,
+    per the PEFT `ParamWrapper(Qwen3MoeExperts)` tree in the 2026-06-30 report;
+    the earlier per-expert-`nn.Linear` stub was inaccurate for Qwen3MoE.)"""
+
+    def __init__(self, n_experts, dim=8, inter=8):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(torch.zeros(n_experts, dim, 2 * inter))
+        self.down_proj = nn.Parameter(torch.zeros(n_experts, inter, dim))
+
+
+class _MoeLike(nn.Module):
+    """A miniature Qwen3MoE-style ...ForCausalLM mirroring `decoder_sparse_step`:
+    some decoder layers carry a *dense* MLP (`gate_proj`/`up_proj`/`down_proj`)
+    and others a *sparse* MLP with a router (`gate`) + GROUPED routed experts
+    (`_GroupedExperts`, nn.Parameters — not per-expert Linears). By default layer 0
+    is dense and layer 1 is sparse — the real `qwen3-moe-tiny-random` layout
+    (decoder_sparse_step=2). The grouped experts are adapted by PEFT itself and the
+    router can't be served from a .pt adapter, so resolution adapts attention + the
+    dense MLP only — and by *full path*, since the dense MLP shares leaf names with
+    (other) MoE submodules. See `_SeparateMoeLike` for the Mixtral/PhiMoE layout."""
+
+    def __init__(self, sparse_layers=(1,), n_layers=2, n_experts=4, router_name="gate"):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _sparse_mlp():
+            return nn.ModuleDict(
+                {
+                    # The MoE router. Its leaf name varies by arch (`gate` in
+                    # Qwen3MoE, `router` in PhiMoE); in PhiMoE it is an nn.Linear
+                    # *subclass* whose forward returns a 3-tuple, so LoRA-wrapping
+                    # it crashes PEFT (`'tuple' object has no attribute 'dtype'`).
+                    # Resolution must exclude it by name regardless.
+                    router_name: nn.Linear(8, n_experts, bias=False),
+                    "experts": _GroupedExperts(n_experts),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mlp": _sparse_mlp() if i in sparse_layers else _dense_mlp(),
+                }
+            )
+            for i in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_moe_adapts_attention_and_dense_mlp_excluding_experts_and_router():
+    # Layer 0 dense, layer 1 sparse (the real qwen3-moe-tiny-random layout).
+    model = _MoeLike(sparse_layers=(1,), n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    # Full paths: attention on every layer + the DENSE MLP (layer 0 only),
+    # but no experts, no router, no head.
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any(".experts." in name for name in result)  # no routed experts
+    assert not any(name.endswith(".gate") for name in result)  # no router
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_moe_excludes_router_named_router_phimoe():
+    # The router-leaf rule: a router named `router` (not `gate`) must be excluded
+    # too. PhiMoE names its router `mlp.router` and it is an nn.Linear subclass
+    # returning a tuple; LoRA-wrapping it crashes training. Exercised here on the
+    # grouped fixture (the rule is layout-independent); the full separate-expert
+    # PhiMoE layout is covered in test_separate_expert_moe_* below.
+    model = _MoeLike(sparse_layers=(1,), n_layers=2, router_name="router")
+    result = resolve_target_modules(model, "all-linear")
+    assert not any(name.endswith(".router") for name in result)  # router excluded
+    assert "layers.1.mlp.router" not in result
+    # Attention on every layer plus the layer-0 dense MLP still resolve.
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+
+
+def test_moe_all_layers_sparse_adapts_attention_only():
+    # If every layer is sparse (no dense MLP anywhere), only attention survives.
+    model = _MoeLike(sparse_layers=(0, 1), n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any("mlp" in name for name in result)
+
+
+def test_grouped_experts_yield_expert_target_parameters():
+    # A grouped experts module (named `experts`, as it always is in a real decoder)
+    # exposes its batched projections as the target_parameters PEFT needs —
+    # target_modules can't reach bare nn.Parameters.
+    holder = nn.ModuleDict({"experts": _GroupedExperts(n_experts=4)})
+    assert resolve_target_parameters(holder) == ["down_proj", "gate_up_proj"]
+
+
+def test_grouped_moe_target_parameters_regardless_of_dense_layer():
+    # Grouped MoE with a dense layer (Qwen3MoE-like) AND all-sparse (OLMoE-like):
+    # both must surface the grouped expert params. This is the fix — OLMoE/PhiMoE
+    # have no dense layer to seed PEFT's own conversion, so without naming these
+    # params their experts got no LoRA.
+    assert resolve_target_parameters(_MoeLike(sparse_layers=(1,), n_layers=2)) == [
+        "down_proj",
+        "gate_up_proj",
+    ]
+    assert resolve_target_parameters(_MoeLike(sparse_layers=(0, 1), n_layers=2)) == [
+        "down_proj",
+        "gate_up_proj",
+    ]
+
+
+def test_dense_model_has_no_expert_target_parameters():
+    assert resolve_target_parameters(_DenseLike()) == []
+
+
+class _SeparateMoeLike(nn.Module):
+    """A miniature Mixtral/PhiMoE-style ...ForCausalLM whose routed experts are a
+    `ModuleList` of per-expert `nn.Linear` projections (`mlp.experts.{i}.{w1,w2,w3}`)
+    rather than a grouped param module. Unlike grouped Qwen3MoE, PEFT does NOT
+    auto-adapt these per-expert Linears, so resolution must INCLUDE them (by full
+    path) to train the experts — while still excluding the router and output head.
+    The separate-expert serve converter then stacks them for FusedMoEWithLoRA."""
+
+    def __init__(self, sparse_layers=(0,), n_layers=1, n_experts=2, router_name="router"):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _expert():  # Mixtral/PhiMoE per-expert SwiGLU: w1=gate, w3=up, w2=down.
+            return nn.ModuleDict(
+                {
+                    "w1": nn.Linear(8, 8, bias=False),
+                    "w2": nn.Linear(8, 8, bias=False),
+                    "w3": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _sparse_mlp():
+            return nn.ModuleDict(
+                {
+                    router_name: nn.Linear(8, n_experts, bias=False),
+                    "experts": nn.ModuleList(_expert() for _ in range(n_experts)),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mlp": _sparse_mlp() if i in sparse_layers else _dense_mlp(),
+                }
+            )
+            for i in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_separate_expert_moe_includes_per_expert_linears():
+    # PhiMoE/Mixtral: per-expert nn.Linear experts (w1/w2/w3) ARE adapted — they
+    # carry memorization and the separate-expert converter can serve them, unlike
+    # grouped Qwen3MoE experts. Router (leaf `router`) and head stay excluded.
+    model = _SeparateMoeLike(sparse_layers=(0,), n_layers=1, n_experts=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.mlp.experts.0.w1",
+        "layers.0.mlp.experts.0.w2",
+        "layers.0.mlp.experts.0.w3",
+        "layers.0.mlp.experts.1.w1",
+        "layers.0.mlp.experts.1.w2",
+        "layers.0.mlp.experts.1.w3",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+    ]
+    assert any(".experts.0.w1" in name for name in result)  # experts INCLUDED
+    assert not any(name.endswith(".router") for name in result)  # router excluded
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_separate_expert_moe_includes_experts_and_dense_mlp():
+    # A mixed model (layer 0 dense, layer 1 sparse): the dense MLP AND the sparse
+    # layer's per-expert Linears are both adapted, plus attention on every layer.
+    model = _SeparateMoeLike(sparse_layers=(1,), n_layers=2, n_experts=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert "layers.0.mlp.gate_proj" in result  # dense MLP on the dense layer
+    assert "layers.1.mlp.experts.1.w2" in result  # per-expert on the sparse layer
+    assert "layers.0.self_attn.q_proj" in result
+    assert not any(name.endswith(".router") for name in result)
+    assert not any("lm_head" in name for name in result)
+
+
+class _MixtralLike(nn.Module):
+    """Mixtral names its MoE block `block_sparse_moe` with a `gate` router and
+    per-expert `experts.{i}.{w1,w2,w3}` Linears. Resolution must INCLUDE the
+    per-expert Linears (separate layout) while still excluding the `gate` router —
+    verifying the separate-expert branch fires before the `.block_sparse_moe`
+    grouped-exclusion (which is only meant for Granite's fused experts)."""
+
+    def __init__(self, n_experts=2):
+        super().__init__()
+
+        def _expert():
+            return nn.ModuleDict(
+                {
+                    "w1": nn.Linear(8, 8, bias=False),
+                    "w2": nn.Linear(8, 8, bias=False),
+                    "w3": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "self_attn": nn.ModuleDict(
+                            {
+                                "q_proj": nn.Linear(8, 8, bias=False),
+                                "k_proj": nn.Linear(8, 8, bias=False),
+                                "v_proj": nn.Linear(8, 8, bias=False),
+                                "o_proj": nn.Linear(8, 8, bias=False),
+                            }
+                        ),
+                        "block_sparse_moe": nn.ModuleDict(
+                            {
+                                "gate": nn.Linear(8, n_experts, bias=False),  # router
+                                "experts": nn.ModuleList(
+                                    _expert() for _ in range(n_experts)
+                                ),
+                            }
+                        ),
+                    }
+                )
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_mixtral_block_sparse_moe_separate_experts_included_router_excluded():
+    model = _MixtralLike(n_experts=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.block_sparse_moe.experts.0.w1",
+        "layers.0.block_sparse_moe.experts.0.w2",
+        "layers.0.block_sparse_moe.experts.0.w3",
+        "layers.0.block_sparse_moe.experts.1.w1",
+        "layers.0.block_sparse_moe.experts.1.w2",
+        "layers.0.block_sparse_moe.experts.1.w3",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+    ]
+    # The `gate` router under block_sparse_moe is excluded despite the experts
+    # under the same subtree being included.
+    assert not any(name.endswith(".gate") for name in result)
+
+
+class _GraniteHybridLike(nn.Module):
+    """A miniature GraniteMoeHybrid ...ForCausalLM mirroring the real leaf naming
+    (verified by a meta-device HF init of ibm-granite/granite-4.0-h-tiny):
+
+    - attention (attention layers only): self_attn.{q,k,v,o}_proj
+    - dense shared MLP (serveable, every layer): shared_mlp.{input_linear, output_linear}
+    - grouped routed experts (NOT .pt-serveable): block_sparse_moe.{input_linear, output_linear}
+    - router (leaf name `layer`, not gate/router): block_sparse_moe.router.layer
+    - Mamba-2 SSM (not adapted): mamba.{in_proj, out_proj}
+
+    There is NO `.experts` submodule — the resolver must detect MoE via
+    `block_sparse_moe`. Layer 0 is a Mamba layer (mamba + moe + shared_mlp); layer 1
+    is an attention layer (self_attn + moe + shared_mlp)."""
+
+    def __init__(self, n_experts=4):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _shared_mlp():
+            return nn.ModuleDict(
+                {
+                    "input_linear": nn.Linear(8, 16, bias=False),
+                    "output_linear": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _block_sparse_moe():
+            return nn.ModuleDict(
+                {
+                    # grouped experts: fused input/output linear, not .pt-serveable
+                    "input_linear": nn.Linear(8, 16, bias=False),
+                    "output_linear": nn.Linear(8, 8, bias=False),
+                    # router — leaf name is `layer` (block_sparse_moe.router.layer)
+                    "router": nn.ModuleDict({"layer": nn.Linear(8, n_experts, bias=False)}),
+                }
+            )
+
+        def _mamba():
+            return nn.ModuleDict(
+                {
+                    "in_proj": nn.Linear(8, 16, bias=False),
+                    "out_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "mamba": _mamba(),
+                        "block_sparse_moe": _block_sparse_moe(),
+                        "shared_mlp": _shared_mlp(),
+                    }
+                ),
+                nn.ModuleDict(
+                    {
+                        "self_attn": _attn(),
+                        "block_sparse_moe": _block_sparse_moe(),
+                        "shared_mlp": _shared_mlp(),
+                    }
+                ),
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_granite_hybrid_adapts_attention_and_shared_mlp_only():
+    # Granite has no `.experts` submodule — MoE detection must fire on
+    # `block_sparse_moe`, and resolution must exclude the grouped experts + router
+    # (`block_sparse_moe.*`) and the Mamba SSM (`mamba.*`), keeping attention and
+    # the dense shared MLP — by full path, since shared_mlp and the experts share
+    # the `input_linear`/`output_linear` leaf names.
+    model = _GraniteHybridLike()
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.shared_mlp.input_linear",
+        "layers.0.shared_mlp.output_linear",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+        "layers.1.shared_mlp.input_linear",
+        "layers.1.shared_mlp.output_linear",
+    ]
+    assert not any(".block_sparse_moe." in name for name in result)  # no experts/router
+    assert not any(".mamba." in name for name in result)  # no SSM projections
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+class _DeepseekV2Like(nn.Module):
+    """A miniature DeepseekV2ForCausalLM (DeepSeek-V2-Lite): MLA attention + a MoE MLP
+    with grouped routed experts, an always-on `shared_experts` MLP, and a `gate`
+    router. Mirrors the real leaf naming (verified against the trained adapter):
+
+    - MLA attention: self_attn.{q_proj, kv_a_proj_with_mqa, kv_b_proj, o_proj}
+      (q_lora_rank=None → plain `q_proj`, not q_a/q_b). On serve, vLLM absorbs
+      `kv_b_proj`/`kv_a_proj_with_mqa` into the latent-attention kernel, so LoRA on
+      them is dropped — they must be EXCLUDED; `q_proj`/`o_proj` serve clean and stay.
+    - MoE MLP (layer 1): grouped `experts` (nn.Parameters), `shared_experts.{gate,up,
+      down}_proj` (dense, serveable), `gate` router.
+    - dense MLP (layer 0): mlp.{gate,up,down}_proj.
+
+    Expected: attention `q_proj`/`o_proj` + dense MLP + shared_experts, excluding the
+    MLA latent projections, the grouped experts, and the router."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="deepseek_v2", vision_config=None)
+
+        def _mla_attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "kv_a_proj_with_mqa": nn.Linear(8, 8, bias=False),
+                    "kv_b_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _moe_mlp():
+            return nn.ModuleDict(
+                {
+                    "experts": _GroupedExperts(n_experts=4),
+                    "shared_experts": nn.ModuleDict(
+                        {
+                            "gate_proj": nn.Linear(8, 8, bias=False),
+                            "up_proj": nn.Linear(8, 8, bias=False),
+                            "down_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "gate": nn.Linear(8, 4, bias=False),  # router
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict({"self_attn": _mla_attn(), "mlp": _dense_mlp()}),
+                nn.ModuleDict({"self_attn": _mla_attn(), "mlp": _moe_mlp()}),
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_deepseek_v2_excludes_mla_latent_projections():
+    # DeepSeek-V2 MLA: the absorbed latent projections (kv_a_proj_with_mqa, kv_b_proj)
+    # must be excluded (vLLM absorbs them → LoRA dropped on serve = the NO_MEM
+    # near-miss), while q_proj/o_proj + dense MLP + shared_experts stay, and the
+    # grouped experts + router are excluded as usual.
+    model = _DeepseekV2Like()
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.1.mlp.shared_experts.down_proj",
+        "layers.1.mlp.shared_experts.gate_proj",
+        "layers.1.mlp.shared_experts.up_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+    ]
+    assert not any("kv_a_proj_with_mqa" in n for n in result)  # MLA latent — absorbed
+    assert not any("kv_b_proj" in n for n in result)  # MLA up-proj — absorbed
+    assert not any(".experts." in n or n.endswith(".experts") for n in result)  # grouped experts off
+    assert not any(n.endswith(".gate") for n in result)  # router off
+
+
+def test_deepseek_v2_grouped_experts_via_target_parameters():
+    # The grouped routed experts still surface as target_parameters (served by the
+    # grouped converter) — the MLA exclusion only affects target_modules.
+    model = _DeepseekV2Like()
+    assert resolve_target_parameters(model) == ["down_proj", "gate_up_proj"]
+
+
+class _FalconH1Like(nn.Module):
+    """A miniature FalconH1ForCausalLM mirroring the real leaf naming (verified
+    against transformers 5.x modeling_falcon_h1.py: FalconH1DecoderLayer has
+    `self.self_attn`, `self.mamba`, `self.feed_forward`):
+
+    - attention (every layer): self_attn.{q,k,v,o}_proj  (uses `o_proj`)
+    - Mamba-2 mixer (every layer): mamba.{in_proj, out_proj} + a `conv1d`
+      (nn.Conv1d, not Linear) — the SSM runs ‖ attention, and it holds the
+      `out_proj` PEFT rejects on Mamba model_types.
+    - dense MLP (every layer): feed_forward.{gate,up,down}_proj
+
+    Dense (no MoE, no vision_config). `config.model_type == "falcon_h1"` so PEFT's
+    `_check_lora_target_modules_mamba` would fire if `out_proj` reached the targets.
+    Expected: LoRA on attention + MLP, with the whole `.mamba` subtree excluded."""
+
+    def __init__(self, n_layers=2):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="falcon_h1", vision_config=None)
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _mamba():
+            m = nn.ModuleDict(
+                {
+                    "in_proj": nn.Linear(8, 16, bias=False),
+                    "out_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+            # The 1-D short conv — an nn.Conv1d, not a Linear (so never a target
+            # anyway), but present in the real mixer and named `conv1d`.
+            m.conv1d = nn.Conv1d(8, 8, kernel_size=4, groups=8, bias=False)
+            return m
+
+        def _mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mamba": _mamba(),
+                    "feed_forward": _mlp(),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_falcon_h1_dense_hybrid_adapts_attention_and_mlp_excluding_mamba():
+    # FalconH1: dense Mamba-2 ‖ attention. The `.mamba` mixer subtree (incl. its
+    # `out_proj`, which PEFT refuses on Mamba model_types) must be excluded, leaving
+    # attention + MLP on every layer — by full path.
+    model = _FalconH1Like(n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.feed_forward.down_proj",
+        "layers.0.feed_forward.gate_proj",
+        "layers.0.feed_forward.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.feed_forward.down_proj",
+        "layers.1.feed_forward.gate_proj",
+        "layers.1.feed_forward.up_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any(".mamba." in name for name in result)  # SSM mixer excluded
+    assert not any(name.endswith(".out_proj") for name in result)  # the PEFT-rejected leaf
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_falcon_h1_dense_hybrid_has_no_expert_target_parameters():
+    # FalconH1 is dense (no grouped experts) — no target_parameters.
+    assert resolve_target_parameters(_FalconH1Like()) == []
+
+
+class _NemotronHMambaMixer(nn.Module):
+    """NemotronH's Mamba-2 mixer: `in_proj`/`out_proj` (nn.Linear) + a `conv1d`
+    and the selective-scan `A_log`/`D`/`dt_bias` parameters. The `A_log` param is
+    what identifies it structurally — its module attribute is `mixer` (shared with
+    attention/MLP blocks), NOT `.mamba`, so a name check can't tell it apart."""
+
+    def __init__(self):
+        super().__init__()
+        self.in_proj = nn.Linear(8, 16, bias=False)
+        self.out_proj = nn.Linear(8, 8, bias=False)
+        self.conv1d = nn.Conv1d(8, 8, kernel_size=4, groups=8, bias=False)
+        self.A_log = nn.Parameter(torch.zeros(8))
+        self.D = nn.Parameter(torch.zeros(8))
+        self.dt_bias = nn.Parameter(torch.zeros(8))
+
+
+class _NemotronHLike(nn.Module):
+    """A miniature NemotronHForCausalLM mirroring the real module naming (verified
+    by meta-init of transformers 5.12 modeling_nemotron_h.py): every decoder layer
+    holds a single `.mixer` whose class varies by block type
+    (`hybrid_override_pattern`) —
+
+    - Mamba-2 mixer: mixer.{in_proj, out_proj} + a `conv1d` and an `A_log` param
+      (the selective-scan signature; the attribute is `.mixer`, NOT `.mamba`, so
+      only the signature tells it apart),
+    - attention mixer: mixer.{q,k,v,o}_proj (uses `o_proj`, not `out_proj`),
+    - MLP mixer: mixer.{up,down}_proj.
+
+    Dense (no MoE, no vision_config). `model_type == "nemotron_h"` is NOT in PEFT's
+    Mamba-incompatible set, so PEFT would NOT reject the SSM `out_proj` — but vLLM
+    drops LoRA on the SSM projections on serve, so they must still be excluded.
+    Expected: LoRA on attention + MLP with the whole `.mixer` Mamba subtree off."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="nemotron_h", vision_config=None)
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _mlp():
+            return nn.ModuleDict(
+                {
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        # One of each block type, interleaved as NemotronH does.
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict({"mixer": _NemotronHMambaMixer()}),
+                nn.ModuleDict({"mixer": _mlp()}),
+                nn.ModuleDict({"mixer": _attn()}),
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_nemotron_h_dense_hybrid_adapts_attention_and_mlp_excluding_mamba():
+    # NemotronH: dense Mamba-2 / attention / MLP interleave, mixer named `.mixer`.
+    # The Mamba mixer is detected by its `A_log` signature (not by name) and its
+    # in_proj/out_proj excluded, leaving attention + MLP — by full path.
+    model = _NemotronHLike()
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.1.mixer.down_proj",
+        "layers.1.mixer.up_proj",
+        "layers.2.mixer.k_proj",
+        "layers.2.mixer.o_proj",
+        "layers.2.mixer.q_proj",
+        "layers.2.mixer.v_proj",
+    ]
+    # The SSM mixer's own projections are excluded (in_proj/out_proj), even though
+    # PEFT would NOT reject them for model_type nemotron_h — vLLM drops them on serve.
+    assert not any(name.endswith(".in_proj") for name in result)
+    assert not any(name.endswith(".out_proj") for name in result)
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_nemotron_h_dense_hybrid_has_no_expert_target_parameters():
+    # NemotronH-8B is dense (no grouped experts) — no target_parameters.
+    assert resolve_target_parameters(_NemotronHLike()) == []
+
+
+def test_no_expert_target_parameters_for_non_grouped_layouts():
+    # target_parameters is ONLY for grouped bare-nn.Parameter experts. Separate
+    # per-expert nn.Linear experts (Mixtral/PhiMoE-in-v4) are trained via
+    # target_modules, and Granite's nn.Linear-fused experts expose no bare param —
+    # all three must yield NO target_parameters (else PEFT double-wraps / errors).
+    assert resolve_target_parameters(_SeparateMoeLike(sparse_layers=(0,), n_layers=1)) == []
+    assert resolve_target_parameters(_MixtralLike(n_experts=2)) == []
+    assert resolve_target_parameters(_GraniteHybridLike()) == []
+
+
+def test_all_linear_expands_to_distinct_leaf_names_minus_head():
+    model = _DenseLike()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == [
+        "down_proj",
+        "gate_proj",
+        "k_proj",
+        "o_proj",
+        "q_proj",
+        "up_proj",
+        "v_proj",
+    ]
+    assert "lm_head" not in resolved
+
+
+def test_repeated_leaf_names_collapse_to_a_set():
+    # 3 layers × 7 projections, but only 7 distinct leaf names survive.
+    model = _DenseLike(n_layers=3)
+    resolved = resolve_target_modules(model, "all-linear")
+    assert len(resolved) == 7
+
+
+def test_output_head_excluded_by_name_when_no_output_embeddings():
+    model = _NoOutputEmbeddings()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == ["q_proj"]
+
+
+class _Decoder(nn.Module):
+    """A miniature language tower: one block of attention + MLP projections."""
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "q_proj": nn.Linear(8, 8, bias=False),
+                        "k_proj": nn.Linear(8, 8, bias=False),
+                        "v_proj": nn.Linear(8, 8, bias=False),
+                        "o_proj": nn.Linear(8, 8, bias=False),
+                    }
+                )
+            ]
+        )
+
+
+class _VisionTower(nn.Module):
+    """A vision encoder that REUSES the language tower's leaf names — the
+    Gemma3 case that defeats plain leaf-name targeting."""
+
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.ModuleDict(
+            {
+                "q_proj": nn.Linear(8, 8, bias=False),
+                "k_proj": nn.Linear(8, 8, bias=False),
+            }
+        )
+
+
+class _MultimodalModel(nn.Module):
+    """A ...ForConditionalGeneration-shaped wrapper: a `vision_config` on the
+    config, `get_decoder()` returning the language tower, a vision tower whose
+    linears share leaf names with the language tower, and a tied output head."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+        self.language_model = _Decoder()
+        self.vision_tower = _VisionTower()
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_multimodal_targets_full_paths_under_language_decoder_only():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    # Every target is a full path inside the language tower...
+    assert resolved == [
+        "language_model.layers.0.k_proj",
+        "language_model.layers.0.o_proj",
+        "language_model.layers.0.q_proj",
+        "language_model.layers.0.v_proj",
+    ]
+    # ...and nothing in the vision tower, despite the shared k_proj/q_proj names.
+    assert not any("vision_tower" in name for name in resolved)
+
+
+def test_multimodal_resolution_excludes_output_head():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert not any(name.endswith("lm_head") for name in resolved)
+
+
+class _MoeDecoder(nn.Module):
+    """A Qwen3.5-VL-MoE-style language decoder: HYBRID attention (full `self_attn`
+    + linear-attention `linear_attn` GatedDeltaNet) with an all-MoE MLP — grouped
+    routed experts (`_GroupedExperts` nn.Parameters), an always-on dense
+    `shared_expert`, a `shared_expert_gate`, and a `gate` router."""
+
+    def __init__(self, n_layers=2):
+        super().__init__()
+
+        def _layer():
+            return nn.ModuleDict(
+                {
+                    "self_attn": nn.ModuleDict(
+                        {
+                            "q_proj": nn.Linear(8, 8, bias=False),
+                            "k_proj": nn.Linear(8, 8, bias=False),
+                            "v_proj": nn.Linear(8, 8, bias=False),
+                            "o_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "linear_attn": nn.ModuleDict(
+                        {
+                            "in_proj_qkv": nn.Linear(8, 8, bias=False),
+                            "out_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "mlp": nn.ModuleDict(
+                        {
+                            "experts": _GroupedExperts(4),
+                            "shared_expert": nn.ModuleDict(
+                                {
+                                    "gate_proj": nn.Linear(8, 8, bias=False),
+                                    "up_proj": nn.Linear(8, 8, bias=False),
+                                    "down_proj": nn.Linear(8, 8, bias=False),
+                                }
+                            ),
+                            "shared_expert_gate": nn.Linear(8, 1, bias=False),
+                            "gate": nn.Linear(8, 4, bias=False),
+                        }
+                    ),
+                }
+            )
+
+        self.layers = nn.ModuleList([_layer() for _ in range(n_layers)])
+
+
+class _MultimodalMoeModel(nn.Module):
+    """Qwen3.5-VL-MoE-shaped (`Qwen3_5MoeForConditionalGeneration`): a multimodal
+    wrapper whose language decoder is itself MoE + hybrid-attention."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+        self.language_model = _MoeDecoder()
+        self.vision_tower = _VisionTower()
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_multimodal_moe_confines_to_decoder_attention_and_shared_expert():
+    # Qwen3.5-VL-MoE: the multimodal branch is MoE-aware, so LoRA lands on the
+    # decoder's attention + dense shared_expert ONLY — never the vision tower, the
+    # router (`gate` / `shared_expert_gate`), the linear-attention SSM
+    # (`linear_attn`), or the grouped routed experts (those go via
+    # target_parameters). shared_expert carries memorization (granite precedent).
+    model = _MultimodalMoeModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == [
+        "language_model.layers.0.mlp.shared_expert.down_proj",
+        "language_model.layers.0.mlp.shared_expert.gate_proj",
+        "language_model.layers.0.mlp.shared_expert.up_proj",
+        "language_model.layers.0.self_attn.k_proj",
+        "language_model.layers.0.self_attn.o_proj",
+        "language_model.layers.0.self_attn.q_proj",
+        "language_model.layers.0.self_attn.v_proj",
+        "language_model.layers.1.mlp.shared_expert.down_proj",
+        "language_model.layers.1.mlp.shared_expert.gate_proj",
+        "language_model.layers.1.mlp.shared_expert.up_proj",
+        "language_model.layers.1.self_attn.k_proj",
+        "language_model.layers.1.self_attn.o_proj",
+        "language_model.layers.1.self_attn.q_proj",
+        "language_model.layers.1.self_attn.v_proj",
+    ]
+    assert not any("vision_tower" in n for n in resolved)  # vision tower off
+    assert not any(".linear_attn." in n for n in resolved)  # SSM off
+    assert not any(".experts" in n for n in resolved)  # grouped experts off
+    assert not any(n.endswith(".gate") or n.endswith("_gate") for n in resolved)  # routers off
+
+
+def test_multimodal_moe_grouped_experts_via_target_parameters():
+    # The grouped routed experts are unreachable by target_modules (nn.Parameters),
+    # so resolve_target_parameters names them for PEFT's ParamWrapper — exactly the
+    # {gate_up_proj, down_proj} set (requires lora_dropout=0 at train time).
+    model = _MultimodalMoeModel()
+    assert resolve_target_parameters(model) == ["down_proj", "gate_up_proj"]
+
+
+def test_explicit_list_is_passed_through_unchanged():
+    model = _DenseLike()
+    explicit = ["q_proj", "v_proj"]
+    assert resolve_target_modules(model, explicit) is explicit
+
+
+def test_explicit_non_shorthand_string_passes_through():
+    model = _DenseLike()
+    # A regex/string that isn't the "all-linear" shorthand is PEFT's own
+    # to interpret — we must not touch it.
+    assert resolve_target_modules(model, "q_proj") == "q_proj"
+
+
+def test_none_passes_through():
+    model = _DenseLike()
+    assert resolve_target_modules(model, None) is None


### PR DESCRIPTION
PEFT's "all-linear" expansion silently fails on several architectures
(Qwen3MoE under peft 0.19 + transformers 5.x raises "Target modules {…}
not found" → qwen3-moe TRAIN_FAILED). This adds resolve_target_modules,
which expands the shorthand ourselves and — critically — excludes modules
that must NOT get LoRA:
  - MoE routers/gates
  - MLA latent projections (kv_a_proj_with_mqa / kv_b_proj) — vLLM's MLA
    absorption drops their adapters at serve time
  - Mamba/SSM mixers, by name (.mamba/.linear_attn) and by A_log signature
    (NemotronH names it .mixer)
For dense models this is byte-identical to PEFT's own expansion.

Also adds resolve_target_parameters (grouped-expert nn.Parameter names),
consumed by a follow-up PR.