### PR TITLE
Skip original/consolidated weight files on model download

### DIFF
--- a/ml/cray_megatron/huggingface/download_model.py
+++ b/ml/cray_megatron/huggingface/download_model.py
@@ -5,4 +5,11 @@ from huggingface_hub import snapshot_download
 
 @main_rank_only
 def download_model(model_name):
-    snapshot_download(repo_id=model_name)
+    # Skip redundant original-format weights (e.g. Mixtral's consolidated.*.pt,
+    # ~97GB) that transformers never loads when safetensors are present — they
+    # otherwise blow the disk on large models. from_pretrained uses the
+    # safetensors shards + config/tokenizer only.
+    snapshot_download(
+        repo_id=model_name,
+        ignore_patterns=["*.pt", "*.pth", "*.bin", "consolidated*"],
+    )


### PR DESCRIPTION
snapshot_download pulled *.pt/*.pth/*.bin/consolidated* alongside the
safetensors, blowing up disk (Mixtral's consolidated.*.pt). Pass
ignore_patterns to fetch only what training loads.