### PR TITLE
Declare trust_remote_code on JobConfig so per-job train_args survive

### DIFF
--- a/infra/cray_infra/util/default_job_config.py
+++ b/infra/cray_infra/util/default_job_config.py
@@ -9,6 +9,7 @@ class LoraConfig(BaseModel):
     lora_dropout: float = 0.1
     target_modules: Union[str, list] = "all-linear"  # or list of module names
 
+
 class JobConfig(BaseModel):
 
     job_directory: str
@@ -79,4 +80,17 @@ class JobConfig(BaseModel):
     # fp32 paths run fine — operators can pass `dtype: float32` in
     # train_args without changing the running deployment's config.
     dtype: str = "auto"
+
+    # Opt-in per job: allow AutoConfig/AutoTokenizer to execute a repo's
+    # custom modeling code (HF `trust_remote_code`). Required to TRAIN
+    # models that ship custom code (InternVL3, Molmo, GLM-4/ChatGLM, ...);
+    # without it load_model raises "contains custom code which must be
+    # executed ... pass trust_remote_code=True" and TRAIN_FAILEDs. MUST be
+    # declared here: get_job_config() funnels the raw train_args through
+    # this model, and Pydantic DROPS any field not declared — so a
+    # `trust_remote_code: true` in train_args silently vanishes without
+    # this line. Defaults False so arbitrary remote code only runs when the
+    # job explicitly opts in. (vLLM serve passes trust_remote_code on its
+    # own, which is why such models serve but wouldn't train.)
+    trust_remote_code: bool = False
 

--- a/test/unit/test_job_config_trust_remote_code.py
+++ b/test/unit/test_job_config_trust_remote_code.py
@@ -1,0 +1,41 @@
+"""
+Unit tests for the per-job `trust_remote_code` override.
+
+Contract under test: train_args["trust_remote_code"] passed via the SDK
+round-trips into JobConfig.trust_remote_code and reaches load_model, so
+models that ship custom modeling code (InternVL3, Molmo, GLM-4/ChatGLM,
+...) can be TRAINED. Before this fix the field was missing from JobConfig
+(Pydantic silently dropped it), so get_job_config() always returned the
+False default and load_model called AutoConfig.from_pretrained WITHOUT
+trust_remote_code — raising "contains custom code which must be executed
+... pass trust_remote_code=True" and TRAIN_FAILED, even though config.yaml
+carried `trust_remote_code: true`. Same failure mode as the historical
+`dtype` drop (see test_job_config_dtype.py).
+"""
+
+from cray_infra.util.default_job_config import JobConfig
+
+
+REQUIRED_FIELDS = {
+    "job_directory": "/tmp/job",
+    "training_data_path": "/tmp/dataset.jsonlines",
+    "dataset_hash": "abc",
+}
+
+
+def test_trust_remote_code_defaults_to_false():
+    cfg = JobConfig(**REQUIRED_FIELDS).dict()
+    assert cfg["trust_remote_code"] is False
+
+
+def test_trust_remote_code_override_survives_roundtrip():
+    # The regression: this key must NOT be dropped by the Pydantic model.
+    cfg = JobConfig(**REQUIRED_FIELDS, trust_remote_code=True).dict()
+    assert cfg["trust_remote_code"] is True
+
+
+def test_trust_remote_code_present_in_default_dict():
+    # load_model does job_config.get("trust_remote_code", False); the key
+    # should exist explicitly (not rely on the .get default) so the field
+    # is a first-class part of the job contract.
+    assert "trust_remote_code" in JobConfig(**REQUIRED_FIELDS).dict()


### PR DESCRIPTION
get_job_config() funnels raw train_args through the Pydantic JobConfig,
which DROPS any undeclared field — so `trust_remote_code: true` in
train_args silently vanished, and models shipping custom code (InternVL3,
Molmo, GLM-4/ChatGLM) TRAIN_FAILED with "contains custom code …". Declare
it as a field (default False, so remote code only runs on explicit opt-in).