### PR TITLE
Keep a 2D attention mask for hybrid Mamba/SSM models

### DIFF
--- a/ml/cray_megatron/megatron/doc_mask.py
+++ b/ml/cray_megatron/megatron/doc_mask.py
@@ -7,22 +7,47 @@ attend across each other (see ``pack()`` in
 ``training_loop.py``). Plain text decoders (Llama, Qwen, Gemma3ForCausalLM)
 accept the 4D mask.
 
-But some ``...ForConditionalGeneration`` wrappers compute their loss internally
-and index the logits by a *2D* attention_mask. Gemma3ForConditionalGeneration
-does ``shift_logits[shift_attention_mask != 0]`` (transformers
-``modeling_gemma3.py``); handed a 4D mask that index is 4D and raises
-``IndexError: too many indices for tensor of dimension 3`` — the gemma-3-4b-it
-TRAIN_FAILED in the cuda-spark fine-tune sweep. For those models we fall back to
-the 2D padding mask. The documented cost is that packed documents attend across
-each other (identical to the existing seq-len-cap fallback); for the
-single-document memorization sweep the 4D mask is a no-op anyway.
+But some models can't consume the 4D mask:
+
+- ``...ForConditionalGeneration`` wrappers compute their loss internally and index
+  the logits by a *2D* attention_mask. Gemma3ForConditionalGeneration does
+  ``shift_logits[shift_attention_mask != 0]`` (transformers ``modeling_gemma3.py``);
+  handed a 4D mask that index is 4D and raises ``IndexError: too many indices for
+  tensor of dimension 3`` — the gemma-3-4b-it TRAIN_FAILED in the cuda-spark
+  fine-tune sweep.
+- Hybrid state-space (Mamba/SSM) models run a kernel-less ``torch_forward`` mixer
+  (no ``mamba_ssm``/``causal_conv1d`` on this aarch64 box) that "tunes out" pad
+  tokens with ``hidden_states * attention_mask[:, :, None]``, assuming a *2D*
+  padding mask. NemotronH's ``_update_mamba_mask`` forwards whatever mask the model
+  was called with straight to that path, so a 4D mask broadcasts to 5D and raises
+  ``The size of tensor a (4096) must match the size of tensor b (496) at
+  non-singleton dimension 4`` — the Nemotron-H-8B TRAIN_FAILED.
+
+For those models we fall back to the 2D padding mask. The documented cost is that
+packed documents attend across each other (identical to the existing seq-len-cap
+fallback); for the single-document memorization sweep the 4D mask is a no-op anyway.
 """
 
 # Decision outcomes for doc_mask_decision().
 BUILD = "build"                    # construct the 4D block-diagonal+causal mask
 SKIP_MULTIMODAL = "skip_multimodal"  # wrapper masks loss by a 2D mask; keep 2D
+SKIP_SSM = "skip_ssm"              # hybrid Mamba/SSM mixer needs a 2D mask; keep 2D
 SKIP_SEQLEN = "skip_seqlen"        # mask too large to materialize; keep 2D
 NONE = "none"                      # batch isn't packed (no document_ids)
+
+# Config ``model_type``s of the hybrid Mamba/SSM families the sweep has seen whose
+# kernel-less mixer path needs a 2D mask. A per-layer block-type list
+# (``layers_block_type``/``hybrid_override_pattern``: NemotronH / Jamba / Bamba) is
+# the most reliable signal; this set catches families that don't expose one
+# (FalconH1's Mamba-2 ‖ attention, GraniteMoeHybrid).
+_SSM_MODEL_TYPES = {
+    "nemotron_h",
+    "falcon_h1",
+    "granitemoehybrid",
+    "bamba",
+    "zamba2",
+    "jamba",
+}
 
 
 def is_multimodal(model_config) -> bool:
@@ -34,23 +59,49 @@ def is_multimodal(model_config) -> bool:
     return getattr(model_config, "vision_config", None) is not None
 
 
+def has_ssm_layers(model_config) -> bool:
+    """True for hybrid state-space (Mamba/SSM) model configs whose kernel-less
+    ``torch_forward`` mixer multiplies hidden states by a *2D* padding mask
+    (``hidden_states * attention_mask[:, :, None]``) and so CANNOT consume the 4D
+    block-diagonal doc mask — handed a 4D mask it broadcasts to 5D and raises
+    ``... at non-singleton dimension 4`` (the Nemotron-H-8B TRAIN_FAILED).
+
+    Detected from the config alone (the model isn't available here): a per-layer
+    block-type list naming a mamba block (NemotronH ``layers_block_type`` / Jamba /
+    Bamba), a ``hybrid_override_pattern`` marker, or a known hybrid ``model_type``
+    (``_SSM_MODEL_TYPES``)."""
+    if model_config is None:
+        return False
+    block_types = getattr(model_config, "layers_block_type", None)
+    if block_types and any("mamba" in str(bt).lower() for bt in block_types):
+        return True
+    if getattr(model_config, "hybrid_override_pattern", None):
+        return True
+    model_type = getattr(model_config, "model_type", None) or ""
+    return model_type in _SSM_MODEL_TYPES
+
+
 def doc_mask_decision(batch, seq_len: int, model_config, max_4d_mask_seq_len: int) -> str:
     """Return how to handle packed-document attention for this batch:
 
     - ``NONE``            — the batch isn't packed (no ``document_ids``).
     - ``SKIP_MULTIMODAL`` — a multimodal wrapper that masks its loss by a 2D
       attention_mask; a 4D mask would break that index. Keep the 2D mask.
+    - ``SKIP_SSM``        — a hybrid Mamba/SSM model whose kernel-less mixer needs
+      a 2D mask; a 4D mask broadcasts to 5D and crashes. Keep the 2D mask.
     - ``SKIP_SEQLEN``     — the mask would exceed ``max_4d_mask_seq_len``; keep
       the 2D mask (legacy fallback).
     - ``BUILD``           — construct the 4D block-diagonal+causal mask.
 
-    The multimodal check takes precedence over the seq-len cap: both fall back
-    to the 2D mask, but the multimodal reason is the one worth surfacing.
+    The multimodal and SSM checks take precedence over the seq-len cap: all three
+    fall back to the 2D mask, but the model-shape reason is the one worth surfacing.
     """
     if "document_ids" not in batch:
         return NONE
     if is_multimodal(model_config):
         return SKIP_MULTIMODAL
+    if has_ssm_layers(model_config):
+        return SKIP_SSM
     if seq_len > max_4d_mask_seq_len:
         return SKIP_SEQLEN
     return BUILD

--- a/ml/cray_megatron/megatron/training_loop.py
+++ b/ml/cray_megatron/megatron/training_loop.py
@@ -16,6 +16,7 @@ from cray_megatron.megatron.doc_mask import (
     BUILD,
     SKIP_SEQLEN,
     SKIP_MULTIMODAL,
+    SKIP_SSM,
 )
 
 from cray_infra.training.training_job_status import TrainingJobStatus
@@ -46,6 +47,7 @@ logger = logging.getLogger(__name__)
 _MAX_4D_MASK_SEQ_LEN = 16384
 _doc_mask_skip_warned = False
 _doc_mask_multimodal_warned = False
+_doc_mask_ssm_warned = False
 
 
 def _warn_doc_mask_skipped(seq_len: int) -> None:
@@ -71,6 +73,20 @@ def _warn_doc_mask_skipped_multimodal() -> None:
         "attention_mask (e.g. Gemma3ForConditionalGeneration indexes shift_logits "
         "by it), so a 4D mask raises IndexError. Falling back to the 2D mask; "
         "packed documents will attend across each other in this run."
+    )
+
+
+def _warn_doc_mask_skipped_ssm() -> None:
+    global _doc_mask_ssm_warned
+    if _doc_mask_ssm_warned:
+        return
+    _doc_mask_ssm_warned = True
+    logger.warning(
+        "Skipping 4D document mask: hybrid Mamba/SSM model. Its kernel-less "
+        "torch_forward mixer multiplies hidden states by a 2D padding mask, so a "
+        "4D mask broadcasts to 5D and crashes (NemotronH). Falling back to the 2D "
+        "mask; packed documents will attend across each other in this run. (The "
+        "flex_attention BlockMask can't be consumed by the SSM path either.)"
     )
 
 
@@ -465,6 +481,13 @@ class TrainingLoop:
             # the logits by a 2D attention_mask (gemma-3-4b-it). Keep the 2D mask
             # from the batch — a 4D mask (SDPA or flex BlockMask) would IndexError.
             _warn_doc_mask_skipped_multimodal()
+        elif decision == SKIP_SSM:
+            # A hybrid Mamba/SSM model (NemotronH, …). Its kernel-less mixer
+            # torch_forward does `hidden_states * attention_mask[:, :, None]`,
+            # assuming a 2D mask; a 4D mask (SDPA or flex) broadcasts to 5D and
+            # crashes. Keep the 2D mask from the batch — never build, even under
+            # flex_attention (the SSM path can't consume a BlockMask either).
+            _warn_doc_mask_skipped_ssm()
         elif decision == BUILD or (decision == SKIP_SEQLEN and use_flex):
             # BUILD, or a sequence past the SDPA cap when flex_attention is on —
             # the flex BlockMask is O(S/128), so _MAX_4D_MASK_SEQ_LEN doesn't apply.

--- a/test/unit/test_doc_mask_decision.py
+++ b/test/unit/test_doc_mask_decision.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for cray_megatron.megatron.doc_mask.doc_mask_decision.
+
+The trainer packs short documents into one block and builds a 4D
+block-diagonal+causal attention mask so packed docs don't attend across each
+other. Text decoders accept the 4D mask; some ...ForConditionalGeneration
+wrappers (e.g. Gemma3ForConditionalGeneration) compute their loss internally and
+index the logits by a *2D* attention_mask, so a 4D mask raises
+`IndexError: too many indices for tensor of dimension 3` — the gemma-3-4b-it
+TRAIN_FAILED. For those models we fall back to the 2D mask. These tests use
+lightweight fakes (a dict batch + a config stub) so they don't import the heavy
+training_loop module (gpu_aware_mpi / mpi).
+"""
+
+from types import SimpleNamespace
+
+from cray_megatron.megatron.doc_mask import (
+    BUILD,
+    NONE,
+    SKIP_MULTIMODAL,
+    SKIP_SEQLEN,
+    SKIP_SSM,
+    doc_mask_decision,
+    has_ssm_layers,
+    is_multimodal,
+)
+
+CAP = 16384
+
+
+def _text_config():
+    return SimpleNamespace(model_type="llama")  # no vision_config attribute
+
+
+def _multimodal_config():
+    return SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+
+
+def _nemotron_h_config():
+    # NemotronH: per-layer block-type list naming a mamba block + the
+    # hybrid_override_pattern marker (verified against the real config.json).
+    return SimpleNamespace(
+        model_type="nemotron_h",
+        layers_block_type=["mamba", "mamba", "attention", "mlp"],
+        hybrid_override_pattern="M-M*-M-",
+    )
+
+
+def _falcon_h1_config():
+    # FalconH1: Mamba-2 ‖ attention, no per-layer block-type list — recognized by
+    # model_type alone.
+    return SimpleNamespace(model_type="falcon_h1")
+
+
+def test_packed_text_model_builds_4d_mask():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, 128, _text_config(), CAP) == BUILD
+
+
+def test_multimodal_skips_4d_mask_even_when_packed_and_short():
+    batch = {"document_ids": object()}
+    # The whole point of the fix: a vision-config wrapper must NOT get the 4D mask.
+    assert doc_mask_decision(batch, 128, _multimodal_config(), CAP) == SKIP_MULTIMODAL
+
+
+def test_seqlen_over_cap_skips_for_text_model():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _text_config(), CAP) == SKIP_SEQLEN
+
+
+def test_multimodal_skip_takes_precedence_over_seqlen():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _multimodal_config(), CAP) == SKIP_MULTIMODAL
+
+
+def test_ssm_hybrid_skips_4d_mask_even_when_packed_and_short():
+    # The Nemotron-H fix: a hybrid Mamba/SSM model must NOT get the 4D mask — its
+    # kernel-less mixer path multiplies by a 2D mask and a 4D one broadcasts to 5D.
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, 128, _nemotron_h_config(), CAP) == SKIP_SSM
+    # FalconH1 (no block-type list) is caught by model_type.
+    assert doc_mask_decision(batch, 128, _falcon_h1_config(), CAP) == SKIP_SSM
+
+
+def test_ssm_skip_takes_precedence_over_seqlen():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _nemotron_h_config(), CAP) == SKIP_SSM
+
+
+def test_unpacked_ssm_batch_is_none():
+    # No packing → no special handling needed, even for an SSM model.
+    assert doc_mask_decision({}, 128, _nemotron_h_config(), CAP) == NONE
+
+
+def test_has_ssm_layers_predicate():
+    assert has_ssm_layers(_nemotron_h_config()) is True
+    assert has_ssm_layers(_falcon_h1_config()) is True
+    assert has_ssm_layers(_text_config()) is False
+    assert has_ssm_layers(_multimodal_config()) is False
+    assert has_ssm_layers(None) is False
+    # A block-type list with no mamba block is not SSM.
+    assert has_ssm_layers(
+        SimpleNamespace(model_type="x", layers_block_type=["attention", "mlp"])
+    ) is False
+
+
+def test_unpacked_batch_is_none():
+    assert doc_mask_decision({}, 128, _text_config(), CAP) == NONE
+    # Even a multimodal model with no packing needs no special handling.
+    assert doc_mask_decision({}, 128, _multimodal_config(), CAP) == NONE
+
+
+def test_is_multimodal_predicate():
+    assert is_multimodal(_multimodal_config()) is True
+    assert is_multimodal(_text_config()) is False
+    assert is_multimodal(None) is False
+    # vision_config present but None must read as not-multimodal.
+    assert is_multimodal(SimpleNamespace(vision_config=None)) is False


### PR DESCRIPTION
Hybrid state-space models (NemotronH, FalconH1, …) run a kernel-less
torch_forward mixer that multiplies hidden states by a *2D* padding mask.
The trainer's 4D packed-doc mask broadcasts to 5D there and crashes
("… at non-singleton dimension 4" — Nemotron-H-8B TRAIN_FAILED). Add a
SKIP_SSM decision (config-only detection: layers_block_type,
hybrid_override_pattern, or known model_type) and apply the 2D fallback in
training_loop. Packed docs attend across each other in this path — a no-op
for the single-document memorization sweep.

Tests: test/unit/test_doc_mask_decision.py — 10 pass.