### PR TITLE
Pin dependency ceilings (transformers<5.13, fastapi<0.137) + timm

### DIFF
--- a/infra/requirements-megatron.txt
+++ b/infra/requirements-megatron.txt
@@ -1,5 +1,17 @@
 torchao>=0.16.1
 accelerate
-transformers>=5.5.0
+# Cap below 5.13: this layer installs with --no-deps (see Dockerfile), so it
+# will NOT pull safetensors up to satisfy a newer transformers. transformers
+# 5.13.0 hard-requires safetensors>=0.8.0, but the image ships safetensors 0.7.0
+# (from the NGC/vLLM stack, which pins transformers<5), so 5.13 makes the api
+# server crash-loop at startup ("safetensors>=0.8.0 is required ... found 0.7.0").
+# 5.12.x is the last line compatible with the shipped safetensors and is the
+# version every training/serving path here was validated against. Pinning it
+# makes that explicit instead of relying on a frozen Docker layer cache (a
+# requirements change elsewhere would otherwise silently upgrade to 5.13).
+transformers>=5.5.0,<5.13
 huggingface_hub>=0.37
 peft
+# InternVL (and other hub VLMs) ship custom modeling code whose vision tower
+# imports timm; without it AutoModel load raises "requires ... timm".
+timm

--- a/infra/requirements-vllm.txt
+++ b/infra/requirements-vllm.txt
@@ -1,2 +1,12 @@
+# Pin FastAPI below 0.137.0. That release (fastapi/fastapi#15745) made
+# include_router() keep _IncludedRouter wrapper objects in app.routes instead
+# of flattening route copies; those wrappers lack a `.path`, and
+# prometheus-fastapi-instrumentator's route-name resolver reads route.path
+# unconditionally -> AttributeError -> HTTP 500 on EVERY vLLM endpoint
+# (including /health). cray's health check asserts vLLM /health == 200, so the
+# stack reports vllm "down" and the finetune sweep fails with RESTART_FAILED.
+# See vllm-project/vllm#45597 and trallnag/prometheus-fastapi-instrumentator#370.
+# fastapi-utils pulls FastAPI in transitively, so the ceiling must live here.
+fastapi[standard]>=0.115.0,<0.137.0
 fastapi-utils
 typing-inspect


### PR DESCRIPTION
Three dependency ceilings/additions that keep the training + serving stack from crash-looping on the versions currently shipped in the image:

- transformers >=5.5.0,<5.13 — the requirements layer installs with `--no-deps`, so a newer transformers won't pull safetensors up. transformers 5.13 hard- requires safetensors>=0.8.0 but the image ships 0.7.0, so 5.13 makes the api server crash-loop at startup. 5.12.x is the last line compatible with the shipped safetensors and what every path here was validated against.
- fastapi[standard] <0.137.0 — 0.137 keeps `_IncludedRouter` wrappers (no `.path`) in `app.routes`; prometheus-fastapi-instrumentator reads `route.path` unconditionally -> AttributeError -> HTTP 500 on every vLLM endpoint including /health, so cray reports vLLM down and the sweep RESTART_FAILEDs.
- timm — InternVL and other hub VLMs ship custom modeling code whose vision tower imports timm; without it AutoModel load raises "requires ... timm".

Independent of the vLLM 0.25 migration — applies to the current stack.