### PR TITLE
build(v0.25): NGC 26.04 base + create_vllm import/arg drift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ ARG BASE_NAME=cpu
 
 ###############################################################################
 # NVIDIA BASE IMAGE
-FROM nvcr.io/nvidia/pytorch:26.01-py3 AS nvidia
+# NGC 26.04-py3 (torch 2.12.0a0) is the floor for the vLLM 0.25 migration:
+# 0.25's register_opaque_type(...) uses the `hoist` kwarg that first lands in
+# torch 2.12 — NGC 26.03 (torch 2.11.0a0) crashes on import. See the Phase-2
+# toolchain spike (docs/reports/2026-07-14-phase2-toolchain-spike-findings.md).
+FROM nvcr.io/nvidia/pytorch:26.04-py3 AS nvidia
 
 RUN apt-get update -y && apt-get install -y python3-venv slurm-wlm libslurm-dev
 
@@ -120,7 +124,7 @@ ARG INSTALL_ROOT=/app/cray
 WORKDIR ${INSTALL_ROOT}
 
 # Install build dependencies FIRST
-RUN pip install setuptools-scm
+RUN pip install setuptools-scm setuptools-rust
 
 # Configure vLLM source - can use either local directory or remote repo.
 #

--- a/infra/cray_infra/one_server/create_vllm.py
+++ b/infra/cray_infra/one_server/create_vllm.py
@@ -15,7 +15,7 @@ from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-from vllm.entrypoints.utils import (log_non_default_args)
+from vllm.entrypoints.serve.utils.api_utils import log_non_default_args
 import vllm.envs as envs
 
 import uvicorn
@@ -97,7 +97,10 @@ async def run_server(server_status, args, **uvicorn_kwargs) -> None:
     # Add process-specific prefix to stdout and stderr.
     decorate_logs("APIServer")
 
-    listen_address, sock = setup_server(args)
+    # vLLM 0.25 made `reuse_port` a required keyword-only arg on setup_server
+    # (SO_REUSEPORT for multi-worker API servers sharing a port). cray runs a
+    # single API server worker, so False.
+    listen_address, sock = setup_server(args, reuse_port=False)
     await run_server_worker(server_status, listen_address, sock, args, **uvicorn_kwargs)
 
 async def run_server_worker(server_status, listen_address,


### PR DESCRIPTION
Couples with the vllm-fork v0.25 migration (georgi/vllm-0.25-integration):
  - Dockerfile: NGC 26.01 → 26.04-py3 (torch 2.12), add setuptools-rust
  - create_vllm.py: log_non_default_args import moved to
    vllm.entrypoints.serve.utils.api_utils; setup_server(reuse_port=False)

Do not merge before the fork migration is in.