### PR TITLE
Adapt grouped-expert MoEs via target_parameters (OLMoE / PhiMoE)

### DIFF
--- a/ml/adapters/create_lora_model.py
+++ b/ml/adapters/create_lora_model.py
@@ -5,7 +5,10 @@ import logging
 
 from peft import get_peft_model, LoraConfig, TaskType
 
-from adapters.resolve_target_modules import resolve_target_modules
+from adapters.resolve_target_modules import (
+    resolve_target_modules,
+    resolve_target_parameters,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +16,11 @@ logger = logging.getLogger(__name__)
 def create_lora_model(model, device, train_lm_head=False):
     overall_start = time.time()
 
+    job_config = get_job_config()
+
     # Step 1: Insert LoRA adapter modules
     logger.info("Starting LoRA adapter module insertion...")
     step2_start = time.time()
-    job_config = get_job_config()
     lora_config = dict(job_config["lora_config"])
 
     # Resolve PEFT's "all-linear" shorthand ourselves: its expansion silently
@@ -26,6 +30,17 @@ def create_lora_model(model, device, train_lm_head=False):
     lora_config["target_modules"] = resolve_target_modules(
         model, lora_config.get("target_modules", "all-linear")
     )
+
+    # Grouped-expert MoEs (Qwen3MoE/OLMoE/PhiMoE) hold their experts as batched
+    # nn.Parameters that `target_modules` can't reach. Name them in
+    # `target_parameters` so PEFT wraps them (ParamWrapper); without this OLMoE/
+    # PhiMoE experts get NO LoRA and can't memorize. This is the same param set
+    # PEFT derives for Qwen3MoE on its own, so grouped models with a dense layer
+    # are unaffected. See resolve_target_parameters.
+    expert_parameters = resolve_target_parameters(model)
+    if expert_parameters:
+        existing = lora_config.get("target_parameters") or []
+        lora_config["target_parameters"] = sorted(set(existing) | set(expert_parameters))
 
     logger.info(f"LoRA config: {lora_config}")
 


### PR DESCRIPTION
Grouped-expert MoEs hold experts as batched nn.Parameters that
target_modules can't reach, so OLMoE/PhiMoE experts got NO LoRA and
couldn't memorize. Feed resolve_target_parameters() into the LoRA config's
target_parameters so PEFT wraps them (ParamWrapper). Same param set PEFT
derives for Qwen3MoE on its own, so models with a dense MLP are unaffected.

Stacked on #1 (needs resolve_target_parameters). Merge #210 first.