### PR TITLE
DiffusionGemma training path (canvas denoising, two-pass SC, NaRA)

### DIFF
--- a/infra/cray_infra/util/default_job_config.py
+++ b/infra/cray_infra/util/default_job_config.py
@@ -9,6 +9,7 @@ class LoraConfig(BaseModel):
     lora_dropout: float = 0.1
     target_modules: Union[str, list] = "all-linear"  # or list of module names
 
+
 class JobConfig(BaseModel):
 
     job_directory: str
@@ -79,4 +80,17 @@ class JobConfig(BaseModel):
     # fp32 paths run fine — operators can pass `dtype: float32` in
     # train_args without changing the running deployment's config.
     dtype: str = "auto"
+
+    # Opt-in per job: allow AutoConfig/AutoTokenizer to execute a repo's
+    # custom modeling code (HF `trust_remote_code`). Required to TRAIN
+    # models that ship custom code (InternVL3, Molmo, GLM-4/ChatGLM, ...);
+    # without it load_model raises "contains custom code which must be
+    # executed ... pass trust_remote_code=True" and TRAIN_FAILEDs. MUST be
+    # declared here: get_job_config() funnels the raw train_args through
+    # this model, and Pydantic DROPS any field not declared — so a
+    # `trust_remote_code: true` in train_args silently vanishes without
+    # this line. Defaults False so arbitrary remote code only runs when the
+    # job explicitly opts in. (vLLM serve passes trust_remote_code on its
+    # own, which is why such models serve but wouldn't train.)
+    trust_remote_code: bool = False
 

--- a/infra/cray_infra/util/default_job_config.py
+++ b/infra/cray_infra/util/default_job_config.py
@@ -10,6 +10,61 @@ class LoraConfig(BaseModel):
     target_modules: Union[str, list] = "all-linear"  # or list of module names
 
 
+class NaraConfig(BaseModel):
+    # Noise-aware LoRA (NaRA, arXiv 2605.29716) for DiffusionGemma — PROTOTYPE.
+    # See docs/adr/0012-nara-noise-aware-lora-integration.md and
+    # docs/references/nara-noise-aware-lora.md. When enabled, the diffusion adapter
+    # path swaps plain LoRA for NaRA: the low-rank update becomes noise-conditioned
+    # (dW(t) = B @ C(t) @ A), where t is the per-example corruption level from
+    # corrupt_canvas. Rank/alpha/dropout are inherited from lora_config; the knobs
+    # below are the NaRA-only extras. Nested block — MUST be declared on the Pydantic
+    # model or get_job_config() silently drops it (the trust_remote_code footgun).
+    enabled: bool = False
+    c_scale: float = 0.1          # residual gain eta: Ceff = c_scale * C(t) + I
+    fnn_hidden_1: int = 256       # shared hypernetwork hidden sizes
+    fnn_hidden_2: int = 512
+    noise_embed_dim: int = 128    # Gaussian-Fourier embedding width for t (even)
+    fourier_scale: float = 16.0
+
+
+class DiffusionConfig(BaseModel):
+    # DiffusionGemma canvas denoising knobs (see ADR 0007/0008 and
+    # docs/superpowers/specs/2026-07-01-diffusiongemma-design.md). Only consumed
+    # when the model is DiffusionGemma (auto-detected via is_diffusion()); ignored
+    # otherwise. Nested block like lora_config; MUST be declared here or
+    # get_job_config()'s Pydantic model silently DROPS it from train_args (the same
+    # footgun that hid trust_remote_code).
+    canvas_length: int = 256   # decoder block size = the loader's pad/truncate target
+    eps: float = 0.001         # minimum corruption level for t ~ U(eps, 1)
+    # Per-step probability of the two-pass self-conditioning scheme (Analog-Bits):
+    # feed the model's own no-grad prediction back as the self-conditioning signal
+    # to match the iterative serve decode. 0 disables it (single-pass v1 training).
+    self_conditioning_prob: float = 0.5
+    # Tier-2 reliability lever (see docs/reports/2026-07-16-diffusiongemma-validation-runs.md).
+    # Prepend one fixed, never-corrupted, supervised anchor token (BOS) at canvas
+    # position 0 so the real output's first token gains a stable left-neighbor. The
+    # cccc/fragment-repeat collapses all begin at positions 0-2, where position 0
+    # otherwise sits at a boundary with no left-context (output is tokenized with
+    # add_special_tokens=False). Default False = byte-identical to prior runs.
+    anchor_token: bool = False
+    # Supervise the FULL fixed-length canvas (answer + terminating EOS + pad tail)
+    # instead of masking the tail with -100. Fixes the train/serve canvas mismatch
+    # that made DiffusionGemma fail the exact-hash memorize test (adapter memorized
+    # perfectly under a clean pad tail, but generate() seeds all canvas positions
+    # from uniform noise). Two effects: (1) the tail becomes corruptible, so the
+    # answer trains under serve's noisy-init context; (2) the model learns to emit
+    # EOS/pad, so a from-noise decode terminates cleanly. See
+    # docs/reports/2026-07-17-diffusiongemma-canvas-termination-plan.md. Default
+    # False = byte-identical to prior runs.
+    supervise_termination: bool = False
+    # Only used when supervise_termination is True and != 1.0: relative CE weight on
+    # the pad-tail positions (answer + EOS always weight 1.0). Lower it if the ~230
+    # pad targets swamp the ~24 answer targets. 1.0 = uniform (try this first).
+    pad_loss_weight: float = 1.0
+    # Noise-aware LoRA (NaRA) prototype. None/omitted or enabled=False = plain LoRA
+    # (byte-identical to prior runs). See NaraConfig.
+    nara: Optional[NaraConfig] = None
+
 class JobConfig(BaseModel):
 
     job_directory: str
@@ -22,6 +77,13 @@ class JobConfig(BaseModel):
     # Training
     max_steps: int = 100
     learning_rate: float = 3e-3
+    # Global training RNG seed (applied before the adapter is built, so PEFT's
+    # lora_A init, the per-step canvas corruption, and the SC mask are all
+    # deterministic). None = historical non-deterministic behavior (byte-identical
+    # to prior runs). Set it to make a run reproducible and to seed-sweep for a
+    # DiffusionGemma draw that lands in the clean-serving basin (see the 2026-07-16
+    # validation report's "State archaeology" section). See determinism.apply_seed.
+    seed: Optional[int] = None
     batch_size: int = 1
     gradient_clip_value: float = 1.0
     gradient_accumulation_steps: int = 4
@@ -66,6 +128,10 @@ class JobConfig(BaseModel):
     # Adapters
     adapter_type: str = "tokenformer"
     lora_config: Optional[LoraConfig] = LoraConfig()
+
+    # DiffusionGemma-only canvas denoising config (nested, like lora_config).
+    # None for every non-diffusion model; is_diffusion() gates whether it is read.
+    diffusion: Optional[DiffusionConfig] = None
 
     # 4 hours in seconds
     timeout: int = 4 * 60 * 60

--- a/ml/adapters/create_lora_model.py
+++ b/ml/adapters/create_lora_model.py
@@ -5,7 +5,10 @@ import logging
 
 from peft import get_peft_model, LoraConfig, TaskType
 
-from adapters.resolve_target_modules import resolve_target_modules
+from adapters.resolve_target_modules import (
+    resolve_target_modules,
+    resolve_target_parameters,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -13,10 +16,11 @@ logger = logging.getLogger(__name__)
 def create_lora_model(model, device, train_lm_head=False):
     overall_start = time.time()
 
+    job_config = get_job_config()
+
     # Step 1: Insert LoRA adapter modules
     logger.info("Starting LoRA adapter module insertion...")
     step2_start = time.time()
-    job_config = get_job_config()
     lora_config = dict(job_config["lora_config"])
 
     # Resolve PEFT's "all-linear" shorthand ourselves: its expansion silently
@@ -26,6 +30,17 @@ def create_lora_model(model, device, train_lm_head=False):
     lora_config["target_modules"] = resolve_target_modules(
         model, lora_config.get("target_modules", "all-linear")
     )
+
+    # Grouped-expert MoEs (Qwen3MoE/OLMoE/PhiMoE) hold their experts as batched
+    # nn.Parameters that `target_modules` can't reach. Name them in
+    # `target_parameters` so PEFT wraps them (ParamWrapper); without this OLMoE/
+    # PhiMoE experts get NO LoRA and can't memorize. This is the same param set
+    # PEFT derives for Qwen3MoE on its own, so grouped models with a dense layer
+    # are unaffected. See resolve_target_parameters.
+    expert_parameters = resolve_target_parameters(model)
+    if expert_parameters:
+        existing = lora_config.get("target_parameters") or []
+        lora_config["target_parameters"] = sorted(set(existing) | set(expert_parameters))
 
     logger.info(f"LoRA config: {lora_config}")
 

--- a/ml/adapters/create_lora_model.py
+++ b/ml/adapters/create_lora_model.py
@@ -13,10 +13,79 @@ from adapters.resolve_target_modules import (
 logger = logging.getLogger(__name__)
 
 
+def _create_nara_model(model, device, job_config, nara_cfg, train_lm_head):
+    """NaRA prototype adapter creation — mirrors the PEFT path's contract (resolve the
+    same target modules, freeze base, unfreeze the adapter branch, attach unwrap_model)
+    but injects noise-aware NaRALinear layers sharing one hypernetwork instead of PEFT
+    LoRA. See ADR 0012."""
+    from adapters.nara_prototype import (
+        NaRAConfig,
+        inject_nara,
+        mark_nara_trainable,
+    )
+
+    start = time.time()
+    lora_config = dict(job_config["lora_config"])
+    target_modules = resolve_target_modules(
+        model, lora_config.get("target_modules", "all-linear")
+    )
+    if not isinstance(target_modules, list):
+        raise ValueError(
+            "NaRA prototype requires an explicit target-module list "
+            f"(got {target_modules!r}); resolve_target_modules should have expanded it."
+        )
+
+    cfg = NaRAConfig(
+        r=lora_config.get("r", 8),
+        lora_alpha=lora_config.get("lora_alpha", 32),
+        lora_dropout=lora_config.get("lora_dropout", 0.0),
+        c_scale=nara_cfg.get("c_scale", 0.1),
+        fnn_hidden_1=nara_cfg.get("fnn_hidden_1", 256),
+        fnn_hidden_2=nara_cfg.get("fnn_hidden_2", 512),
+        noise_embed_dim=nara_cfg.get("noise_embed_dim", 128),
+        fourier_scale=nara_cfg.get("fourier_scale", 16.0),
+    )
+    logger.info(f"NaRA config: {cfg}; {len(target_modules)} target modules")
+
+    inject_nara(model, target_modules, cfg)
+    n_trainable = mark_nara_trainable(model)
+
+    if train_lm_head and hasattr(model, "lm_head") and hasattr(model.lm_head, "weight"):
+        model.lm_head.weight.requires_grad = True
+        logger.info("lm_head weight set to trainable")
+
+    add_methods(model)  # unwrap_model -> filter_checkpoint saves requires_grad params
+    model = model.to(device)
+    logger.info(
+        f"create_nara_model completed in {time.time() - start:.2f}s, "
+        f"{n_trainable} trainable NaRA params"
+    )
+    return model
+
+
+def _nara_config(job_config):
+    """Return the NaRA sub-config (dict) when NaRA is enabled for this (diffusion)
+    job, else None. Handles both dict and Pydantic-model shapes, like the diffusion
+    getters in training_loop.py."""
+    diffusion = job_config.get("diffusion") or {}
+    nara = diffusion.nara if hasattr(diffusion, "nara") else diffusion.get("nara")
+    if nara is None:
+        return None
+    nara = nara if isinstance(nara, dict) else nara.model_dump()
+    return nara if nara.get("enabled") else None
+
+
 def create_lora_model(model, device, train_lm_head=False):
     overall_start = time.time()
 
     job_config = get_job_config()
+
+    # NaRA (noise-aware LoRA) prototype path for DiffusionGemma. Gated by
+    # diffusion.nara.enabled; otherwise the standard PEFT LoRA path runs unchanged.
+    # See ADR 0012 and ml/adapters/nara_prototype.py.
+    nara_cfg = _nara_config(job_config)
+    if nara_cfg is not None:
+        return _create_nara_model(model, device, job_config, nara_cfg, train_lm_head)
 
     # Step 1: Insert LoRA adapter modules
     logger.info("Starting LoRA adapter module insertion...")

--- a/ml/adapters/nara_prototype.py
+++ b/ml/adapters/nara_prototype.py
@@ -1,0 +1,286 @@
+"""NaRA (Noise-aware LoRA) — PROTOTYPE against our diffusion corruption.
+
+Prototype, NOT wired into the production training loop. It reimplements the core of
+NaRA (arXiv 2605.29716, https://github.com/generaldi/NaRA — see
+docs/references/nara-noise-aware-lora.md) in ~200 lines so we can evaluate it against
+our own DiffusionGemma canvas-denoising setup.
+
+The idea in one line
+--------------------
+Plain LoRA learns a *static* low-rank update ``dW = B @ A``. NaRA makes it
+*noise-aware*: ``dW(lambda) = B @ C(lambda) @ A``, where ``C(lambda)`` is an ``r x r``
+core matrix produced by a small **shared** hypernetwork conditioned on the diffusion
+noise level ``lambda``. As denoising sweeps ``lambda`` from ~1 (almost fully corrupted)
+to ~0 (almost clean), the effective adapter changes continuously — the paper's claim is
+that a single static LoRA is structurally mismatched to that trajectory.
+
+Where ``lambda`` comes from HERE
+--------------------------------
+Our ``diffusion_corruption.corrupt_canvas`` already samples a per-example
+``t ~ U(eps, 1)`` and corrupts each supervised canvas position with probability ``t``.
+That ``t`` **is** the NaRA noise level. We just had to stop throwing it away — hence the
+new ``return_noise_level=True`` on ``corrupt_canvas``. So the integration is:
+
+    decoder_input_ids, t = corrupt_canvas(..., return_noise_level=True)
+    nara.set_noise_level(t)          # push lambda into the shared core matrix
+    logits = model(decoder_input_ids=decoder_input_ids, ...)
+
+Divergences from the released repo (deliberate, documented)
+-----------------------------------------------------------
+1. **Per-example** ``C(lambda)`` (shape ``(B, r, r)``) rather than one global scalar
+   noise level broadcast to the whole batch — our corruption draws ``t`` per example,
+   so we condition per example. Falls back to a single shared matrix for a scalar
+   ``lambda``.
+2. ``C(lambda)`` is still **shared across layers** (one mapper, computed once per step),
+   matching the repo's "global shared C broadcast to all layers".
+3. Zero-init of the mapper's last layer means ``C = 0`` at init, so via the residual
+   ``Ceff = c_scale * C + I`` the adapter **starts byte-identical to plain LoRA** — the
+   test asserts this.
+
+See test/unit/test_nara_prototype.py for a runnable demonstration.
+"""
+
+from __future__ import annotations
+
+import math
+import weakref
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class NaRAConfig:
+    r: int = 16                    # LoRA rank (also the size of the r x r core matrix)
+    lora_alpha: int = 32           # scaling = lora_alpha / r, as in standard LoRA
+    lora_dropout: float = 0.0
+    fnn_hidden_1: int = 256        # shared hypernetwork hidden sizes
+    fnn_hidden_2: int = 512
+    noise_embed_dim: int = 128     # Gaussian-Fourier embedding width for lambda
+    c_scale: float = 0.1           # the paper's eta: Ceff = c_scale * C(lambda) + I
+    fourier_scale: float = 16.0
+
+
+class GaussianFourierProjection(nn.Module):
+    """Fixed (non-learnable) random Fourier features for a scalar noise level.
+
+    Maps ``lambda`` of shape ``(B, 1)`` -> ``(B, embed_dim)`` via ``[sin, cos]`` of
+    ``2*pi * lambda * W`` with a fixed random ``W``. Standard trick for feeding a
+    continuous scalar (timestep / noise level) into an MLP.
+    """
+
+    def __init__(self, embed_dim: int, scale: float = 16.0):
+        super().__init__()
+        if embed_dim % 2 != 0:
+            raise ValueError(f"embed_dim must be even, got {embed_dim}")
+        self.register_buffer("W", torch.randn(embed_dim // 2) * scale, persistent=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.reshape(-1, 1)  # (B, 1)
+        proj = 2.0 * math.pi * x * self.W.to(x.dtype)  # (B, embed_dim/2)
+        return torch.cat([proj.sin(), proj.cos()], dim=-1)  # (B, embed_dim)
+
+
+class NaRAMapper(nn.Module):
+    """The single shared hypernetwork: noise embedding -> flattened (r*r) core matrix.
+
+    ``Linear -> SiLU -> Linear -> SiLU -> Linear`` with the **last layer zero-init** so
+    the network outputs ``0`` at initialization (=> ``Ceff = I`` => plain LoRA).
+    """
+
+    def __init__(self, r: int, in_dim: int, h1: int, h2: int):
+        super().__init__()
+        self.r = r
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, h1),
+            nn.SiLU(),
+            nn.Linear(h1, h2),
+            nn.SiLU(),
+            nn.Linear(h2, r * r),
+        )
+        self._reset()
+
+    def _reset(self):
+        linears = [m for m in self.net if isinstance(m, nn.Linear)]
+        for m in linears[:-1]:
+            nn.init.kaiming_uniform_(m.weight, a=math.sqrt(5))
+            nn.init.zeros_(m.bias)
+        nn.init.zeros_(linears[-1].weight)  # zero_last: C == 0 at init
+        nn.init.zeros_(linears[-1].bias)
+
+    def forward(self, noise_emb: torch.Tensor) -> torch.Tensor:
+        b = noise_emb.shape[0]
+        return self.net(noise_emb).view(b, self.r, self.r)  # (B, r, r)
+
+
+class NaRAContext(nn.Module):
+    """Owns the shared mapper + noise embedding and the current core matrix ``Ceff``.
+
+    One context is shared by every ``NaRALinear`` in the model. Call
+    ``set_noise_level(t)`` once per training step (with the ``t`` from
+    ``corrupt_canvas``); each layer then reads ``self.ceff`` in its forward. Set
+    ``training_stage`` to 1 to warm up A/B only (``Ceff = I``, mapper frozen) and 2 to
+    activate noise conditioning — the two-stage schedule from the repo.
+    """
+
+    def __init__(self, config: NaRAConfig):
+        super().__init__()
+        self.config = config
+        self.embed = GaussianFourierProjection(config.noise_embed_dim, config.fourier_scale)
+        self.mapper = NaRAMapper(
+            config.r, config.noise_embed_dim, config.fnn_hidden_1, config.fnn_hidden_2
+        )
+        self.register_buffer("_eye", torch.eye(config.r), persistent=False)
+        self.ceff: Optional[torch.Tensor] = None  # (B, r, r) or (r, r); set per step
+        self.training_stage: int = 2
+
+    def set_training_stage(self, stage: int):
+        if stage not in (1, 2):
+            raise ValueError("stage must be 1 (A/B only) or 2 (noise-aware)")
+        self.training_stage = stage
+        req = stage == 2
+        for p in self.mapper.parameters():
+            p.requires_grad_(req)
+
+    def set_noise_level(self, noise_level: Optional[Union[float, torch.Tensor]]):
+        """Compute and cache ``Ceff = c_scale * C(lambda) + I`` for this step."""
+        if self.training_stage == 1 or noise_level is None:
+            self.ceff = self._eye  # identity => behaves exactly like plain LoRA
+            return
+        if not torch.is_tensor(noise_level):
+            noise_level = torch.tensor([noise_level], dtype=torch.float32)
+        # Match the mapper's dtype (the model may have been cast to bf16/fp16 after
+        # injection, which converts the mapper params and the _eye buffer too).
+        mapper_dtype = next(self.mapper.parameters()).dtype
+        noise_level = noise_level.to(self._eye.device, mapper_dtype)
+        emb = self.embed(noise_level)                 # (B, embed_dim)
+        c = self.mapper(emb)                           # (B, r, r)
+        self.ceff = self.config.c_scale * c + self._eye  # residual: I at init
+
+
+class NaRALinear(nn.Module):
+    """Wraps a frozen base ``nn.Linear`` and adds the noise-aware low-rank branch.
+
+    ``out = base(x) + scaling * ( dropout(x) @ A^T @ Ceff @ B^T )``
+
+    with ``A: (r, in)``, ``B: (out, r)``, ``Ceff: (r, r)`` (or ``(B, r, r)``). ``B`` is
+    zero-init (standard LoRA) so the whole adapter is a no-op at step 0 regardless of
+    ``Ceff``; once trained, ``Ceff`` bends the shared subspace per noise level.
+    """
+
+    def __init__(self, base: nn.Linear, context: NaRAContext, config: NaRAConfig):
+        super().__init__()
+        self.base = base
+        self.base.weight.requires_grad_(False)
+        if self.base.bias is not None:
+            self.base.bias.requires_grad_(False)
+        # Weakref so the shared context is NOT registered as a submodule of every
+        # NaRALinear (that would duplicate the mapper/embedding params across layers
+        # in state_dict). The context is registered ONCE, under the model, by
+        # inject_nara / create_nara_model.
+        self._ctx_ref = weakref.ref(context)
+        self.scaling = config.lora_alpha / config.r
+        self.dropout = nn.Dropout(config.lora_dropout) if config.lora_dropout > 0 else nn.Identity()
+
+        in_f, out_f, r = base.in_features, base.out_features, config.r
+        self.lora_A = nn.Parameter(torch.empty(r, in_f))
+        self.lora_B = nn.Parameter(torch.zeros(out_f, r))
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))  # B stays zero
+
+    @property
+    def context(self) -> "NaRAContext":
+        ctx = self._ctx_ref()
+        if ctx is None:
+            raise RuntimeError("NaRAContext was garbage-collected; keep it registered "
+                               "under the model (inject_nara does this).")
+        return ctx
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out = self.base(x)
+        ceff = self.context.ceff
+        if ceff is None:
+            ceff = self.context._eye
+        h = F.linear(self.dropout(x), self.lora_A)  # (..., r)
+        if ceff.dim() == 3:
+            # per-example (B, r, r): x is (B, S, r) -> einsum over the rank dim
+            h = torch.einsum("bsr,brk->bsk", h, ceff.to(h.dtype))
+        else:
+            h = h @ ceff.to(h.dtype)                # shared (r, r)
+        delta = F.linear(h, self.lora_B) * self.scaling
+        return out + delta
+
+
+#: Attribute/submodule name the shared context is registered under on the model.
+NARA_CONTEXT_ATTR = "nara_context"
+
+
+def inject_nara(model: nn.Module, target_modules, config: NaRAConfig) -> NaRAContext:
+    """Replace every targeted ``nn.Linear`` with a ``NaRALinear`` sharing one
+    ``NaRAContext``, and register that context ONCE under the model as
+    ``model.nara_context`` (so it moves with ``.to(device)`` / dtype casts and its
+    trainable params land in ``state_dict``). Returns the context.
+
+    ``target_modules`` accepts the exact output of ``resolve_target_modules``: either
+    **leaf names** (dense models, e.g. ``"q_proj"``) or **full dotted paths** (MoE
+    decoders, e.g. ``"model.decoder.layers.0.self_attn.q_proj"``). Full-path entries
+    match by exact qualified name; bare leaf entries match by last path segment.
+    Prototype-grade: no merge, no quantization.
+    """
+    targets = set(target_modules)
+    full_targets = {t for t in targets if "." in t}
+    leaf_targets = {t for t in targets if "." not in t}
+    context = NaRAContext(config)
+    to_replace = []
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear) and (
+            name in full_targets or name.split(".")[-1] in leaf_targets
+        ):
+            to_replace.append((name, module))
+    if not to_replace:
+        raise ValueError(f"inject_nara: no nn.Linear matched targets {target_modules}")
+    for name, module in to_replace:
+        parent = model
+        *path, leaf = name.split(".")
+        for p in path:
+            parent = getattr(parent, p)
+        setattr(parent, leaf, NaRALinear(module, context, config))
+    # Register the shared context INSIDE the sub-tree that actually gets
+    # checkpointed. unwrap_model saves ``self.model.state_dict()`` (the inner
+    # backbone), so a context added to the OUTER head-wrapper is a *sibling* of
+    # the saved sub-tree and is silently dropped from the checkpoint — the mapper
+    # (NaRA's whole novelty) never reaches disk, leaving a plain-LoRA .pt. Attach
+    # it to the same backbone the replaced linears live in (``model.model`` for a
+    # HF ``…ForXXX`` wrapper; ``model`` itself when there is no inner backbone) so
+    # ``nara_context.mapper.*`` lands in the saved state_dict exactly once.
+    checkpoint_root = getattr(model, "model", model)
+    if not isinstance(checkpoint_root, nn.Module):
+        checkpoint_root = model
+    checkpoint_root.add_module(NARA_CONTEXT_ATTR, context)
+    return context
+
+
+def find_nara_context(model: nn.Module) -> Optional[NaRAContext]:
+    """Return the model's NaRAContext regardless of distribution-strategy wrapping
+    (DDP/FSDP/identity), or None if NaRA is not active. Wrapper-agnostic: walks the
+    module tree rather than guessing ``.module``/``.model`` depth."""
+    for m in model.modules():
+        if isinstance(m, NaRAContext):
+            return m
+    return None
+
+
+def mark_nara_trainable(model: nn.Module) -> int:
+    """Freeze everything, then unfreeze the NaRA branch (lora_A/lora_B) and the shared
+    mapper/embedding. Mirrors create_lora_model's freeze/unfreeze. Returns the count of
+    trainable params."""
+    for p in model.parameters():
+        p.requires_grad_(False)
+    n = 0
+    for name, p in model.named_parameters():
+        if "lora_" in name or f"{NARA_CONTEXT_ATTR}." in name:
+            p.requires_grad_(True)
+            n += 1
+    return n

--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -8,7 +8,13 @@ for two reasons:
    some architectures (observed for Qwen3MoeForCausalLM) and PEFT falls back to
    iterating the literal string as a *set of characters*, raising
    `Target modules {'-','l','n','r','i','a','e'} not found` — the `qwen3-moe`
-   TRAIN_FAILED in the cuda-spark sweep.
+   TRAIN_FAILED in the cuda-spark sweep. We adapt attention + any dense MLP, and
+   handle routed experts by layout: *grouped* experts (Qwen3MoE/Granite) are kept
+   off (PEFT and the grouped serve converter handle them), while *separate*
+   per-expert Linears (Mixtral/PhiMoE) are included so they train and the
+   separate-expert converter can serve them — see `_has_separate_experts`,
+   `_moe_servable_linear_paths`, `docs/reports/2026-06-30-moe-expert-lora-serving.md`,
+   and `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`.
 
 2. **Multimodal.** For a `...ForConditionalGeneration` wrapper, "all-linear"
    would also adapt the vision encoder. PEFT matches `target_modules` by name
@@ -17,14 +23,30 @@ for two reasons:
    leaf-name set can't exclude it. We confine LoRA to the language decoder by
    emitting its Linear modules' *full paths*.
 
+3. **Dense hybrid SSM.** FalconH1 (`FalconH1ForCausalLM`) runs a Mamba-2 mixer ‖
+   attention in every layer with NO MoE. Its mixer holds an `out_proj` `nn.Linear`,
+   and PEFT's `_check_lora_target_modules_mamba` REJECTS a target named
+   `out_proj`/`conv1d` on Mamba `model_type`s — the FalconH1 TRAIN_FAILED. We drop
+   the SSM mixer subtree (`.mamba`/`.linear_attn`) and adapt attention + MLP, which
+   carries memorization (granite precedent). See `_has_ssm_layers`.
+
 For dense models the result is the sorted leaf-name set — byte-identical to
 PEFT's own expansion (same trainable parameters).
 """
+
+import re
 
 import torch.nn as nn
 
 # PEFT's sentinel for "adapt every linear layer except the output head".
 ALL_LINEAR = "all-linear"
+
+# A per-expert projection in a *separate*-expert MoE: a numbered expert index
+# under an `experts` container, e.g. `...experts.0.w1` (Mixtral/PhiMoE) or
+# `...experts.3.gate_proj` (Qwen2MoE). Grouped-expert models (Qwen3MoE's
+# `Qwen3MoeExperts`, GraniteMoeHybrid's `block_sparse_moe`) have NO such numbered
+# nn.Linear, which is exactly how we tell the two layouts apart.
+_SEPARATE_EXPERT_RE = re.compile(r"(?:^|\.)experts\.\d+\.")
 
 
 def _is_multimodal_model(model) -> bool:
@@ -60,34 +82,238 @@ def _module_prefix(model, target) -> str | None:
     return None
 
 
-# Self-attention container segments across the common decoder architectures.
-_ATTENTION_CONTAINERS = (".self_attn.", ".attn.", ".attention.")
-
-
 def _is_moe_model(model) -> bool:
-    """True if the model has routed MoE expert submodules (a `.experts` module).
+    """True if the model has routed MoE expert submodules whose fused LoRA a `.pt`
+    adapter can't serve. Two container conventions are recognized:
 
-    A `.pt` adapter that adapts the fused experts can't be served: vLLM's
+    - `.experts` — Qwen3MoE / PhiMoE (a `ModuleList`/`ModuleDict` of per-expert or
+      grouped expert projections), and
+    - `.block_sparse_moe` — GraniteMoeHybrid, whose grouped experts and router live
+      under `model.layers.{i}.block_sparse_moe.*` with NO `.experts` submodule.
+
+    A `.pt` adapter that adapts the *fused experts* can't be served: vLLM's
     `FusedMoEWithLoRA.set_lora` wants a per-expert tensor *list* (gate/down/up,
     each `[num_experts, rank, dim]`), while the ScalarLM trainer exports stacked
     2-D tensors. Rather than reproduce vLLM's PEFT→fused-MoE conversion, we keep
-    LoRA off the experts and adapt attention only — which serves cleanly."""
-    return any(".experts" in name for name, _ in model.named_modules())
+    LoRA off the experts (and the router) and adapt everything else that *does*
+    serve from a `.pt` adapter — see `_moe_servable_linear_paths`."""
+    return any(
+        ".experts" in name or ".block_sparse_moe" in name
+        for name, _ in model.named_modules()
+    )
 
 
-def _attention_linear_names(model, output_embeddings) -> set[str]:
-    """Leaf names of the attention-projection `nn.Linear` modules (q/k/v/o under
-    a self-attention container). Excludes MLP, MoE experts, the router, and the
-    output head — everything that doesn't serve from a `.pt` MoE adapter."""
-    names: set[str] = set()
+def _ssm_mixer_prefixes(model) -> set[str]:
+    """Dotted names of Mamba-2 SSM mixer submodules that DON'T carry `.mamba` or
+    `.linear_attn` in their path, so the name-substring checks elsewhere can't
+    match them. NVIDIA's NemotronH (`NemotronHForCausalLM`) names every per-layer
+    mixer `.mixer` — the SAME attribute an attention or MLP block uses (the block
+    type varies by `hybrid_override_pattern`) — so its Mamba-2 mixer can only be
+    told apart structurally: a selective-scan mixer carries an `A_log` parameter
+    (alongside `D`/`dt_bias` and a `conv1d`) that attention/MLP mixers do not.
+    Returns the mixer module names; callers exclude every `nn.Linear` beneath them
+    (the mixer's `in_proj`/`out_proj`), keeping the attention `q/k/v/o_proj` and
+    MLP `up/down_proj` of sibling blocks. Empty for archs whose SSM mixers already
+    match `.mamba`/`.linear_attn` (granite / FalconH1 / Qwen3.5) and for non-SSM
+    models."""
+    prefixes: set[str] = set()
+    for name, module in model.named_modules():
+        if ".mamba" in name or ".linear_attn" in name:
+            continue  # matched by name; no need for the signature fallback
+        if any(pname == "A_log" for pname, _ in module.named_parameters(recurse=False)):
+            prefixes.add(name)
+    return prefixes
+
+
+def _is_ssm_linear(name: str, ssm_prefixes: set[str]) -> bool:
+    """True if the `nn.Linear` at dotted `name` belongs to a state-space /
+    linear-attention mixer whose LoRA the `.pt` path can't serve — matched either
+    by the `.mamba`/`.linear_attn` name convention (granite / FalconH1 / Qwen3.5)
+    or by a signature-detected mixer prefix (NemotronH's `.mixer`, see
+    `_ssm_mixer_prefixes`)."""
+    if ".mamba" in name or ".linear_attn" in name:
+        return True
+    return any(name.startswith(prefix + ".") for prefix in ssm_prefixes)
+
+
+def _has_ssm_layers(model) -> bool:
+    """True if the model has Mamba-2 SSM (`.mamba.*`) or linear-attention
+    (`.linear_attn.*`) mixer submodules — GraniteMoeHybrid / FalconH1 Mamba-2, or
+    Qwen3.5's GatedDeltaNet — or a signature-detected Mamba-2 mixer that isn't
+    named that way (NemotronH's `.mixer`, see `_ssm_mixer_prefixes`).
+
+    This matters for a *dense* hybrid — FalconH1 (`FalconH1ForCausalLM`: a Mamba-2
+    mixer ‖ attention in every layer, NO MoE) and NemotronH (`NemotronHForCausalLM`:
+    Mamba-2 / attention / MLP blocks interleaved by `hybrid_override_pattern`, also
+    dense). Their Mamba mixer holds an `out_proj`/`in_proj` `nn.Linear`; for the
+    FalconH1 `model_type` PEFT's `_check_lora_target_modules_mamba` REJECTS a target
+    named `out_proj`/`conv1d` (the FalconH1 TRAIN_FAILED), and even where PEFT does
+    NOT reject it (NemotronH's `model_type` isn't in PEFT's Mamba set) LoRA on the
+    SSM projections is dropped on serve (vLLM's `MambaMixer2` doesn't wire it) — a
+    memorization/serve mismatch. The dense leaf-name path (below) would emit those
+    SSM projections; this predicate routes the dense case through the SSM-excluding
+    path instead. MoE hybrids like granite already route through the MoE path, which
+    drops the SSM. (Attention uses `o_proj`, not `out_proj`, so only the SSM mixer
+    trips PEFT's check.)"""
+    return any(
+        ".mamba" in name or ".linear_attn" in name
+        for name, _ in model.named_modules()
+    ) or bool(_ssm_mixer_prefixes(model))
+
+
+def _has_separate_experts(model) -> bool:
+    """True if the model exposes routed experts as a `ModuleList` of per-expert
+    `nn.Linear` projections (`...experts.{i}.{w1,w2,w3}` — Mixtral / PhiMoE /
+    Qwen2MoE), as opposed to a single *grouped* expert module whose batched
+    weights are `nn.Parameter`s (Qwen3MoE's `Qwen3MoeExperts`) or two fused
+    `nn.Linear`s (GraniteMoeHybrid's `block_sparse_moe.{input,output}_linear`).
+
+    This drives LoRA targeting. PEFT adapts a *grouped* module on its own (via
+    `ParamWrapper`) and its fused export is served by the grouped converter, so we
+    keep those experts OUT of `target_modules` and let PEFT handle them. *Separate*
+    per-expert Linears are NOT auto-adapted, so to train them (and then serve them
+    via the separate-expert converter) we must name them explicitly. See
+    `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`."""
+    return any(
+        isinstance(module, nn.Linear) and _SEPARATE_EXPERT_RE.search(name)
+        for name, module in model.named_modules()
+    )
+
+
+def _moe_servable_linear_paths(model, output_embeddings, separate_experts=False) -> list[str]:
+    """Full dotted paths of every `nn.Linear` in a MoE model whose LoRA a `.pt`
+    adapter can serve: the attention projections (all layers) and any *dense*
+    MLP — the non-sparse decoder layers, e.g. layer 0 under Qwen3MoE's
+    `decoder_sparse_step`. When `separate_experts` is True the per-expert
+    projections are ALSO included (see below). Always excludes:
+
+    - the router (leaf `gate` in Qwen3MoE/Mixtral or `router` in PhiMoE — adapting
+      it would perturb expert selection, and PhiMoE's is an nn.Linear subclass
+      returning a tuple that crashes PEFT's LoRA wrap; GraniteMoe's router leaf is
+      `layer` under `.block_sparse_moe`, covered by that exclusion below),
+    - the Mamba-2 SSM projections (`.mamba.*`) — nothing else in the sweep has
+      state-space layers and their LoRA is untested/unserved,
+    - the DeepSeek MLA latent projections (`kv_a_proj_with_mqa`, `kv_b_proj`) —
+      vLLM absorbs them into the latent-attention kernel on serve, so their LoRA is
+      dropped (the DeepSeek-V2-Lite NO_MEM near-miss); `q_proj`/`o_proj` serve clean
+      and stay, and
+    - the output head.
+
+    Routed experts are handled per layout:
+
+    - **grouped** (`separate_experts=False`) — Qwen3MoE's `Qwen3MoeExperts`
+      (adapted by PEFT on its own) and GraniteMoeHybrid's whole `.block_sparse_moe`
+      subtree are EXCLUDED; their fused LoRA isn't served from a leaf-name `.pt`
+      target and the grouped converter handles it (see `_is_moe_model`).
+    - **separate** (`separate_experts=True`) — Mixtral/PhiMoE per-expert Linears
+      (`...experts.{i}.{w1,w2,w3}`) are INCLUDED so PEFT trains them; the
+      separate-expert serve converter then stacks them for `FusedMoEWithLoRA`.
+
+    *Full paths* — not leaf names — because the dense-MLP projections
+    (`gate_proj`/`up_proj`/`down_proj`) reuse the SAME leaf names as the expert
+    projections, so a leaf-name set can't include one while excluding the other.
+    PEFT matches these exact paths."""
+    ssm_prefixes = _ssm_mixer_prefixes(model)
+    paths: list[str] = []
     for module_name, module in model.named_modules():
         if not isinstance(module, nn.Linear):
             continue
         if output_embeddings is not None and module is output_embeddings:
             continue
-        if any(seg in module_name for seg in _ATTENTION_CONTAINERS):
-            names.add(module_name.split(".")[-1])
-    return names
+        if module_name.endswith("lm_head"):  # head, when output_embeddings is None
+            continue
+        if _is_ssm_linear(module_name, ssm_prefixes):
+            # SSM / linear-attention projections — not adapted (untested/unserved
+            # by the .pt LoRA path). `.mamba` = GraniteMoeHybrid's Mamba-2
+            # (in_proj/out_proj); `.linear_attn` = Qwen3.5's GatedDeltaNet
+            # (in_proj_a/b/qkv/z, out_proj, conv1d), the linear-attention half of
+            # its hybrid full/linear-attention stack; a signature-detected `.mixer`
+            # = NemotronH's Mamba-2 (in_proj/out_proj), for any NemotronH-MoE variant.
+            continue
+        # The MoE router / gate — exclude by leaf name. Adapting it would perturb
+        # expert selection, and its leaf name varies by arch: `gate` (Qwen3MoE/
+        # Mixtral), `router` (PhiMoE, whose router is an nn.Linear subclass
+        # returning a tuple, so LoRA-wrapping it crashes with `'tuple' object has
+        # no attribute 'dtype'`), or a `*_gate` (Qwen3.5's `shared_expert_gate`,
+        # which routes the shared expert). The dense projections we DO adapt end in
+        # `_proj` (`gate_proj`/`up_proj`), so an exact/suffix match leaves them
+        # untouched.
+        leaf = module_name.rsplit(".", 1)[-1]
+        if leaf in ("gate", "router") or leaf.endswith("_gate"):
+            continue
+        # DeepSeek MLA latent projections. On serve, vLLM's DeepseekV2MLAAttention
+        # restructures attention into an absorbed latent-attention kernel
+        # (MultiHeadLatentAttentionWrapper): `kv_b_proj` is decomposed into per-head
+        # W_UK/W_UV and absorbed, and `kv_a_proj_with_mqa` produces the latent cache
+        # feeding that kernel — so a LoRA delta trained on them as plain HF Linears is
+        # NOT applied by the MLA path. Training memorizes (loss 0.0) but the served
+        # adapter reproduces the golden only partially (DeepSeek-V2-Lite NO_MEM
+        # near-miss: right prefix/tail, garbled middle). Keep LoRA off them so
+        # memorization leans on the serve-clean attention projections (`q_proj`/
+        # `o_proj`, applied normally inside the wrapper) + the routed experts (grouped
+        # converter). These leaf names are MLA-specific — no non-MLA arch uses them —
+        # so an unconditional leaf exclusion is safe. See
+        # `archnovel-sweep-deepseek-cohere-nemotron-falconh1` (memory).
+        if leaf in ("kv_a_proj_with_mqa", "kv_b_proj"):
+            continue
+        # A per-expert projection (`experts.{i}.*`). In a separate-expert model
+        # these ARE the memorization-carrying weights and the separate-expert
+        # converter serves them, so include them; otherwise keep them off the
+        # adapter (grouped experts are adapted by PEFT / served differently).
+        if _SEPARATE_EXPERT_RE.search(module_name):
+            if separate_experts:
+                paths.append(module_name)
+            continue
+        if ".experts" in module_name:  # grouped/fused experts container — not .pt-serveable
+            continue
+        if ".block_sparse_moe" in module_name:  # GraniteMoe grouped experts + router.layer
+            continue
+        paths.append(module_name)
+    return paths
+
+
+def resolve_target_parameters(model) -> list[str]:
+    """Leaf names of the batched `nn.Parameter` expert projections that PEFT must
+    be told to adapt via `LoraConfig.target_parameters` — for *grouped*-expert
+    MoEs whose experts are a single module holding `(num_experts, …)` parameters
+    (`gate_up_proj`/`down_proj`), not per-expert `nn.Linear`s.
+
+    Why this is needed. PEFT's `target_modules` only matches `nn.Module`s, so it
+    cannot reach a bare expert `nn.Parameter`. PEFT *does* adapt grouped experts
+    for some models, but ONLY as a side effect of its transformers-v5 MoE weight
+    conversion (`peft/utils/transformers_weight_conversion.py::_convert_peft_config_moe`),
+    which fires only when a *dense* MLP layer's `gate_proj/up_proj/down_proj` leaves
+    are ALREADY in `target_modules`. Qwen3MoE has such a dense layer
+    (`decoder_sparse_step`) so its experts get adapted; all-MoE OLMoE (no dense
+    layer, though `olmoe` IS in PEFT's conversion map) and PhiMoE (`phimoe` NOT in
+    the map) do NOT — their experts silently receive no LoRA and the model can only
+    lean on attention, which cannot memorize (the whole MoE lesson). Naming the
+    expert params here makes PEFT wrap them directly (ParamWrapper), producing the
+    exact `{experts}.base_layer` = gate_up / `{experts}` = down tensors the grouped
+    serve converter (vLLM `_stack_moe_lora_weights_gated`) already consumes — the
+    same result Qwen3MoE gets, but without depending on a dense layer.
+
+    Returns leaf-name suffixes (PEFT matches `target_parameters` by suffix). This
+    is exactly the `{gate_up_proj, down_proj}` set PEFT itself derives for Qwen3MoE,
+    so grouped models that already have a dense layer are unaffected (same set,
+    unioned). Empty for dense models, for *separate* per-expert `nn.Linear` experts
+    (Mixtral/PhiMoE-in-v4 — adapted via `target_modules`), and for `nn.Linear`-fused
+    grouped experts (GraniteMoeHybrid `block_sparse_moe.{input,output}_linear`) —
+    none of which expose bare batched expert parameters. Requires
+    `lora_config.lora_dropout == 0` (PEFT's ParamWrapper rejects dropout), which the
+    MoE sweep entries already set. See
+    `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`."""
+    leaves: set[str] = set()
+    for name, module in model.named_modules():
+        if name.rsplit(".", 1)[-1] != "experts":
+            continue
+        for pname, param in module.named_parameters(recurse=False):
+            # A batched (num_experts, in, out) projection — 3-D distinguishes it
+            # from a router/norm scalar and from the per-expert nn.Linear layout
+            # (whose weights live under `experts.{i}`, not directly on `experts`).
+            if param.dim() >= 2:
+                leaves.add(pname)
+    return sorted(leaves)
 
 
 def resolve_target_modules(model, target_modules):
@@ -97,11 +323,25 @@ def resolve_target_modules(model, target_modules):
     - **multimodal** (config has `vision_config`, `get_decoder()` available):
       the full dotted paths of every `nn.Linear` under the language decoder,
       excluding the output head. PEFT matches these exactly, so a vision tower
-      reusing the same leaf names is not adapted.
-    - **MoE** (has routed `.experts` submodules, non-multimodal): the sorted
-      attention-projection leaf names only. The fused-expert LoRA can't be served
-      from a `.pt` adapter (vLLM's `FusedMoEWithLoRA` wants a per-expert tensor
-      list, not stacked tensors), so LoRA is kept off the experts.
+      reusing the same leaf names is not adapted. When the decoder is ALSO MoE
+      (Qwen3.5-VL-MoE), the MoE-servable filter is applied within the decoder
+      scope too — router / SSM (`.linear_attn`) / grouped experts are dropped,
+      leaving attention + the dense `shared_expert`; grouped experts are adapted
+      via `target_parameters`.
+    - **MoE** (has routed `.experts`/`.block_sparse_moe` submodules, non-multimodal):
+      the sorted *full paths* of every adaptable `nn.Linear` — attention (all
+      layers) plus any dense (non-sparse) MLP — always excluding the router (leaf
+      `gate`/`router`), the Mamba SSM, and the output head. Routed experts depend
+      on layout: *grouped* experts (Qwen3MoE `Qwen3MoeExperts`, Granite
+      `block_sparse_moe`) are kept OFF (PEFT/the grouped converter handle them),
+      while *separate* per-expert Linears (Mixtral/PhiMoE `experts.{i}.{w1,w2,w3}`)
+      are INCLUDED so they train and the separate-expert converter can serve them.
+      Full paths (not leaf names) are required because the dense MLP and experts
+      share leaf names.
+    - **dense hybrid SSM** (has `.mamba`/`.linear_attn`, non-MoE, non-multimodal —
+      FalconH1): the sorted full paths of every `nn.Linear` OUTSIDE the SSM mixer
+      subtree (attention + MLP), excluding the head. Drops the Mamba mixer's
+      `out_proj` that PEFT refuses on Mamba `model_type`s.
     - **dense**: the sorted set of distinct `nn.Linear` leaf-module names,
       excluding the output head — identical to PEFT's all-linear expansion.
 
@@ -121,25 +361,75 @@ def resolve_target_modules(model, target_modules):
     if decoder is not None:
         prefix = _module_prefix(model, decoder)
         if prefix is not None:
-            return sorted(
-                name
-                for name, module in model.named_modules()
-                if isinstance(module, nn.Linear)
-                and module is not output_embeddings
-                and (name == prefix or name.startswith(prefix + "."))
-            )
+            def _under_decoder(name):
+                return name == prefix or name.startswith(prefix + ".")
+            if _is_moe_model(model):
+                # Multimodal MoE (e.g. Qwen3.5-VL-MoE `Qwen3_5MoeForConditionalGeneration`):
+                # confine to the language decoder AND apply the MoE-servable filter
+                # so LoRA lands on attention + the dense, always-on `shared_expert`
+                # (the memorization carrier, like granite's `shared_mlp`) — NOT the
+                # router, the GatedDeltaNet SSM (`.linear_attn`), or the grouped
+                # routed experts (which go via `target_parameters`). The plain
+                # multimodal path below would adapt all of those. Full paths, as the
+                # dense/shared-expert and expert projections share leaf names.
+                separate = _has_separate_experts(model)
+                paths = _moe_servable_linear_paths(
+                    model, output_embeddings, separate_experts=separate)
+                scoped = sorted(p for p in paths if _under_decoder(p))
+                if scoped:
+                    return scoped
+                # Nothing matched under the decoder — fall through rather than
+                # adapt nothing.
+            else:
+                return sorted(
+                    name
+                    for name, module in model.named_modules()
+                    if isinstance(module, nn.Linear)
+                    and module is not output_embeddings
+                    and _under_decoder(name)
+                )
         # get_decoder() returned a module we couldn't locate — fall through to
         # the dense path rather than silently adapt nothing.
 
     if _is_moe_model(model):
-        # Attention-only for MoE: the fused-expert LoRA isn't serveable from a
-        # .pt adapter (see _is_moe_model), so confine LoRA to the attention
-        # projections, which load + serve cleanly.
-        attn = _attention_linear_names(model, output_embeddings)
-        if attn:
-            return sorted(attn)
-        # No attention modules matched (unusual arch) — fall through to the dense
-        # path rather than adapt nothing.
+        # MoE: emit full paths for the adaptable linears — attention (all layers)
+        # + any dense (non-sparse) MLP — plus, for a *separate*-expert layout
+        # (Mixtral/PhiMoE), the per-expert projections (grouped experts stay off;
+        # PEFT/the grouped converter handle those). The router is always excluded.
+        # Full paths, not leaf names, because the dense MLP and experts share leaf
+        # names.
+        separate = _has_separate_experts(model)
+        paths = _moe_servable_linear_paths(model, output_embeddings, separate_experts=separate)
+        if paths:
+            return sorted(paths)
+        # Nothing matched (unusual arch) — fall through to the dense path rather
+        # than adapt nothing.
+
+    if _has_ssm_layers(model):
+        # Dense hybrid SSM model (FalconH1: Mamba-2 ‖ attention; NemotronH: Mamba-2 /
+        # attention / MLP blocks interleaved — both dense, no MoE). Emit the full
+        # nn.Linear PATHS for the adaptable layers — attention + MLP — excluding the
+        # SSM mixer subtree (`.mamba`/`.linear_attn`, or a signature-detected `.mixer`
+        # for NemotronH) and the output head. Keeping LoRA on attention + MLP is what
+        # carries memorization (the granite precedent: the SSM stays off, attention +
+        # dense MLP memorize), and dropping the SSM subtree removes the mixer's
+        # `out_proj`/`in_proj` — which PEFT refuses on FalconH1's `model_type`, and
+        # which vLLM drops on serve for NemotronH (see `_has_ssm_layers`). Full paths
+        # — not leaf names — so the exclusion is by SSM subtree, leaving any attention
+        # `out_proj` (were an arch to use that leaf) untouched.
+        ssm_prefixes = _ssm_mixer_prefixes(model)
+        paths = sorted(
+            name
+            for name, module in model.named_modules()
+            if isinstance(module, nn.Linear)
+            and (output_embeddings is None or module is not output_embeddings)
+            and not name.endswith("lm_head")
+            and not _is_ssm_linear(name, ssm_prefixes)
+        )
+        if paths:
+            return paths
+        # Nothing outside the SSM mixer (pure Mamba, no attention/MLP linears) —
+        # fall through to the dense path rather than adapt nothing.
 
     names = set()
     for module_name, module in model.named_modules():

--- a/ml/adapters/resolve_target_modules.py
+++ b/ml/adapters/resolve_target_modules.py
@@ -256,6 +256,14 @@ def _moe_servable_linear_paths(model, output_embeddings, separate_experts=False)
         # `archnovel-sweep-deepseek-cohere-nemotron-falconh1` (memory).
         if leaf in ("kv_a_proj_with_mqa", "kv_b_proj"):
             continue
+        # DiffusionGemma's router is `...router.proj` (an nn.Linear under a
+        # `DiffusionGemmaTextRouter` module) — the leaf is `proj`, not `gate`/
+        # `router`, so the leaf check above misses it. Adapting the routing
+        # projection destabilizes expert selection mid-fine-tune (the NeMo recipe
+        # sets `freeze_router: true`); exclude the whole `.router.` subtree by
+        # path. Harmless for archs without a `.router.` container.
+        if ".router." in module_name:
+            continue
         # A per-expert projection (`experts.{i}.*`). In a separate-expert model
         # these ARE the memorization-carrying weights and the separate-expert
         # converter serves them, so include them; otherwise keep them off the
@@ -302,7 +310,18 @@ def resolve_target_parameters(model) -> list[str]:
     none of which expose bare batched expert parameters. Requires
     `lora_config.lora_dropout == 0` (PEFT's ParamWrapper rejects dropout), which the
     MoE sweep entries already set. See
-    `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`."""
+    `docs/superpowers/plans/2026-07-06-separate-expert-lora-converter.md`.
+
+    DiffusionGemma is deliberately excluded: every decoder layer runs a dense MLP
+    *and* the grouped experts in parallel (`dense_out + moe_out`), so the always-on
+    dense MLP carries memorization (like granite's `shared_mlp`) and the experts do
+    NOT need LoRA. Adapting them would deviate from the NeMo reference recipe
+    (freeze_router + target_modules only) and pull in the FusedMoE-LoRA serve path
+    that ADR 0011 avoids. Its grouped `experts` module would otherwise match the
+    scan below, so short-circuit on the diffusion config."""
+    config = getattr(model, "config", None)
+    if getattr(config, "model_type", None) == "diffusion_gemma":
+        return []
     leaves: set[str] = set()
     for name, module in model.named_modules():
         if name.rsplit(".", 1)[-1] != "experts":

--- a/ml/cray_megatron/megatron/dataset/diffusion_canvas.py
+++ b/ml/cray_megatron/megatron/dataset/diffusion_canvas.py
@@ -1,0 +1,142 @@
+"""Pure canvas-tokenization helpers for DiffusionGemma, split out from
+``load_diffusion_dataset`` so they can be unit-tested without importing the heavy
+dataset pipeline (which pulls in ``gpu_aware_mpi`` via the data-parallel helpers).
+Only depends on ``logging`` and the tokenizer passed in.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def pad_token_id(tokenizer):
+    """A valid embedding index to fill canvas padding. Padded slots are excluded
+    from the loss via -100 labels, so the token only matters as a legal index for
+    the decoder's embedding lookup. Prefer pad, then eos, then 0."""
+    for tok in (tokenizer.pad_token_id, tokenizer.eos_token_id):
+        if tok is not None:
+            return tok
+    return 0
+
+
+def anchor_token_id(tokenizer):
+    """Resolve the Tier-2 canvas anchor token, or ``None`` if unavailable.
+
+    The anchor is a single fixed token pinned to canvas position 0 (clean,
+    never-corrupted, supervised) to give the real output's first token a stable
+    left-neighbor — the diffusion collapses (cccc / fragment-repeat) all originate
+    at positions 0-2. BOS is the natural choice: it is exactly the "start of
+    sequence" left-context the output is otherwise missing (it's tokenized with
+    ``add_special_tokens=False``), and serving strips a leading BOS during decode
+    (``skip_special_tokens``), so no output token is displaced. Returns ``None``
+    when the tokenizer has no BOS so the caller can warn and no-op rather than
+    inventing a spurious anchor id."""
+    return getattr(tokenizer, "bos_token_id", None)
+
+
+def tokenize_canvas_batch(
+    tokenizer,
+    canvas_length,
+    inputs,
+    outputs,
+    anchor_id=None,
+    supervise_termination=False,
+    pad_loss_weight=1.0,
+):
+    """Tokenize a batch of ``{input, output}`` rows into DiffusionGemma canvas
+    fields. The encoder side is the prompt tokenized as-is; the canvas side is the
+    output tokenized without special tokens (diffusion has no autoregressive
+    BOS/EOS stop) and padded/truncated to ``canvas_length``.
+
+    Returns clean canvas tokens (``canvas_input_ids``, pad-filled) and canvas
+    labels (``canvas_labels``, ``-100`` at padding). Live corruption is applied
+    later, per training step. Oversized outputs are truncated to the first
+    ``canvas_length`` tokens with a warning (budget-based subsampling, not a hard
+    error — mirrors the causal loader's over-budget document handling).
+
+    When ``anchor_id`` is not ``None``, it is prepended as a fixed anchor at canvas
+    position 0 (Tier-2 lever): the output budget shrinks to ``canvas_length - 1``,
+    the anchor is **supervised** (label = ``anchor_id``, so the model learns to
+    reproduce it at serve — no fork-side clamp required), and the corruption step
+    must keep position 0 clean (``protect_prefix=1``, wired from the training loop).
+    ``anchor_id=None`` reproduces the pre-anchor behavior byte-for-byte.
+
+    When ``supervise_termination`` is True, the whole fixed-length canvas is
+    supervised (answer + a terminating EOS + the pad tail) instead of masking the
+    tail with ``-100``: the tail labels become ``pad_id`` and one canvas slot is
+    reserved for the EOS. This fixes the train/serve canvas mismatch — the tail is
+    now (a) **corruptible** (``corrupt_canvas`` noises supervised positions, so the
+    answer trains under serve's noisy-init context) and (b) **targeted** (the model
+    learns answer→EOS→pad, so a from-noise decode terminates cleanly). See
+    docs/reports/2026-07-17-diffusiongemma-canvas-termination-plan.md.
+    ``supervise_termination=False`` reproduces the pre-termination behavior byte-for-byte.
+
+    When ``supervise_termination`` is True **and** ``pad_loss_weight != 1.0``, a
+    per-position ``canvas_loss_weight`` field is also returned (``1.0`` on the
+    anchor/answer/EOS positions, ``pad_loss_weight`` on the pad tail) so the training
+    step can down-weight the pad targets. It is omitted otherwise, keeping the
+    default and uniform-weight paths on the unchanged loss path."""
+    pad_id = pad_token_id(tokenizer)
+    # Append a terminating EOS so a from-noise serve decode learns to stop. Only
+    # when supervising the tail (a lone EOS with a -100 tail would be unsupervised
+    # noise); skip if the tokenizer has no EOS.
+    eos_id = tokenizer.eos_token_id if supervise_termination else None
+    append_eos = supervise_termination and eos_id is not None
+
+    prefix_len = 1 if anchor_id is not None else 0
+    # One canvas slot is consumed by the anchor and (when supervising) one by the
+    # EOS, so the raw-output budget shrinks accordingly.
+    output_budget = canvas_length - prefix_len - (1 if append_eos else 0)
+
+    encoder = tokenizer(inputs)
+    output_tokens = tokenizer(outputs, add_special_tokens=False)["input_ids"]
+
+    emit_weight = supervise_termination and pad_loss_weight != 1.0
+
+    canvas_input_ids = []
+    canvas_labels = []
+    canvas_loss_weight = [] if emit_weight else None
+    for toks in output_tokens:
+        if len(toks) > output_budget:
+            logger.warning(
+                "DiffusionGemma output has %d tokens > canvas budget %d "
+                "(canvas_length %d%s%s); truncating to the first %d.",
+                len(toks),
+                output_budget,
+                canvas_length,
+                " minus 1 anchor slot" if anchor_id is not None else "",
+                " minus 1 EOS slot" if append_eos else "",
+                output_budget,
+            )
+            toks = toks[:output_budget]
+
+        # Body = answer tokens plus the terminating EOS (when supervising).
+        body = list(toks) + ([eos_id] if append_eos else [])
+        # Anchor prefix: clean input token + supervised label, both fixed to
+        # anchor_id. corrupt_canvas(protect_prefix=1) keeps this slot clean so the
+        # model always conditions position 1 on a stable, real anchor.
+        prefix_input = [anchor_id] if anchor_id is not None else []
+        prefix_label = [anchor_id] if anchor_id is not None else []
+
+        pad = canvas_length - len(prefix_input) - len(body)
+        canvas_input_ids.append(prefix_input + body + [pad_id] * pad)
+        if supervise_termination:
+            # Supervise every canvas slot: the pad tail gets a real target (pad_id),
+            # making it both corruptible and a learned termination signal.
+            canvas_labels.append(prefix_label + body + [pad_id] * pad)
+            if emit_weight:
+                canvas_loss_weight.append(
+                    [1.0] * (len(prefix_label) + len(body)) + [pad_loss_weight] * pad
+                )
+        else:
+            canvas_labels.append(prefix_label + body + [-100] * pad)
+
+    result = {
+        "encoder_input_ids": encoder["input_ids"],
+        "encoder_attention_mask": encoder["attention_mask"],
+        "canvas_input_ids": canvas_input_ids,
+        "canvas_labels": canvas_labels,
+    }
+    if emit_weight:
+        result["canvas_loss_weight"] = canvas_loss_weight
+    return result

--- a/ml/cray_megatron/megatron/dataset/load_dataset.py
+++ b/ml/cray_megatron/megatron/dataset/load_dataset.py
@@ -1,14 +1,24 @@
 from cray_infra.util.get_job_config import get_job_config
 
+from cray_megatron.megatron.doc_mask import is_diffusion
 from cray_megatron.megatron.dataset.load_embedding_dataset import load_embedding_dataset
+from cray_megatron.megatron.dataset.load_diffusion_dataset import load_diffusion_dataset
 from cray_megatron.megatron.dataset.load_language_model_dataset import load_language_model_dataset
 
 def load_dataset(model, tokenizer, epoch):
-    """Load dataset for either language model or embedding model training."""
+    """Load dataset for language-model, diffusion, or embedding training.
+
+    DiffusionGemma is auto-detected from the model's HF config (is_diffusion),
+    not the training_mode string — the model class is the source of truth, and a
+    diffusion job needs the canvas loader regardless of what training_mode says.
+    The existing `model.config` access in the LM loader confirms the (wrapped)
+    model exposes `.config` here."""
     job_config = get_job_config()
     training_mode = job_config["training_mode"]
 
-    if training_mode == "embedding":
+    if is_diffusion(getattr(model, "config", None)):
+        return load_diffusion_dataset(model, tokenizer, epoch)
+    elif training_mode == "embedding":
         return load_embedding_dataset(model, tokenizer, epoch)
     else:
         return load_language_model_dataset(model, tokenizer, epoch)

--- a/ml/cray_megatron/megatron/dataset/load_diffusion_dataset.py
+++ b/ml/cray_megatron/megatron/dataset/load_diffusion_dataset.py
@@ -1,0 +1,188 @@
+"""Dataset loader for DiffusionGemma (`DiffusionGemmaForBlockDiffusion`).
+
+Unlike the causal-LM loader (``load_language_model_dataset.py``, which packs many
+documents into one block and builds document-masked position_ids), DiffusionGemma
+trains one example per fixed-size **canvas**: the ``input`` is encoded by the
+prompt encoder, and the ``output`` is the clean canvas the bidirectional decoder
+learns to denoise. There is no packing — a canvas is a fixed ``canvas_length``
+block, padded or truncated per example.
+
+This loader yields **clean** canvas tokens plus canvas labels. The live
+uniform-vocabulary corruption (sample ``t ~ U(eps, 1)`` per example, replace
+supervised canvas positions with a random vocab token w.p. ``t``) happens per
+training step in ``training_loop.training_step_accumulate`` — NOT here — so the
+corruption pattern is resampled fresh every step rather than frozen for a whole
+epoch (see the design spec §3).
+
+Fields produced per example:
+- ``encoder_input_ids`` / ``encoder_attention_mask`` — the prompt for the encoder.
+- ``canvas_input_ids`` — clean canvas tokens, length ``canvas_length``, padded
+  with the pad token (a valid embedding index; the decoder processes every canvas
+  slot).
+- ``canvas_labels`` — the clean token at every supervised canvas position, ``-100``
+  at padding (so padded slots are excluded from the cross-entropy loss).
+
+Batch size 1 is assumed (the finetune sweep's default): encoder prompts are
+variable length, which the default torch collate only stacks cleanly one row at a
+time. The canvas is always ``canvas_length``, so it stacks for any batch size.
+"""
+
+from cray_infra.util.get_job_config import get_job_config
+
+from cray_megatron.collectives.data_parallelism import (
+    get_data_parallel_rank,
+    get_data_parallel_world_size,
+)
+from cray_megatron.megatron.dataset.diffusion_canvas import (
+    anchor_token_id,
+    tokenize_canvas_batch,
+)
+
+import datasets
+import jsonlines
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Fallback canvas size if a job somehow omits the diffusion block. Matches the
+# DiffusionConfig default and the model's own config.canvas_length default.
+_DEFAULT_CANVAS_LENGTH = 256
+
+
+def load_diffusion_dataset(model, tokenizer, epoch):
+    canvas_length = _get_canvas_length()
+    anchor_id = _resolve_anchor_id(tokenizer)
+    supervise_termination = _supervise_termination()
+    pad_loss_weight = _pad_loss_weight()
+
+    hf_dataset = datasets.IterableDataset.from_generator(
+        make_dataset_generator(),
+        features=datasets.Features(
+            {
+                "input": datasets.Value(dtype="string"),
+                "output": datasets.Value(dtype="string"),
+            }
+        ),
+    )
+    shuffled_dataset = hf_dataset.shuffle(seed=42 + epoch, buffer_size=256)
+    split_dataset = split_dataset_by_node(shuffled_dataset)
+
+    tokenized_dataset = split_dataset.map(
+        get_canvas_tokenize_function(
+            tokenizer,
+            canvas_length,
+            anchor_id,
+            supervise_termination,
+            pad_loss_weight,
+        ),
+        batched=True,
+        remove_columns=["input", "output"],
+    )
+
+    torch_dataset = tokenized_dataset.with_format("torch")
+
+    return torch_dataset
+
+
+def make_dataset_generator():
+    def read_dataset():
+        dataset_path = get_dataset_path()
+        with open(dataset_path) as dataset_file:
+            reader = jsonlines.Reader(dataset_file)
+            for obj in reader:
+                yield obj
+
+    return read_dataset
+
+
+def get_dataset_path():
+    job_config = get_job_config()
+    return job_config["training_data_path"]
+
+
+def split_dataset_by_node(dataset):
+    data_parallel_rank = get_data_parallel_rank()
+    data_parallel_world_size = get_data_parallel_world_size()
+
+    filtered_dataset = dataset.filter(
+        lambda example, idx: idx % data_parallel_world_size == data_parallel_rank,
+        with_indices=True,
+    )
+
+    return filtered_dataset
+
+
+def _get_canvas_length():
+    job_config = get_job_config()
+    diffusion = job_config.get("diffusion") or {}
+    # job_config is a plain dict here; the nested block may be a dict or a
+    # pydantic model depending on the caller, so tolerate both.
+    if hasattr(diffusion, "canvas_length"):
+        return diffusion.canvas_length
+    return diffusion.get("canvas_length", _DEFAULT_CANVAS_LENGTH)
+
+
+def _anchor_enabled():
+    """Whether the Tier-2 anchor token is requested via the diffusion job config."""
+    job_config = get_job_config()
+    diffusion = job_config.get("diffusion") or {}
+    if hasattr(diffusion, "anchor_token"):
+        return bool(diffusion.anchor_token)
+    return bool(diffusion.get("anchor_token", False))
+
+
+def _supervise_termination():
+    """Whether to supervise the full canvas (answer + EOS + pad tail) instead of
+    masking the tail with -100. See diffusion_canvas.tokenize_canvas_batch and
+    docs/reports/2026-07-17-diffusiongemma-canvas-termination-plan.md."""
+    job_config = get_job_config()
+    diffusion = job_config.get("diffusion") or {}
+    if hasattr(diffusion, "supervise_termination"):
+        return bool(diffusion.supervise_termination)
+    return bool(diffusion.get("supervise_termination", False))
+
+
+def _pad_loss_weight():
+    """Relative CE weight on the supervised pad tail (only meaningful when
+    supervise_termination is on and != 1.0). 1.0 = uniform."""
+    job_config = get_job_config()
+    diffusion = job_config.get("diffusion") or {}
+    if hasattr(diffusion, "pad_loss_weight"):
+        return float(diffusion.pad_loss_weight)
+    return float(diffusion.get("pad_loss_weight", 1.0))
+
+
+def _resolve_anchor_id(tokenizer):
+    """Resolve the anchor token id when enabled, else None. Warns and disables the
+    anchor if the tokenizer has no BOS rather than inventing a spurious id."""
+    if not _anchor_enabled():
+        return None
+    anchor_id = anchor_token_id(tokenizer)
+    if anchor_id is None:
+        logger.warning(
+            "diffusion.anchor_token is set but the tokenizer has no bos_token_id; "
+            "training without a canvas anchor."
+        )
+    return anchor_id
+
+
+def get_canvas_tokenize_function(
+    tokenizer,
+    canvas_length,
+    anchor_id=None,
+    supervise_termination=False,
+    pad_loss_weight=1.0,
+):
+    def tokenize(dataset):
+        return tokenize_canvas_batch(
+            tokenizer,
+            canvas_length,
+            dataset["input"],
+            dataset["output"],
+            anchor_id,
+            supervise_termination,
+            pad_loss_weight,
+        )
+
+    return tokenize

--- a/ml/cray_megatron/megatron/determinism.py
+++ b/ml/cray_megatron/megatron/determinism.py
@@ -1,0 +1,43 @@
+"""Training-RNG seeding, split into its own torch-only module so it can be
+unit-tested without importing the full training loop (which pulls in
+``gpu_aware_mpi`` and the rest of the harness).
+
+DiffusionGemma (and any LoRA run) draws three stochastic inputs from the global
+torch RNG: PEFT's ``lora_A`` kaiming init (the adapter's starting point), the
+per-step canvas corruption (``corrupt_canvas(generator=None)``), and the
+self-conditioning subset mask (``torch.rand``). With no seed set, every fresh run
+is a different draw — which is why an identical config lands in the clean-serving
+basin or the degenerate ``cccc`` attractor by luck (see
+docs/reports/2026-07-16-diffusiongemma-validation-runs.md, "State archaeology").
+Seeding once — before the adapter is built — makes the whole init+train sequence
+deterministic and, crucially, *searchable*: sweep seeds to find one that lands
+clean, then pin it.
+"""
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def apply_seed(seed):
+    """Seed the global torch RNG (CPU + all CUDA devices) for deterministic
+    training. Call once at the very start of ``train()``, before the model/adapter
+    is materialized, so the LoRA init and every subsequent global-RNG draw form one
+    reproducible sequence.
+
+    ``seed=None`` is a no-op (returns ``False``) — the historical non-deterministic
+    behavior, so runs without the knob are byte-identical to before. Returns
+    ``True`` when a seed was applied.
+    """
+    if seed is None:
+        return False
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    logger.info(
+        "Training RNG seeded with %d (deterministic LoRA init + corruption + SC mask).",
+        seed,
+    )
+    return True

--- a/ml/cray_megatron/megatron/diffusion_corruption.py
+++ b/ml/cray_megatron/megatron/diffusion_corruption.py
@@ -1,0 +1,78 @@
+"""Live canvas corruption for DiffusionGemma training.
+
+Factored out of the training loop so the corruption schedule can be unit-tested in
+isolation (seeded RNG, in-vocab replacement, supervised-only masking) without the
+full training harness. See the design spec §3 and ADR 0007.
+"""
+
+import torch
+
+
+def corrupt_canvas(
+    canvas_input_ids,
+    canvas_labels,
+    vocab_size,
+    eps,
+    generator=None,
+    protect_prefix=0,
+    return_noise_level=False,
+):
+    """Uniform-state discrete-diffusion corruption of a clean canvas.
+
+    Samples ``t ~ U(eps, 1)`` per example, then independently replaces each
+    *supervised* canvas position (``canvas_labels != -100``) with a uniform-random
+    vocabulary token with probability ``t``. There is no ``[MASK]`` token — the
+    replacements are ordinary in-vocabulary tokens. Padding positions
+    (``canvas_labels == -100``) are never corrupted (they keep the pad token and are
+    excluded from the loss).
+
+    Args:
+        canvas_input_ids: ``(B, canvas_length)`` clean canvas tokens (pad-filled).
+        canvas_labels:    ``(B, canvas_length)`` clean tokens at supervised
+                          positions, ``-100`` at padding.
+        vocab_size:       upper bound (exclusive) for random replacement tokens.
+        eps:              minimum corruption level (``t`` is drawn from ``[eps, 1)``).
+        generator:        optional ``torch.Generator`` for reproducible tests. When
+                          ``None`` the global RNG is used (which the checkpoint
+                          resume restores, keeping resumed runs bit-identical).
+        protect_prefix:   number of leading canvas positions to keep clean regardless
+                          of their label (Tier-2 anchor: position 0 is a supervised
+                          anchor that must never be corrupted so it stays a stable
+                          left-neighbor). 0 (default) = original behavior.
+        return_noise_level: when True, also return the per-example corruption level
+                          ``t`` (shape ``(B, 1)``, float). This is the diffusion
+                          "noise level" ``lambda`` that a noise-aware adapter (NaRA,
+                          see ml/adapters/nara_prototype.py) conditions its low-rank
+                          update on. Default False = byte-identical prior behavior
+                          (returns only ``decoder_input_ids``).
+
+    Returns:
+        ``(B, canvas_length)`` corrupted ``decoder_input_ids``, same dtype/device as
+        ``canvas_input_ids``. When ``return_noise_level`` is True, returns the tuple
+        ``(decoder_input_ids, t)`` where ``t`` is ``(B, 1)`` float.
+    """
+    device = canvas_input_ids.device
+    batch_sz, canvas_len = canvas_input_ids.shape
+
+    t = torch.rand(batch_sz, 1, device=device, generator=generator) * (1.0 - eps) + eps
+    supervised = canvas_labels != -100
+    if protect_prefix > 0:
+        # Force the first `protect_prefix` positions out of the supervised (thus
+        # corruptible) set — the anchor stays clean every step.
+        supervised = supervised.clone()
+        supervised[:, :protect_prefix] = False
+    corrupt_mask = (
+        torch.rand(batch_sz, canvas_len, device=device, generator=generator) < t
+    ) & supervised
+    random_tokens = torch.randint(
+        0,
+        vocab_size,
+        (batch_sz, canvas_len),
+        device=device,
+        dtype=canvas_input_ids.dtype,
+        generator=generator,
+    )
+    decoder_input_ids = torch.where(corrupt_mask, random_tokens, canvas_input_ids)
+    if return_noise_level:
+        return decoder_input_ids, t
+    return decoder_input_ids

--- a/ml/cray_megatron/megatron/doc_mask.py
+++ b/ml/cray_megatron/megatron/doc_mask.py
@@ -7,22 +7,47 @@ attend across each other (see ``pack()`` in
 ``training_loop.py``). Plain text decoders (Llama, Qwen, Gemma3ForCausalLM)
 accept the 4D mask.
 
-But some ``...ForConditionalGeneration`` wrappers compute their loss internally
-and index the logits by a *2D* attention_mask. Gemma3ForConditionalGeneration
-does ``shift_logits[shift_attention_mask != 0]`` (transformers
-``modeling_gemma3.py``); handed a 4D mask that index is 4D and raises
-``IndexError: too many indices for tensor of dimension 3`` — the gemma-3-4b-it
-TRAIN_FAILED in the cuda-spark fine-tune sweep. For those models we fall back to
-the 2D padding mask. The documented cost is that packed documents attend across
-each other (identical to the existing seq-len-cap fallback); for the
-single-document memorization sweep the 4D mask is a no-op anyway.
+But some models can't consume the 4D mask:
+
+- ``...ForConditionalGeneration`` wrappers compute their loss internally and index
+  the logits by a *2D* attention_mask. Gemma3ForConditionalGeneration does
+  ``shift_logits[shift_attention_mask != 0]`` (transformers ``modeling_gemma3.py``);
+  handed a 4D mask that index is 4D and raises ``IndexError: too many indices for
+  tensor of dimension 3`` — the gemma-3-4b-it TRAIN_FAILED in the cuda-spark
+  fine-tune sweep.
+- Hybrid state-space (Mamba/SSM) models run a kernel-less ``torch_forward`` mixer
+  (no ``mamba_ssm``/``causal_conv1d`` on this aarch64 box) that "tunes out" pad
+  tokens with ``hidden_states * attention_mask[:, :, None]``, assuming a *2D*
+  padding mask. NemotronH's ``_update_mamba_mask`` forwards whatever mask the model
+  was called with straight to that path, so a 4D mask broadcasts to 5D and raises
+  ``The size of tensor a (4096) must match the size of tensor b (496) at
+  non-singleton dimension 4`` — the Nemotron-H-8B TRAIN_FAILED.
+
+For those models we fall back to the 2D padding mask. The documented cost is that
+packed documents attend across each other (identical to the existing seq-len-cap
+fallback); for the single-document memorization sweep the 4D mask is a no-op anyway.
 """
 
 # Decision outcomes for doc_mask_decision().
 BUILD = "build"                    # construct the 4D block-diagonal+causal mask
 SKIP_MULTIMODAL = "skip_multimodal"  # wrapper masks loss by a 2D mask; keep 2D
+SKIP_SSM = "skip_ssm"              # hybrid Mamba/SSM mixer needs a 2D mask; keep 2D
 SKIP_SEQLEN = "skip_seqlen"        # mask too large to materialize; keep 2D
 NONE = "none"                      # batch isn't packed (no document_ids)
+
+# Config ``model_type``s of the hybrid Mamba/SSM families the sweep has seen whose
+# kernel-less mixer path needs a 2D mask. A per-layer block-type list
+# (``layers_block_type``/``hybrid_override_pattern``: NemotronH / Jamba / Bamba) is
+# the most reliable signal; this set catches families that don't expose one
+# (FalconH1's Mamba-2 ‖ attention, GraniteMoeHybrid).
+_SSM_MODEL_TYPES = {
+    "nemotron_h",
+    "falcon_h1",
+    "granitemoehybrid",
+    "bamba",
+    "zamba2",
+    "jamba",
+}
 
 
 def is_multimodal(model_config) -> bool:
@@ -34,23 +59,49 @@ def is_multimodal(model_config) -> bool:
     return getattr(model_config, "vision_config", None) is not None
 
 
+def has_ssm_layers(model_config) -> bool:
+    """True for hybrid state-space (Mamba/SSM) model configs whose kernel-less
+    ``torch_forward`` mixer multiplies hidden states by a *2D* padding mask
+    (``hidden_states * attention_mask[:, :, None]``) and so CANNOT consume the 4D
+    block-diagonal doc mask — handed a 4D mask it broadcasts to 5D and raises
+    ``... at non-singleton dimension 4`` (the Nemotron-H-8B TRAIN_FAILED).
+
+    Detected from the config alone (the model isn't available here): a per-layer
+    block-type list naming a mamba block (NemotronH ``layers_block_type`` / Jamba /
+    Bamba), a ``hybrid_override_pattern`` marker, or a known hybrid ``model_type``
+    (``_SSM_MODEL_TYPES``)."""
+    if model_config is None:
+        return False
+    block_types = getattr(model_config, "layers_block_type", None)
+    if block_types and any("mamba" in str(bt).lower() for bt in block_types):
+        return True
+    if getattr(model_config, "hybrid_override_pattern", None):
+        return True
+    model_type = getattr(model_config, "model_type", None) or ""
+    return model_type in _SSM_MODEL_TYPES
+
+
 def doc_mask_decision(batch, seq_len: int, model_config, max_4d_mask_seq_len: int) -> str:
     """Return how to handle packed-document attention for this batch:
 
     - ``NONE``            — the batch isn't packed (no ``document_ids``).
     - ``SKIP_MULTIMODAL`` — a multimodal wrapper that masks its loss by a 2D
       attention_mask; a 4D mask would break that index. Keep the 2D mask.
+    - ``SKIP_SSM``        — a hybrid Mamba/SSM model whose kernel-less mixer needs
+      a 2D mask; a 4D mask broadcasts to 5D and crashes. Keep the 2D mask.
     - ``SKIP_SEQLEN``     — the mask would exceed ``max_4d_mask_seq_len``; keep
       the 2D mask (legacy fallback).
     - ``BUILD``           — construct the 4D block-diagonal+causal mask.
 
-    The multimodal check takes precedence over the seq-len cap: both fall back
-    to the 2D mask, but the multimodal reason is the one worth surfacing.
+    The multimodal and SSM checks take precedence over the seq-len cap: all three
+    fall back to the 2D mask, but the model-shape reason is the one worth surfacing.
     """
     if "document_ids" not in batch:
         return NONE
     if is_multimodal(model_config):
         return SKIP_MULTIMODAL
+    if has_ssm_layers(model_config):
+        return SKIP_SSM
     if seq_len > max_4d_mask_seq_len:
         return SKIP_SEQLEN
     return BUILD

--- a/ml/cray_megatron/megatron/doc_mask.py
+++ b/ml/cray_megatron/megatron/doc_mask.py
@@ -59,6 +59,19 @@ def is_multimodal(model_config) -> bool:
     return getattr(model_config, "vision_config", None) is not None
 
 
+def is_diffusion(model_config) -> bool:
+    """True for DiffusionGemma configs (``DiffusionGemmaForBlockDiffusion``), the
+    discrete-diffusion encoder-decoder MoE. Detected by ``model_type`` rather than
+    a wrapper attribute because a diffusion config ALSO carries a ``vision_config``
+    (so ``is_multimodal`` is likewise True) and its own ``model_type`` is the only
+    field that distinguishes it — the load path must check this *before* the
+    multimodal/causal fork so it isn't misrouted to ``AutoModelForImageTextToText``.
+    See ``docs/superpowers/specs/2026-07-01-diffusiongemma-design.md`` and ADR 0007."""
+    if model_config is None:
+        return False
+    return getattr(model_config, "model_type", None) == "diffusion_gemma"
+
+
 def has_ssm_layers(model_config) -> bool:
     """True for hybrid state-space (Mamba/SSM) model configs whose kernel-less
     ``torch_forward`` mixer multiplies hidden states by a *2D* padding mask

--- a/ml/cray_megatron/megatron/training_loop.py
+++ b/ml/cray_megatron/megatron/training_loop.py
@@ -10,9 +10,13 @@ from cray_megatron.models.get_latest_checkpoint_path import (
 from cray_megatron.collectives.main_rank_only import main_rank_only, is_main_rank
 from cray_megatron.megatron.training_harness import TrainingHarness
 from cray_megatron.megatron import stop_flag
+from cray_megatron.megatron.diffusion_corruption import corrupt_canvas
+from cray_megatron.megatron.dataset.diffusion_canvas import anchor_token_id
+from cray_megatron.megatron.determinism import apply_seed
 from cray_megatron.megatron.doc_mask import (
     doc_mask_decision,
     is_multimodal,
+    is_diffusion,
     BUILD,
     SKIP_SEQLEN,
     SKIP_MULTIMODAL,
@@ -213,6 +217,12 @@ class TrainingLoop:
         self.training_state = TrainingState()
 
     def train(self):
+        # Seed BEFORE load_model() so PEFT's lora_A init and every subsequent
+        # global-RNG draw (corruption, SC mask) form one deterministic sequence.
+        # On resume, checkpoint RNG-state restore (inside load_model) overrides
+        # this, keeping resumed slices bit-identical. No-op when seed is unset.
+        apply_seed(get_job_config().get("seed"))
+
         self.model_manager = get_model_manager()
 
         self.training_state.model_info = self.model_manager.load_model()
@@ -452,6 +462,18 @@ class TrainingLoop:
 
     def training_step_accumulate(self, batch, accum_step, gradient_accumulation_steps):
         """Perform a single forward/backward pass with gradient accumulation."""
+        model_config = self.training_state.model_info.get("model_config")
+
+        # DiffusionGemma has a wholly different forward contract: encoder prompt +
+        # corrupted canvas in, canvas logits out (NO `labels` kwarg, NO internal
+        # `.loss`), with live per-step corruption. It also doesn't use packed-
+        # document masking. Handle it on its own path rather than threading branches
+        # through the causal construction below.
+        if is_diffusion(model_config):
+            return self._diffusion_training_step_accumulate(
+                batch, accum_step, gradient_accumulation_steps
+            )
+
         device = self.training_state.model_info["distribution_strategy"]["device"]
 
         start_time = time.time()
@@ -554,6 +576,190 @@ class TrainingLoop:
         self.print_microbatch_info(accum_step, avg_loss, start_time)
 
         return avg_loss
+
+    def _diffusion_training_step_accumulate(
+        self, batch, accum_step, gradient_accumulation_steps
+    ):
+        """DiffusionGemma canvas-denoising training step.
+
+        The model encodes ``encoder_input_ids`` into a prompt KV cache and denoises
+        a corrupted canvas, returning canvas logits ``(B, canvas_length, vocab)``.
+        Unlike the causal path it takes NO ``labels`` kwarg and computes NO internal
+        ``.loss`` — so the corrupted canvas is built here (resampled fresh every
+        step) and the cross-entropy against the clean canvas labels is computed
+        explicitly. See ``load_diffusion_dataset.py`` and the design spec §3."""
+        device = self.training_state.model_info["distribution_strategy"]["device"]
+        model = self.training_state.model_info["model"]
+        model_config = self.training_state.model_info.get("model_config")
+
+        start_time = time.time()
+
+        encoder_input_ids = batch["encoder_input_ids"].to(device)
+        encoder_attention_mask = batch["encoder_attention_mask"].to(device)
+        canvas_input_ids = batch["canvas_input_ids"].to(device)  # clean, pad-filled
+        canvas_labels = batch["canvas_labels"].to(device)        # clean, -100 on pad
+
+        vocab_size = model_config.text_config.vocab_size
+        eps = self._diffusion_eps()
+
+        # Live uniform-vocabulary corruption, resampled every step (baking it into a
+        # dataset .map would freeze one pattern per epoch). generator=None uses the
+        # global RNG, which the checkpoint resume restores. See diffusion_corruption.
+        # protect_prefix keeps the Tier-2 anchor (canvas position 0) clean every
+        # step; resolved from the SAME tokenizer/config the loader used so the
+        # protected count exactly matches the anchor the canvas actually carries
+        # (0 when the anchor is disabled or the tokenizer lacks BOS).
+        protect_prefix = 1 if self._diffusion_anchor_id() is not None else 0
+
+        # NaRA (noise-aware LoRA): the per-example corruption level t IS the noise
+        # level lambda the adapter conditions on. When NaRA is active, capture t and
+        # push it into the shared hypernetwork BEFORE any forward pass (both the
+        # self-conditioning no-grad pass and the gradient pass see the same Ceff).
+        # See ADR 0012 and adapters/nara_prototype.py.
+        nara_context = self._diffusion_nara_context()
+        if nara_context is not None:
+            decoder_input_ids, noise_level = corrupt_canvas(
+                canvas_input_ids, canvas_labels, vocab_size, eps,
+                protect_prefix=protect_prefix, return_noise_level=True,
+            )
+            nara_context.set_noise_level(noise_level)
+        else:
+            decoder_input_ids = corrupt_canvas(
+                canvas_input_ids, canvas_labels, vocab_size, eps,
+                protect_prefix=protect_prefix,
+            )
+
+        base_kwargs = {
+            "input_ids": encoder_input_ids,
+            "attention_mask": encoder_attention_mask,
+            "decoder_input_ids": decoder_input_ids,
+        }
+        # DiffusionGemmaEncoderModel is "very similar to Gemma4Model", whose
+        # ...ForConditionalGeneration lineage can crash without mm_token_type_ids on
+        # text-only batches despite it being documented optional. Pass zeros
+        # defensively (flows to the encoder via **kwargs).
+        if is_multimodal(model_config):
+            base_kwargs["mm_token_type_ids"] = torch.zeros_like(encoder_input_ids)
+
+        # Self-conditioning (Analog-Bits scheme). At serve the diffusion sampler
+        # feeds each denoise step's prediction back as the next step's
+        # self-conditioning signal; a model trained with self_conditioning=None
+        # never sees that feedback, so iterative serve decode misconverges the
+        # early canvas positions (the exact-hash near-miss). To match serve, run
+        # a no-grad pass to predict the clean canvas, then feed that prediction
+        # back as the self-conditioning signal on the gradient-carrying pass for
+        # a random ~sc_prob subset of the batch (the per-example mask teaches both
+        # the conditioned and unconditioned modes, so step-1 — which has no prior
+        # prediction — still works). sc_prob=0 restores the single-pass v1 path.
+        sc_prob = self._diffusion_self_conditioning_prob()
+        if sc_prob > 0.0:
+            with torch.no_grad():
+                sc_logits = model(
+                    **base_kwargs,
+                    self_conditioning_logits=None,
+                    self_conditioning_mask=None,
+                ).logits.detach()
+            sc_mask = torch.rand(decoder_input_ids.size(0), device=device) < sc_prob
+            forward_kwargs = {
+                **base_kwargs,
+                "self_conditioning_logits": sc_logits,
+                "self_conditioning_mask": sc_mask,
+            }
+        else:
+            forward_kwargs = {
+                **base_kwargs,
+                "self_conditioning_logits": None,
+                "self_conditioning_mask": None,
+            }
+
+        outputs = model(**forward_kwargs)
+        logits = outputs.logits  # (B, canvas_length, vocab)
+
+        # fp32 CE for numerical stability; ignore padded canvas slots.
+        # When supervise_termination emits a per-position canvas_loss_weight (only
+        # when pad_loss_weight != 1.0), down-weight the supervised pad-tail targets
+        # so the ~230 pad positions don't swamp the ~24 answer/EOS targets. The
+        # weight comes from the loader (not label==pad_id) so it stays unambiguous
+        # if an answer ever contains the pad token. Absent it, the loss is byte-
+        # identical to the prior uniform CE.
+        canvas_loss_weight = batch.get("canvas_loss_weight")
+        if canvas_loss_weight is not None:
+            per_position = torch.nn.functional.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                canvas_labels.reshape(-1),
+                ignore_index=-100,
+                reduction="none",
+            )
+            weights = canvas_loss_weight.to(device).reshape(-1).to(per_position.dtype)
+            loss = (per_position * weights).sum() / weights.sum().clamp_min(1e-8)
+        else:
+            loss = torch.nn.functional.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                canvas_labels.reshape(-1),
+                ignore_index=-100,
+            )
+
+        scaled_loss = loss / gradient_accumulation_steps
+        _, avg_loss = self.sync_loss(loss)
+        scaled_loss.backward()
+
+        self.print_microbatch_info(accum_step, avg_loss, start_time)
+        return avg_loss
+
+    def _diffusion_nara_context(self):
+        """Return the model's NaRAContext when NaRA is enabled for this job, else None.
+        Resolved once and cached (the module tree doesn't change after load). Walks the
+        module tree so it works regardless of distribution-strategy wrapping. See
+        adapters/nara_prototype.find_nara_context and ADR 0012."""
+        if getattr(self, "_nara_context_resolved", False):
+            return self._nara_context_cache
+
+        self._nara_context_resolved = True
+        self._nara_context_cache = None
+
+        job_config = get_job_config()
+        diffusion = job_config.get("diffusion") or {}
+        nara = diffusion.nara if hasattr(diffusion, "nara") else diffusion.get("nara")
+        if nara is not None:
+            enabled = nara.enabled if hasattr(nara, "enabled") else nara.get("enabled", False)
+            if enabled:
+                from adapters.nara_prototype import find_nara_context
+                self._nara_context_cache = find_nara_context(
+                    self.training_state.model_info["model"]
+                )
+        return self._nara_context_cache
+
+    def _diffusion_eps(self):
+        job_config = get_job_config()
+        diffusion = job_config.get("diffusion") or {}
+        if hasattr(diffusion, "eps"):
+            return diffusion.eps
+        return diffusion.get("eps", 0.001)
+
+    def _diffusion_anchor_id(self):
+        """Resolve the Tier-2 canvas anchor id when enabled, else None — mirrors
+        load_diffusion_dataset._resolve_anchor_id so the per-step protect_prefix
+        matches the anchor the loader baked into the canvas."""
+        job_config = get_job_config()
+        diffusion = job_config.get("diffusion") or {}
+        if hasattr(diffusion, "anchor_token"):
+            enabled = bool(diffusion.anchor_token)
+        else:
+            enabled = bool(diffusion.get("anchor_token", False))
+        if not enabled:
+            return None
+        tokenizer = self.training_state.model_info["tokenizer"]
+        return anchor_token_id(tokenizer)
+
+    def _diffusion_self_conditioning_prob(self):
+        """Per-step probability of feeding the model's own prediction back as the
+        self-conditioning signal during training (0 disables the two-pass scheme).
+        Default 0.5 per Analog-Bits; see _diffusion_training_step_accumulate."""
+        job_config = get_job_config()
+        diffusion = job_config.get("diffusion") or {}
+        if hasattr(diffusion, "self_conditioning_prob"):
+            return diffusion.self_conditioning_prob
+        return diffusion.get("self_conditioning_prob", 0.5)
 
     def optimizer_step(self):
         """Perform optimizer and scheduler step after gradient accumulation."""

--- a/ml/cray_megatron/megatron/training_loop.py
+++ b/ml/cray_megatron/megatron/training_loop.py
@@ -16,6 +16,7 @@ from cray_megatron.megatron.doc_mask import (
     BUILD,
     SKIP_SEQLEN,
     SKIP_MULTIMODAL,
+    SKIP_SSM,
 )
 
 from cray_infra.training.training_job_status import TrainingJobStatus
@@ -46,6 +47,7 @@ logger = logging.getLogger(__name__)
 _MAX_4D_MASK_SEQ_LEN = 16384
 _doc_mask_skip_warned = False
 _doc_mask_multimodal_warned = False
+_doc_mask_ssm_warned = False
 
 
 def _warn_doc_mask_skipped(seq_len: int) -> None:
@@ -71,6 +73,20 @@ def _warn_doc_mask_skipped_multimodal() -> None:
         "attention_mask (e.g. Gemma3ForConditionalGeneration indexes shift_logits "
         "by it), so a 4D mask raises IndexError. Falling back to the 2D mask; "
         "packed documents will attend across each other in this run."
+    )
+
+
+def _warn_doc_mask_skipped_ssm() -> None:
+    global _doc_mask_ssm_warned
+    if _doc_mask_ssm_warned:
+        return
+    _doc_mask_ssm_warned = True
+    logger.warning(
+        "Skipping 4D document mask: hybrid Mamba/SSM model. Its kernel-less "
+        "torch_forward mixer multiplies hidden states by a 2D padding mask, so a "
+        "4D mask broadcasts to 5D and crashes (NemotronH). Falling back to the 2D "
+        "mask; packed documents will attend across each other in this run. (The "
+        "flex_attention BlockMask can't be consumed by the SSM path either.)"
     )
 
 
@@ -465,6 +481,13 @@ class TrainingLoop:
             # the logits by a 2D attention_mask (gemma-3-4b-it). Keep the 2D mask
             # from the batch — a 4D mask (SDPA or flex BlockMask) would IndexError.
             _warn_doc_mask_skipped_multimodal()
+        elif decision == SKIP_SSM:
+            # A hybrid Mamba/SSM model (NemotronH, …). Its kernel-less mixer
+            # torch_forward does `hidden_states * attention_mask[:, :, None]`,
+            # assuming a 2D mask; a 4D mask (SDPA or flex) broadcasts to 5D and
+            # crashes. Keep the 2D mask from the batch — never build, even under
+            # flex_attention (the SSM path can't consume a BlockMask either).
+            _warn_doc_mask_skipped_ssm()
         elif decision == BUILD or (decision == SKIP_SEQLEN and use_flex):
             # BUILD, or a sequence past the SDPA cap when flex_attention is on —
             # the flex BlockMask is O(S/128), so _MAX_4D_MASK_SEQ_LEN doesn't apply.

--- a/ml/nara_offline_eval.py
+++ b/ml/nara_offline_eval.py
@@ -1,0 +1,898 @@
+#!/usr/bin/env python3
+"""Offline NaRA memorize eval for DiffusionGemma.
+
+Serving NaRA is deferred (ADR 0012): the fork's static .pt adapter path can't
+reconstruct dW(t)=B·C(t)·A. This runs the model's OWN native block-diffusion
+`generate()` decode in-process with the NaRA adapter injected, hooking the shared
+mapper into every denoising step (noise level t = fraction of not-yet-accepted
+canvas positions, exactly training's corruption fraction), then scores the decoded
+output against the golden string.
+
+Runs three decodes from the SAME seed (so the only variable is the adapter):
+  BASE          - no adapter
+  LORA_ONLY     - NaRA adapter, mapper forced to identity (Ceff=I) => plain B·A
+  NARA          - NaRA adapter, mapper active per denoising step
+Reports difflib longest-block and total-match scores vs golden for each.
+
+Usage (inside the cray container):
+  python nara_offline_eval.py --checkpoint /app/cray/.../checkpoint_449.pt \
+      --model google/diffusiongemma-26B-A4B-it \
+      --prompt "My bank account's balance is" \
+      --golden aaaf6f8ae738dfc6577e63dda6daf9cc --seed 42
+"""
+import argparse, sys, time, difflib, json, random
+
+sys.path.insert(0, "/app/cray/ml")
+sys.path.insert(0, "/app/cray/infra")
+
+import torch
+
+
+def block_scores(sample: str, golden: str, prompt: str = ""):
+    """Sweep-reference scorer (~/block.py): longest contiguous match + total matched
+    chars via difflib, GOLDEN first. The sweep scored the generated hex only, so strip
+    the prompt prefix. autojunk=False so a long canvas decode isn't mangled (block.py's
+    inputs were short enough that autojunk never triggered — equivalent on those)."""
+    if prompt and sample.startswith(prompt):
+        sample = sample[len(prompt):].lstrip()
+    sm = difflib.SequenceMatcher(None, golden, sample, autojunk=False)
+    m = sm.find_longest_match(0, len(golden), 0, len(sample))
+    total = sum(b.size for b in sm.get_matching_blocks())
+    return m.size, total
+
+
+def load_base(model_id, dtype=torch.bfloat16):
+    from transformers import AutoTokenizer
+    from transformers.models.diffusion_gemma import DiffusionGemmaForBlockDiffusion
+    t0 = time.time()
+    tok = AutoTokenizer.from_pretrained(model_id)
+    model = DiffusionGemmaForBlockDiffusion.from_pretrained(
+        model_id, dtype=dtype, device_map={"": 0},
+    )
+    model.eval()
+    print(f"[load] base model+tokenizer ({dtype}) in {time.time()-t0:.1f}s", flush=True)
+    return model, tok
+
+
+def inject_and_load(model, ckpt_path):
+    """Inject NaRA into exactly the modules the checkpoint adapted, then load the
+    lora + mapper weights. Returns (context, report)."""
+    from adapters.nara_prototype import inject_nara, NaRAConfig, find_nara_context
+
+    sd = torch.load(ckpt_path, map_location="cpu")["model_state_dict"]
+    lora_keys = [k for k in sd if ".lora_A" in k]
+    # backbone-relative module paths -> outer-model paths (outer.model.<path>)
+    mod_paths = sorted({k.rsplit(".lora_A", 1)[0] for k in lora_keys})
+    outer_targets = ["model." + p for p in mod_paths]
+    r = sd[lora_keys[0]].shape[0]
+    mapper_keys = [k for k in sd if "nara_context.mapper" in k]
+
+    cfg = NaRAConfig(r=r, lora_alpha=2 * r, lora_dropout=0.0, c_scale=0.1)
+    inject_nara(model, outer_targets, cfg)
+
+    # checkpoint keys are backbone-relative => load into the backbone (model.model)
+    missing, unexpected = model.model.load_state_dict(sd, strict=False)
+    # inject_nara created the adapter (lora_A/B) + mapper params on CPU in float32;
+    # the base is on GPU in bf16 (device_map load). Training moves everything with
+    # model.to(device) AFTER inject — mirror that so the adapter matches the base
+    # device+dtype (else: 'mat2 is on cpu, other tensors on cuda').
+    base_p = next(model.parameters())
+    model.model.to(device=base_p.device, dtype=base_p.dtype)
+    loaded_lora = [k for k in sd if ".lora_" in k]
+    # sanity: adapter B must be non-zero after load (trained), mapper present+loaded
+    some_B = [model.model.state_dict()[k] for k in sd if k.endswith(".lora_B")][:50]
+    b_nonzero = sum(float(b.abs().sum() > 0) for b in some_B)
+    report = {
+        "adapted_modules": len(mod_paths), "rank": r,
+        "lora_tensors_loaded": len(loaded_lora), "mapper_tensors": len(mapper_keys),
+        "unexpected_keys": [k for k in unexpected], "b_nonzero_of_50": b_nonzero,
+    }
+    ctx = find_nara_context(model)
+    return ctx, report
+
+
+def make_mapper_hook(model, ctx, eps):
+    """Wrap _denoising_step so the shared mapper sees the current noise level
+    (fraction of not-yet-accepted canvas positions) before each decoder forward."""
+    orig = model._denoising_step
+    steps_seen = {"n": 0, "t_first": None, "t_last": None}
+
+    def find_sampler(args, kwargs):
+        s = kwargs.get("sampler")
+        if s is not None:
+            return s
+        for a in args:
+            if a.__class__.__name__ == "EntropyBoundSampler":
+                return a
+        return None
+
+    def wrapped(*args, **kwargs):
+        s = find_sampler(args, kwargs)
+        am = getattr(s, "accepted_token_mask", None) if s is not None else None
+        if am is None:
+            t = 1.0
+        else:
+            t = float((~am).float().mean().item())
+        t = max(t, eps)
+        ctx.set_noise_level(torch.tensor([t], dtype=torch.float32))
+        steps_seen["n"] += 1
+        if steps_seen["t_first"] is None:
+            steps_seen["t_first"] = t
+        steps_seen["t_last"] = t
+        return orig(*args, **kwargs)
+
+    model._denoising_step = wrapped
+    return steps_seen
+
+
+def decode(model, tok, prompt, seed, gen_kwargs):
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    enc = tok(prompt, return_tensors="pt").to(model.device)
+    with torch.no_grad():
+        out = model.generate(input_ids=enc.input_ids, attention_mask=enc.attention_mask,
+                             **gen_kwargs)
+    seq = out.sequences if hasattr(out, "sequences") else out
+    text = tok.decode(seq[0], skip_special_tokens=True)
+    return text
+
+
+def get_vocab_size(model, tok):
+    """Full embedding vocab (the corruption sampler's upper bound), matching
+    training's model_config.text_config.vocab_size. Falls back to config.vocab_size
+    then the tokenizer length."""
+    cfg = getattr(model, "config", None)
+    for path in (("text_config", "vocab_size"), ("vocab_size",)):
+        obj = cfg
+        for p in path:
+            obj = getattr(obj, p, None)
+            if obj is None:
+                break
+        if isinstance(obj, int):
+            return obj
+    return len(tok)
+
+
+def needs_mm_token(model):
+    """Mirror training's is_multimodal(model_config): a vision_config anywhere on
+    the config means the encoder wants mm_token_type_ids even on text-only input."""
+    cfg = getattr(model, "config", None)
+    tc = getattr(cfg, "text_config", cfg)
+    return getattr(cfg, "vision_config", None) is not None or getattr(tc, "vision_config", None) is not None
+
+
+def build_golden_canvas(tok, golden, canvas_length, anchor):
+    """Build the golden output canvas exactly as the training loader does
+    (diffusion_canvas.tokenize_canvas_batch): output tokenized WITHOUT special
+    tokens, optional BOS anchor at position 0, pad to canvas_length. Returns
+    (canvas_input_ids, canvas_labels, n_protect) as plain python lists. When
+    canvas_length<=0 the canvas is fit tight to the golden (no trailing pad) — the
+    pad slots are label=-100 (loss-ignored) so they don't affect the probe; pass the
+    job's real canvas_length for byte-exact bidirectional-attention faithfulness."""
+    pad_id = tok.pad_token_id
+    if pad_id is None:
+        pad_id = tok.eos_token_id
+    if pad_id is None:
+        pad_id = 0
+    anchor_id = getattr(tok, "bos_token_id", None) if anchor else None
+    prefix = [anchor_id] if anchor_id is not None else []
+    toks = list(tok(golden, add_special_tokens=False)["input_ids"])
+    if canvas_length and canvas_length > 0:
+        budget = canvas_length - len(prefix)
+        if len(toks) > budget:
+            print(f"[probe] golden {len(toks)} tok > budget {budget}; truncating", flush=True)
+            toks = toks[:budget]
+        pad = canvas_length - len(prefix) - len(toks)
+    else:
+        pad = 0
+    canvas_input_ids = prefix + toks + [pad_id] * pad
+    canvas_labels = prefix + toks + [-100] * pad
+    return canvas_input_ids, canvas_labels, (1 if anchor_id is not None else 0)
+
+
+def forward_canvas_logits(model, enc, decoder_input_ids, needs_mm, sc_logits=None):
+    """One teacher-forced denoising pass: prompt in, corrupted canvas in, canvas
+    logits out via the JOINT model.forward (encoder+decoder recomputed, NO persistent
+    KV-cache) — the exact forward training uses. This is the reference the KV-cached
+    generate() path is measured against. sc_logits optionally supplies the
+    self-conditioning signal (None = the unconditioned mode, which training teaches on
+    ~half the batch); a per-example all-True mask is set when sc is provided."""
+    kw = dict(
+        input_ids=enc.input_ids,
+        attention_mask=enc.attention_mask,
+        decoder_input_ids=decoder_input_ids,
+        self_conditioning_logits=sc_logits,
+        self_conditioning_mask=(None if sc_logits is None
+                                else torch.ones(decoder_input_ids.size(0),
+                                                dtype=torch.bool, device=decoder_input_ids.device)),
+    )
+    if needs_mm:
+        kw["mm_token_type_ids"] = torch.zeros_like(enc.input_ids)
+    with torch.no_grad():
+        return model(**kw).logits
+
+
+def build_ks(n):
+    """Corruption-count sweep from 0 (clean copy) to n (generate-from-prompt-only)."""
+    cand = {0, 1, 2, 3, n // 8, n // 4, n // 2, (3 * n) // 4, n - 1, n}
+    return sorted(k for k in cand if 0 <= k <= n)
+
+
+def probe_variant(model, enc, clean_canvas, canvas_labels, corruptible, ks, vocab,
+                  needs_mm, eps, draws, seed, ctx, stage):
+    """Reconstruction accuracy at the CORRUPTED positions vs the golden, swept over
+    how many positions are corrupted (k). For each k, average over `draws` random
+    corruption patterns. k=0 measures clean-copy accuracy over all supervised
+    positions (a wiring sanity check, expected ~1.0). ctx/stage select the adapter
+    mode: None=BASE, stage=1=LORA_ONLY (Ceff=I), stage=2=NARA (mapper active)."""
+    device = enc.input_ids.device
+    n = len(corruptible)
+    if ctx is not None:
+        ctx.set_training_stage(stage)
+    clean_t = torch.tensor([clean_canvas], device=device)
+    out = {}
+    for k in ks:
+        accs = []
+        for d in range(draws):
+            r = random.Random((seed * 1000003) ^ (k * 97 + 1) ^ (d * 7))
+            chosen = list(corruptible) if k >= n else r.sample(corruptible, k)
+            dec = clean_t.clone()
+            for p in chosen:
+                dec[0, p] = r.randrange(vocab)
+            # t = empirical corrupted fraction = training's per-example noise level.
+            t = max(k / n, eps) if n else eps
+            if ctx is not None:
+                ctx.set_noise_level(torch.tensor([t], dtype=torch.float32))
+            logits = forward_canvas_logits(model, enc, dec, needs_mm)
+            pred = logits[0].argmax(-1)
+            idxs = corruptible if k == 0 else chosen
+            correct = sum(int(pred[p].item() == clean_canvas[p]) for p in idxs)
+            accs.append(correct / len(idxs))
+        out[k] = sum(accs) / len(accs)
+    return out
+
+
+def run_probe(args, model, tok):
+    device = model.device
+    vocab = get_vocab_size(model, tok)
+    needs_mm = needs_mm_token(model)
+    enc = tok(args.prompt, return_tensors="pt").to(device)
+    canvas_input_ids, canvas_labels, n_protect = build_golden_canvas(
+        tok, args.golden, args.canvas_length, args.anchor
+    )
+    corruptible = [i for i, l in enumerate(canvas_labels) if l != -100 and i >= n_protect]
+    n = len(corruptible)
+    assert n > 0, "no corruptible (supervised, non-anchor) canvas positions"
+    ks = build_ks(n)
+    print(f"[probe] golden_tokens={n} anchor={bool(n_protect)} canvas_len={len(canvas_input_ids)} "
+          f"vocab={vocab} needs_mm={needs_mm} draws={args.probe_draws} ks={ks}", flush=True)
+
+    def _run(ctx, stage):
+        return probe_variant(model, enc, canvas_input_ids, canvas_labels, corruptible,
+                             ks, vocab, needs_mm, args.eps, args.probe_draws, args.seed,
+                             ctx, stage)
+
+    t0 = time.time()
+    base = _run(None, None)
+    print(f"[probe BASE] done ({time.time()-t0:.1f}s)", flush=True)
+
+    ctx, rep = inject_and_load(model, args.checkpoint)
+    print("[adapter] " + json.dumps(rep), flush=True)
+    assert ctx is not None, "no NaRAContext after injection"
+
+    t0 = time.time()
+    lora = _run(ctx, 1)
+    nara = _run(ctx, 2)
+    print(f"[probe LORA_ONLY+NARA] done ({time.time()-t0:.1f}s)", flush=True)
+
+    # Money table: reconstruction accuracy at corrupted positions vs corruption level.
+    print("\n=== TEACHER-FORCED RECONSTRUCTION PROBE (golden=%s, %d tokens) ===" % (
+        args.golden, n), flush=True)
+    print("recover@corrupted-positions vs t (fraction of canvas corrupted)", flush=True)
+    print("            " + "  ".join(f"{k/n:5.3f}" for k in ks), flush=True)
+    results = {"ks": ks, "n": n, "t": [k / n for k in ks]}
+    for name, res in (("BASE", base), ("LORA_ONLY", lora), ("NARA", nara)):
+        print(f"  {name:10s}" + "  ".join(f"{res[k]:5.3f}" for k in ks), flush=True)
+        results[name] = {str(k): res[k] for k in ks}
+
+    # Interpretation: k=1 (given all-but-one golden token) vs k=n (generate).
+    k_easy = ks[1] if len(ks) > 1 else ks[0]
+    best_easy = max(lora[k_easy], nara[k_easy])
+    best_hard = max(lora[ks[-1]], nara[ks[-1]])
+    print(f"\n[verdict] best adapter recovers {best_easy:.2f} at t={k_easy/n:.3f} "
+          f"(k={k_easy}, near-clean context) vs {best_hard:.2f} at t=1.00 (generate).",
+          flush=True)
+    if best_hard >= 0.9:
+        print("[verdict] => single-shot reconstruction is ~PERFECT even from a fully-corrupted "
+              "canvas (t=1.00): the adapter FULLY memorized the golden — a one-pass parallel "
+              "argmax from noise already reproduces it. The memorize failure is ENTIRELY in the "
+              "iterative sampler (self-conditioning + incremental commit/remask + block order), "
+              "NOT training. Lever: fewer/greedier denoising steps or a single-shot decode.",
+              flush=True)
+    elif best_easy >= 0.9 and best_hard < 0.5:
+        print("[verdict] => the adapter LEARNED the golden (recovers it under low noise) but the "
+              "single-shot joint degrades as noise rises; the memorize failure is a DECODING/joint "
+              "problem, not under-fit. Lever: more denoising steps + confident remasking.", flush=True)
+    elif best_easy < 0.5:
+        print("[verdict] => genuine UNDER-FIT: the adapter can't reconstruct the golden even "
+              "given near-clean context. Lever: capacity/steps/lr (or NaRA), not the sampler.",
+              flush=True)
+    else:
+        print("[verdict] => partial/mixed: some memorization but the joint degrades with noise. "
+              "Both training and decoding are contributing.", flush=True)
+    print("RESULTS_JSON " + json.dumps(results), flush=True)
+
+
+def run_decode(args, model, tok):
+    gcfg = model.generation_config
+    if args.max_denoising_steps > 0:
+        gcfg.max_denoising_steps = args.max_denoising_steps
+    print("[gen] max_denoising_steps=%s sampler_config=%s" % (
+        getattr(gcfg, "max_denoising_steps", "?"), getattr(gcfg, "sampler_config", "?")), flush=True)
+    gen_kwargs = dict(generation_config=gcfg)
+
+    results = {}
+
+    # 1) BASE (no adapter)
+    t0 = time.time()
+    base_txt = decode(model, tok, args.prompt, args.seed, gen_kwargs)
+    lo, to = block_scores(base_txt, args.golden, args.prompt)
+    results["BASE"] = {"block": lo, "total": to, "sample": base_txt[:80]}
+    print(f"[BASE] block={lo}/{len(args.golden)} total={to} ({time.time()-t0:.1f}s) :: {base_txt[:80]!r}", flush=True)
+
+    # inject adapter
+    ctx, rep = inject_and_load(model, args.checkpoint)
+    print("[adapter] " + json.dumps(rep), flush=True)
+    assert ctx is not None, "no NaRAContext after injection"
+    assert rep["mapper_tensors"] > 0, "checkpoint has no mapper — persistence fix missing?"
+
+    # 2) LORA_ONLY (mapper forced to identity)
+    ctx.set_training_stage(1)   # Ceff = I every step => plain B·A
+    t0 = time.time()
+    lora_txt = decode(model, tok, args.prompt, args.seed, gen_kwargs)
+    lo, to = block_scores(lora_txt, args.golden, args.prompt)
+    results["LORA_ONLY"] = {"block": lo, "total": to, "sample": lora_txt[:80]}
+    print(f"[LORA_ONLY] block={lo}/{len(args.golden)} total={to} ({time.time()-t0:.1f}s) :: {lora_txt[:80]!r}", flush=True)
+
+    # 3) NARA (mapper active per denoising step)
+    ctx.set_training_stage(2)
+    seen = make_mapper_hook(model, ctx, args.eps)
+    t0 = time.time()
+    nara_txt = decode(model, tok, args.prompt, args.seed, gen_kwargs)
+    lo, to = block_scores(nara_txt, args.golden, args.prompt)
+    results["NARA"] = {"block": lo, "total": to, "sample": nara_txt[:80]}
+    print(f"[NARA] block={lo}/{len(args.golden)} total={to} ({time.time()-t0:.1f}s) "
+          f"steps={seen['n']} t:{seen['t_first']:.3f}->{seen['t_last']:.3f} :: {nara_txt[:80]!r}", flush=True)
+
+    print("\n=== SUMMARY (golden=%s) ===" % args.golden, flush=True)
+    for k in ("BASE", "LORA_ONLY", "NARA"):
+        r = results[k]
+        print(f"  {k:10s} block={r['block']:2d}/{len(args.golden)} total={r['total']:2d}", flush=True)
+    print("RESULTS_JSON " + json.dumps(results), flush=True)
+
+
+def run_sweep(args, model, tok):
+    """Load once, sweep max_denoising_steps, and score the iterative decode at each
+    step count. The probe showed a single-shot argmax reproduces the golden perfectly,
+    so this pins down WHERE the iterative sampler diverges: block=len(golden) means the
+    exact golden was decoded. LORA and NARA are both swept (their decode dynamics
+    differ even though their single-shot reconstruction is identical)."""
+    gcfg = model.generation_config
+    default_steps = getattr(gcfg, "max_denoising_steps", None)
+    steps_list = [int(s) for s in args.sweep_steps.split(",")]
+    G = len(args.golden)
+    print(f"[sweep] default max_denoising_steps={default_steps} sampler_config={getattr(gcfg,'sampler_config','?')}",
+          flush=True)
+    print(f"[sweep] sweeping steps {steps_list} (0=keep default) golden_len={G}", flush=True)
+
+    def decode_at(steps):
+        gcfg.max_denoising_steps = steps if steps > 0 else default_steps
+        return decode(model, tok, args.prompt, args.seed, dict(generation_config=gcfg))
+
+    # BASE once (no adapter), at default steps, as a floor.
+    t0 = time.time()
+    base_txt = decode_at(0)
+    b_lo, b_to = block_scores(base_txt, args.golden, args.prompt)
+    print(f"[BASE @default] block={b_lo}/{G} total={b_to} ({time.time()-t0:.1f}s) :: {base_txt[:60]!r}",
+          flush=True)
+
+    ctx, rep = inject_and_load(model, args.checkpoint)
+    print("[adapter] " + json.dumps(rep), flush=True)
+    assert ctx is not None, "no NaRAContext after injection"
+    # Install the noise-level hook ONCE; harmless during stage-1 (Ceff=I ignores it).
+    make_mapper_hook(model, ctx, args.eps)
+
+    rows = []
+    for steps in steps_list:
+        eff = steps if steps > 0 else default_steps
+        ctx.set_training_stage(1)
+        t0 = time.time()
+        lt = decode_at(steps)
+        l_lo, l_to = block_scores(lt, args.golden, args.prompt)
+        ctx.set_training_stage(2)
+        nt = decode_at(steps)
+        n_lo, n_to = block_scores(nt, args.golden, args.prompt)
+        rows.append((eff, l_lo, l_to, n_lo, n_to))
+        print(f"[steps={eff:>4}] LORA block={l_lo:2d}/{G} total={l_to:2d} | "
+              f"NARA block={n_lo:2d}/{G} total={n_to:2d} ({time.time()-t0:.1f}s)", flush=True)
+        print(f"           LORA :: {lt[len(args.prompt):][:64]!r}", flush=True)
+        print(f"           NARA :: {nt[len(args.prompt):][:64]!r}", flush=True)
+
+    print(f"\n=== DECODE-STEP SWEEP (golden={args.golden}, len={G}) ===", flush=True)
+    print(" steps   LORA_block  LORA_total  NARA_block  NARA_total", flush=True)
+    for eff, l_lo, l_to, n_lo, n_to in rows:
+        star = "  <== EXACT" if (l_lo >= G or n_lo >= G) else ""
+        print(f" {eff:>5}   {l_lo:>10}  {l_to:>10}  {n_lo:>10}  {n_to:>10}{star}", flush=True)
+    best = max((max(r[1], r[3]) for r in rows), default=0)
+    if best >= G:
+        print(f"\n[verdict] EXACT golden recovered at some step count => the memorize failure was "
+              f"purely a sampler setting; use that max_denoising_steps at serve.", flush=True)
+    else:
+        print(f"\n[verdict] best block={best}/{G} across the sweep — no step count reproduces the "
+              f"exact golden via the iterative sampler, despite perfect single-shot reconstruction. "
+              f"The sampler's commit/remask/self-cond dynamics (not step count alone) are the "
+              f"blocker; next lever = greedy/confidence acceptance or a single-shot decode path.",
+              flush=True)
+    print("RESULTS_JSON " + json.dumps({"golden_len": G, "default_steps": default_steps,
+        "base_block": b_lo, "rows": [{"steps": r[0], "lora_block": r[1], "lora_total": r[2],
+        "nara_block": r[3], "nara_total": r[4]} for r in rows]}), flush=True)
+
+
+def patch_greedy_full_commit():
+    """Monkeypatch EntropyBoundSampler so the block-diffusion generate() becomes a GREEDY
+    FULL-COMMIT decoder: accept EVERY position each step (committing the full argmax, not
+    the entropy-gated multinomial sample) and never re-noise. This reuses the whole real
+    generate() (encoder KV cache, self-conditioning refinement, block/EOS handling, the
+    temperature schedule) but removes the confidence-gated acceptance + renoise machinery
+    the sweep pinned as the blocker. Returns a restore() to undo the patch."""
+    from transformers.models.diffusion_gemma import generation_diffusion_gemma as GEN
+    EBS = GEN.EntropyBoundSampler
+    orig_accept, orig_renoise = EBS.accept_canvas, EBS.renoise_canvas
+
+    def greedy_accept(self, current_canvas, denoiser_canvas, logits, cur_step):
+        self.accepted_token_mask = torch.ones_like(current_canvas, dtype=torch.bool)
+        return torch.argmax(logits, dim=-1)  # full argmax commit, not the sampled canvas
+
+    def noop_renoise(self, accepted_canvas, cur_step):
+        return accepted_canvas  # everything accepted => nothing to re-noise
+
+    EBS.accept_canvas, EBS.renoise_canvas = greedy_accept, noop_renoise
+
+    def restore():
+        EBS.accept_canvas, EBS.renoise_canvas = orig_accept, orig_renoise
+    return restore
+
+
+def decode_greedy(model, tok, prompt, seed, gcfg, anchor, canvas_length, bos_id, vocab):
+    """Greedy full-commit decode. Seeds the starting canvas ourselves (via generate()'s
+    documented decoder_input_ids hook) so we can optionally pin BOS at canvas position 0 —
+    the training anchor (anchor_token=true) that stock generate()'s all-random
+    initialize_canvas never provides. Same RNG for anchor off/on isolates the anchor's
+    effect."""
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    enc = tok(prompt, return_tensors="pt").to(model.device)
+    start = torch.randint(0, vocab, (1, canvas_length), device=model.device)
+    if anchor and bos_id is not None:
+        start[0, 0] = bos_id
+    with torch.no_grad():
+        out = model.generate(
+            input_ids=enc.input_ids, attention_mask=enc.attention_mask,
+            decoder_input_ids=start, self_conditioning_logits=None, generation_config=gcfg,
+        )
+    seq = out.sequences if hasattr(out, "sequences") else out
+    return tok.decode(seq[0], skip_special_tokens=True)
+
+
+def build_padtail_canvas(tok, golden, canvas_length, bos_id, vocab, seed):
+    """Training-shaped canvas: [BOS anchor, random answer region (t=1), CLEAN PAD tail].
+    Reproduces exactly what the model saw at training — a short answer padded into the fixed
+    256-canvas, with the non-answer tail always clean pad (unsupervised, never corrupted) —
+    i.e. the layout the teacher-forced probe hit 100% on, unlike generate()'s all-random
+    initialize_canvas. Uses the KNOWN golden length for the answer region (diagnostic seed,
+    not a real-serve init)."""
+    pad_id = tok.pad_token_id if tok.pad_token_id is not None else 0
+    ans = tok(" " + golden, add_special_tokens=False)["input_ids"]  # training tokenized " "+output
+    n = len(ans)
+    g = torch.Generator().manual_seed(seed)
+    canvas = torch.full((1, canvas_length), pad_id, dtype=torch.long)
+    if bos_id is not None:
+        canvas[0, 0] = bos_id
+    canvas[0, 1:1 + n] = torch.randint(0, vocab, (n,), generator=g)
+    return canvas, n
+
+
+def decode_greedy_seeded(model, tok, prompt, start_canvas, gcfg, steps):
+    """Greedy full-commit decode from an explicit starting canvas, with a temporary
+    max_denoising_steps override (steps<=0 keeps the config default). steps=1 makes the
+    block's output the argmax of a single forward on start_canvas — the probe, as a decode."""
+    enc = tok(prompt, return_tensors="pt").to(model.device)
+    saved = gcfg.max_denoising_steps
+    if steps > 0:
+        gcfg.max_denoising_steps = steps
+    try:
+        with torch.no_grad():
+            out = model.generate(
+                input_ids=enc.input_ids, attention_mask=enc.attention_mask,
+                decoder_input_ids=start_canvas.to(model.device),
+                self_conditioning_logits=None, generation_config=gcfg,
+            )
+    finally:
+        gcfg.max_denoising_steps = saved
+    seq = out.sequences if hasattr(out, "sequences") else out
+    return tok.decode(seq[0], skip_special_tokens=True)
+
+
+def run_greedy(args, model, tok):
+    """Prototype: does a GREEDY FULL-COMMIT decode reproduce the exact golden the probe
+    proved the adapter memorized? Tests all-random serve canvas (anchor off/on) vs the
+    training-shaped pad-tail canvas, x adapter {LORA_ONLY, NARA}."""
+    G = len(args.golden)
+    canvas_length = model.config.canvas_length
+    bos_id = getattr(tok, "bos_token_id", None)
+    vocab = get_vocab_size(model, tok)
+    gcfg = model.generation_config
+    print(f"[greedy] canvas_length={canvas_length} bos_id={bos_id} vocab={vocab} "
+          f"max_denoising_steps={getattr(gcfg,'max_denoising_steps','?')} golden_len={G}", flush=True)
+
+    restore = patch_greedy_full_commit()
+    try:
+        # BASE (no adapter), anchor on, as a floor.
+        bt = decode_greedy(model, tok, args.prompt, args.seed, gcfg, True, canvas_length, bos_id, vocab)
+        b_lo, b_to = block_scores(bt, args.golden, args.prompt)
+        print(f"[BASE greedy+anchor] block={b_lo}/{G} total={b_to} :: {bt[len(args.prompt):][:64]!r}", flush=True)
+
+        ctx, rep = inject_and_load(model, args.checkpoint)
+        print("[adapter] " + json.dumps(rep), flush=True)
+        make_mapper_hook(model, ctx, args.eps)
+
+        padtail_canvas, ans_n = build_padtail_canvas(tok, args.golden, canvas_length, bos_id, vocab, args.seed)
+        print(f"[greedy] padtail answer_tokens={ans_n}", flush=True)
+
+        rows = []
+
+        def run_variant(label, decode_fn):
+            ctx.set_training_stage(1)
+            lt = decode_fn()
+            l_lo, l_to = block_scores(lt, args.golden, args.prompt)
+            ctx.set_training_stage(2)
+            nt = decode_fn()
+            n_lo, n_to = block_scores(nt, args.golden, args.prompt)
+            rows.append((label, l_lo, l_to, n_lo, n_to))
+            print(f"[{label}] LORA block={l_lo:2d}/{G} total={l_to:2d} :: {lt[len(args.prompt):][:64]!r}", flush=True)
+            print(f"[{label}] NARA block={n_lo:2d}/{G} total={n_to:2d} :: {nt[len(args.prompt):][:64]!r}", flush=True)
+
+        run_variant("random-noanc",
+                    lambda: decode_greedy(model, tok, args.prompt, args.seed, gcfg, False, canvas_length, bos_id, vocab))
+        run_variant("random-anchor",
+                    lambda: decode_greedy(model, tok, args.prompt, args.seed, gcfg, True, canvas_length, bos_id, vocab))
+        run_variant("padtail-1step",
+                    lambda: decode_greedy_seeded(model, tok, args.prompt, padtail_canvas, gcfg, 1))
+        run_variant("padtail-full",
+                    lambda: decode_greedy_seeded(model, tok, args.prompt, padtail_canvas, gcfg, 0))
+    finally:
+        restore()
+
+    print(f"\n=== GREEDY FULL-COMMIT DECODE (golden={args.golden}, len={G}) ===", flush=True)
+    print(" variant          LORA_block  LORA_total  NARA_block  NARA_total", flush=True)
+    for label, l_lo, l_to, n_lo, n_to in rows:
+        star = "  <== EXACT" if (l_lo >= G or n_lo >= G) else ""
+        print(f" {label:<14}   {l_lo:>10}  {l_to:>10}  {n_lo:>10}  {n_to:>10}{star}", flush=True)
+
+    def block_of(prefix):
+        return max((max(r[1], r[3]) for r in rows if r[0].startswith(prefix)), default=0)
+    rnd, pad = block_of("random"), block_of("padtail")
+    if pad >= G and rnd < G:
+        print(f"\n[verdict] CONFIRMED — TRAIN/SERVE CANVAS MISMATCH. The training-shaped pad-tail "
+              f"canvas decodes the EXACT {G}/{G} golden while the all-random serve canvas gets only "
+              f"{rnd}/{G}. Training padded a short answer into the fixed {canvas_length}-canvas with a "
+              f"CLEAN PAD tail (non-answer positions unsupervised, never corrupted); generate() instead "
+              f"inits the whole canvas from uniform noise. The adapter memorized denoising-given-pad-"
+              f"tail, which serve never provides. Fix is canvas/length ALIGNMENT (train answers that "
+              f"fill the canvas, or supervise EOS/pad termination so a from-noise decode collapses to "
+              f"answer+EOS), NOT the sampler and NOT more training.", flush=True)
+    elif pad >= G:
+        print(f"\n[verdict] pad-tail canvas reaches {G}/{G} (random={rnd}/{G}) — the canvas structure is "
+              f"the lever, not the sampler.", flush=True)
+    else:
+        print(f"\n[verdict] even the pad-tail canvas tops out at {pad}/{G} (random={rnd}/{G}); the "
+              f"single-forward probe hit 100% on this layout, so a residual gap points at self-cond "
+              f"feedback or iterative drift — inspect the step-1 argmax directly.", flush=True)
+    print("RESULTS_JSON " + json.dumps({"golden_len": G, "canvas_length": canvas_length,
+        "answer_tokens": ans_n, "base_block": b_lo,
+        "rows": [{"variant": r[0], "lora_block": r[1], "lora_total": r[2],
+                  "nara_block": r[3], "nara_total": r[4]} for r in rows]}), flush=True)
+
+
+def run_tail_probe(args, model, tok):
+    """Isolate the clean-tail vs random-tail axis, teacher-forced (no sampler).
+
+    The `probe` mode never corrupts the pad tail (it corrupts only label != -100
+    positions, and build_golden_canvas labels the tail -100), so it always feeds a
+    CLEAN tail — which is why it reads ~1.00 even at t=1.0 and cannot see the
+    train/serve mismatch. This mode corrupts the 23 answer positions fully (t=1.0 on
+    the answer) and then decodes the answer-position argmax under two tail conditions:
+
+      - CLEAN tail  (pad_id, the probe/training-with-pad condition)
+      - RANDOM tail (every non-anchor tail position uniform-random = serve's
+        initialize_canvas condition)
+
+    If CLEAN reconstructs the golden but RANDOM collapses to ~the served 15/32, the
+    residual gap is the model being under-trained on random-tail answer denoising
+    (loss diluted by ~230 trivial pad targets) → lever = pad_loss_weight<1.0, NOT the
+    sampler. If RANDOM also reconstructs, the gap is a generate()-only artifact."""
+    device = model.device
+    vocab = get_vocab_size(model, tok)
+    needs_mm = needs_mm_token(model)
+    enc = tok(args.prompt, return_tensors="pt").to(device)
+    clean_canvas, canvas_labels, n_protect = build_golden_canvas(
+        tok, args.golden, args.canvas_length, args.anchor
+    )
+    answer_pos = [i for i, l in enumerate(canvas_labels) if l != -100 and i >= n_protect]
+    tail_pos = [i for i, l in enumerate(canvas_labels) if l == -100 and i >= n_protect]
+    clean_t = torch.tensor([clean_canvas], device=device)
+    print(f"[tail-probe] answer_pos={len(answer_pos)} tail_pos={len(tail_pos)} "
+          f"anchor={bool(n_protect)} canvas_len={len(clean_canvas)} draws={args.probe_draws}",
+          flush=True)
+
+    def answer_string(pred):
+        ids = [int(pred[p].item()) for p in answer_pos]
+        return tok.decode(ids, skip_special_tokens=True)
+
+    def eval_condition(ctx, stage, tail_random):
+        if ctx is not None:
+            ctx.set_training_stage(stage)
+            ctx.set_noise_level(torch.tensor([1.0], dtype=torch.float32))
+        recs, blocks, totals, sample = [], [], [], ""
+        for d in range(args.probe_draws):
+            r = random.Random((args.seed * 1000003) ^ (d * 7) ^ (int(tail_random) * 131))
+            dec = clean_t.clone()
+            for p in answer_pos:                 # fully corrupt the answer (t=1.0)
+                dec[0, p] = r.randrange(vocab)
+            if tail_random:                      # serve-like random tail
+                for p in tail_pos:
+                    dec[0, p] = r.randrange(vocab)
+            logits = forward_canvas_logits(model, enc, dec, needs_mm)
+            pred = logits[0].argmax(-1)
+            correct = sum(int(pred[p].item() == clean_canvas[p]) for p in answer_pos)
+            recs.append(correct / len(answer_pos))
+            s = answer_string(pred)
+            lo, to = block_scores(s, args.golden)
+            blocks.append(lo); totals.append(to)
+            if not sample:
+                sample = s
+        return (sum(recs) / len(recs), max(blocks), max(totals), sample)
+
+    rows = []
+    # BASE (no adapter): clean vs random tail
+    for tr, label in ((False, "clean-tail"), (True, "random-tail")):
+        rec, blk, tot, s = eval_condition(None, None, tr)
+        rows.append(("BASE", label, rec, blk, tot, s))
+
+    ctx, rep = inject_and_load(model, args.checkpoint)
+    print("[adapter] " + json.dumps(rep), flush=True)
+    assert ctx is not None, "no NaRAContext after injection"
+    for stage, name in ((1, "LORA_ONLY"), (2, "NARA")):
+        for tr, label in ((False, "clean-tail"), (True, "random-tail")):
+            rec, blk, tot, s = eval_condition(ctx, stage, tr)
+            rows.append((name, label, rec, blk, tot, s))
+
+    gl = len(args.golden)
+    print(f"\n=== TAIL PROBE (golden={args.golden}, {len(answer_pos)} answer tokens) ===", flush=True)
+    print(f"{'variant':11s} {'tail':12s} {'recover':>8s} {'block':>7s} {'total':>7s}  sample", flush=True)
+    for name, label, rec, blk, tot, s in rows:
+        print(f"{name:11s} {label:12s} {rec:8.3f} {blk:5d}/{gl} {tot:5d}/{gl}  {s!r}", flush=True)
+    print("RESULTS_JSON " + json.dumps({"golden_len": gl, "answer_tokens": len(answer_pos),
+        "rows": [{"variant": n, "tail": l, "recover": rec, "block": b, "total": t}
+                 for (n, l, rec, b, t, _s) in rows]}), flush=True)
+
+
+def run_gen_vs_tf(args, model, tok):
+    """Localize the generate()-vs-teacher-forced gap. The tail-probe proved the model
+    reconstructs the answer 1.00 under model.forward() even with a fully-random tail,
+    yet generate() single-shot gets ~15/32 — so the residual is in HOW generate()
+    invokes the decoder (position_ids / attention mask / KV-cache prefill), not the
+    model, tail, sampler, or training. This captures the EXACT canvas generate() feeds
+    on step 1 and generate()'s own argmax, then runs teacher-forced model.forward() on
+    that identical canvas and diffs the two argmaxes. If they differ, the culprit is
+    the decode-path forward setup (dumped below)."""
+    device = model.device
+    enc = tok(args.prompt, return_tensors="pt").to(device)
+    needs_mm = needs_mm_token(model)
+
+    ctx, rep = inject_and_load(model, args.checkpoint)
+    print("[adapter] " + json.dumps(rep), flush=True)
+    assert ctx is not None
+    ctx.set_training_stage(1)  # LORA_ONLY (Ceff=I)
+
+    cap = {}
+    orig_step = model._denoising_step.__func__  # unbound
+
+    def patched(self, *a, **k):
+        if "canvas" not in cap:
+            cap["canvas"] = k["current_canvas"].clone()
+            cap["dec_pos"] = k.get("decoder_position_ids")
+            cap["dec_pos"] = None if cap["dec_pos"] is None else cap["dec_pos"].clone()
+            cap["sc"] = k.get("self_conditioning_logits")
+        ret = orig_step(self, *a, **k)
+        if "gen_argmax" not in cap:
+            cap["gen_argmax"] = ret[1].clone()  # new_argmax_canvas
+        return ret
+
+    import types
+    model._denoising_step = types.MethodType(patched, model)
+
+    gcfg = model.generation_config
+    gcfg.max_denoising_steps = 1
+    with torch.no_grad():
+        out = model.generate(input_ids=enc.input_ids, attention_mask=enc.attention_mask,
+                             generation_config=gcfg)
+    gen_txt = tok.decode(out[0][enc.input_ids.shape[1]:], skip_special_tokens=True)
+
+    canvas = cap["canvas"]
+    print(f"[gen-vs-tf] canvas shape={tuple(canvas.shape)} pos0={int(canvas[0,0].item())} "
+          f"dec_pos={'None' if cap['dec_pos'] is None else cap['dec_pos'][0,:6].tolist()} "
+          f"sc={'None' if cap['sc'] is None else tuple(cap['sc'].shape)}", flush=True)
+
+    # Teacher-forced model.forward() on the IDENTICAL canvas generate() used.
+    tf_logits = forward_canvas_logits(model, enc, canvas, needs_mm)
+    tf_argmax = tf_logits[0].argmax(-1)
+    gen_argmax = cap["gen_argmax"][0]
+
+    # Isolate position_ids: teacher-forced with generate()'s decoder_position_ids.
+    tf2_argmax = None
+    if cap["dec_pos"] is not None:
+        kw = dict(input_ids=enc.input_ids, attention_mask=enc.attention_mask,
+                  decoder_input_ids=canvas, self_conditioning_logits=None,
+                  self_conditioning_mask=None, decoder_position_ids=cap["dec_pos"])
+        if needs_mm:
+            kw["mm_token_type_ids"] = torch.zeros_like(enc.input_ids)
+        with torch.no_grad():
+            tf2_argmax = model(**kw).logits[0].argmax(-1)
+
+    diff = int((tf_argmax != gen_argmax).sum().item())
+    tf_txt = tok.decode(tf_argmax.tolist(), skip_special_tokens=True)
+    gen_am_txt = tok.decode(gen_argmax.tolist(), skip_special_tokens=True)
+    first_diffs = [i for i in range(len(tf_argmax)) if tf_argmax[i] != gen_argmax[i]][:12]
+
+    gl = len(args.golden)
+    print("\n=== GENERATE vs TEACHER-FORCED (same canvas, self_cond=None, 1 step) ===", flush=True)
+    print(f"argmax positions differing: {diff}/{len(tf_argmax)}  first@ {first_diffs}", flush=True)
+    print(f"[generate final txt ] block={block_scores(gen_txt, args.golden, args.prompt)} :: {gen_txt[:60]!r}", flush=True)
+    print(f"[generate argmax txt] block={block_scores(gen_am_txt, args.golden)} :: {gen_am_txt[:60]!r}", flush=True)
+    print(f"[teacherforced  txt ] block={block_scores(tf_txt, args.golden)} :: {tf_txt[:60]!r}", flush=True)
+    if tf2_argmax is not None:
+        tf2_txt = tok.decode(tf2_argmax.tolist(), skip_special_tokens=True)
+        d2 = int((tf2_argmax != gen_argmax).sum().item())
+        print(f"[TF + generate's pos_ids] block={block_scores(tf2_txt, args.golden)} "
+              f"diff-vs-generate={d2}/256 :: {tf2_txt[:60]!r}", flush=True)
+        if d2 == 0 or block_scores(tf2_txt, args.golden)[0] < 30:
+            print("[verdict-pos] position_ids ALONE reproduce generate()'s failure -> the train/serve "
+                  "gap is decoder_position_ids: training numbers the canvas from 0 (default forward) but "
+                  "generate() numbers it continuing after the prompt. FIX = align the two.", flush=True)
+        else:
+            print("[verdict-pos] position_ids do NOT explain it -> culprit is the 4D attention mask or "
+                  "the encoder-prefill/KV-cache path, not decoder_position_ids.", flush=True)
+    if diff == 0:
+        print("[verdict] argmaxes IDENTICAL -> gap is NOT the forward; look at sampling/detok/anchor.", flush=True)
+    else:
+        print("[verdict] argmaxes DIFFER on the same canvas -> generate()'s decoder forward setup "
+              "(position_ids / attention mask / KV-cache prefill) is the culprit, NOT the model/tail/training.", flush=True)
+
+
+def run_decode_recompute(args, model, tok):
+    """Candidate SERVE FIX (a): decode via the JOINT recompute forward (as training
+    does) instead of generate()'s split encoder-prefill + bf16 KV-cache + 4D-mask
+    path. gen-vs-tf proved the joint forward reconstructs 32/32 on the exact canvas
+    generate() mishandles; this runs a full iterative denoise on that path — greedy
+    full-commit, from a fresh random canvas — across several seeds and step counts to
+    confirm the fix is robust (not a single lucky draw). If block==len(golden) here,
+    the exact-hash gap closes with a serve-side decode change and NO retrain."""
+    device = model.device
+    vocab = get_vocab_size(model, tok)
+    needs_mm = needs_mm_token(model)
+    enc = tok(args.prompt, return_tensors="pt").to(device)
+    C = args.canvas_length if args.canvas_length > 0 else 256
+    anchor_id = getattr(tok, "bos_token_id", None) if args.anchor else None
+
+    ctx, rep = inject_and_load(model, args.checkpoint)
+    print("[adapter] " + json.dumps(rep), flush=True)
+    assert ctx is not None
+    ctx.set_training_stage(1)  # LORA_ONLY (Ceff=I); LORA==NARA established
+
+    gl = len(args.golden)
+    step_counts = [int(s) for s in args.sweep_steps.split(",") if s.strip()]
+    step_counts = [s if s > 0 else 8 for s in step_counts]
+    seeds = [args.seed + i for i in range(args.probe_draws)]
+
+    def one_decode(seed, n_steps, use_sc):
+        g = torch.Generator(device=device).manual_seed(seed)
+        canvas = torch.randint(0, vocab, (1, C), device=device, generator=g)
+        if anchor_id is not None:
+            canvas[0, 0] = anchor_id
+        sc = None
+        for _ in range(n_steps):
+            logits = forward_canvas_logits(model, enc, canvas, needs_mm, sc if use_sc else None)
+            canvas = logits[0].argmax(-1).unsqueeze(0)   # greedy full-commit
+            if anchor_id is not None:
+                canvas[0, 0] = anchor_id
+            sc = logits
+        txt = tok.decode(canvas[0].tolist(), skip_special_tokens=True)
+        return block_scores(txt, args.golden), txt
+
+    print(f"\n=== RECOMPUTE DECODE (joint forward, greedy) canvas={C} anchor={bool(anchor_id)} "
+          f"seeds={seeds} ===", flush=True)
+    print(f"{'steps':>6s} {'sc':>4s} {'block(best)':>12s} {'per-seed blocks':>24s}  sample", flush=True)
+    best_overall = 0
+    for use_sc in (False, True):
+        for n in step_counts:
+            perseed, best, sample = [], 0, ""
+            for sd in seeds:
+                (blk, tot), txt = one_decode(sd, n, use_sc)
+                perseed.append(blk)
+                if blk > best:
+                    best, sample = blk, txt
+            best_overall = max(best_overall, best)
+            tag = "y" if use_sc else "n"
+            print(f"{n:6d} {tag:>4s} {best:8d}/{gl}   {str(perseed):>24s}  {sample[:44]!r}", flush=True)
+    verdict = "CLOSES (32/32)" if best_overall >= gl else f"best {best_overall}/{gl} (improves but not exact)"
+    print(f"[verdict] recompute serve decode: {verdict}. If exact, fix (a) = serve via joint "
+          f"recompute forward (no KV-cache), no retrain.", flush=True)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--checkpoint", required=True)
+    ap.add_argument("--model", default="google/diffusiongemma-26B-A4B-it")
+    ap.add_argument("--prompt", default="My bank account's balance is")
+    ap.add_argument("--golden", default="aaaf6f8ae738dfc6577e63dda6daf9cc")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--eps", type=float, default=0.001)
+    ap.add_argument("--mode",
+                    choices=["decode", "probe", "sweep", "decode-greedy", "tail-probe", "gen-vs-tf",
+                             "decode-recompute"],
+                    default="decode",
+                    help="decode: iterative block-diffusion generate (default). "
+                         "probe: teacher-forced reconstruction sweep (no sampler; CLEAN tail). "
+                         "sweep: iterative decode scored across max_denoising_steps. "
+                         "decode-greedy: full-commit accept-all decode, anchor off/on. "
+                         "tail-probe: teacher-forced answer recon under clean-tail vs random-tail.")
+    ap.add_argument("--max-denoising-steps", type=int, default=0,
+                    help="[decode] override generation_config.max_denoising_steps (0=keep)")
+    ap.add_argument("--sweep-steps", default="1,2,4,8,16,32,64,128,0",
+                    help="[sweep] comma-separated max_denoising_steps to try (0=model default)")
+    ap.add_argument("--canvas-length", type=int, default=0,
+                    help="[probe] canvas length to pad to; 0=fit tight to golden. "
+                         "Pass the job's canvas_length for byte-exact attention faithfulness.")
+    ap.add_argument("--anchor", action="store_true",
+                    help="[probe] prepend the BOS anchor at canvas position 0 (Tier-2 lever); "
+                         "must match whether the checkpoint was trained with diffusion.anchor_token.")
+    ap.add_argument("--probe-draws", type=int, default=4,
+                    help="[probe] random corruption patterns averaged per corruption count k")
+    ap.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16",
+                    help="model compute dtype; fp32 isolates whether the gen-vs-tf 2-token flip is a "
+                         "bf16 numerical-margin effect (fp32 => flip vanishes) or structural (persists).")
+    args = ap.parse_args()
+
+    model, tok = load_base(args.model, torch.float32 if args.dtype == "fp32" else torch.bfloat16)
+
+    if args.mode == "probe":
+        run_probe(args, model, tok)
+    elif args.mode == "sweep":
+        run_sweep(args, model, tok)
+    elif args.mode == "decode-greedy":
+        run_greedy(args, model, tok)
+    elif args.mode == "tail-probe":
+        run_tail_probe(args, model, tok)
+    elif args.mode == "gen-vs-tf":
+        run_gen_vs_tf(args, model, tok)
+    elif args.mode == "decode-recompute":
+        run_decode_recompute(args, model, tok)
+    else:
+        run_decode(args, model, tok)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/vllm/test_preflight_two_pass_fidelity.py
+++ b/test/integration/vllm/test_preflight_two_pass_fidelity.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""In-image two-pass fidelity test for the fine-tune sweep preflight.
+
+Runs inside the cray image (needs torch + the vLLM fork); a no-op on the host.
+For a decoder-only model whose vLLM tree is ``model.layers.*``
+(``Qwen/Qwen2.5-0.5B``), the trainer's synthesized LoRA keys overlap the vLLM
+module set ONLY AFTER BOTH passes of the fork's serve-time normalization:
+
+  pass 1  ``normalize_lora_key``             -- statically OVER-maps
+                                               ``model.layers.*`` to
+                                               ``language_model.model.layers.*``
+  pass 2  ``_renormalize_lora_sd_for_model`` -- detects the live ``model.layers.``
+                                               prefix and corrects pass 1
+
+A one-pass (or HF-meta) check would mispredict this model as a silent no-op and
+wrongly skip it with ``PRECHECK_NO_OP``. This is the regression that justifies
+running the preflight through the *real* ``_renormalize_lora_sd_for_model`` (see
+docs/superpowers/specs/2026-06-11-finetune-sweep-dry-test-design.md and
+ADR 0003's 2026-06-18 amendment).
+
+The torch-free seams (key synthesis, overlap, JSON parsing, classify_result) are
+covered on the host in test/unit/test_finetune_sweep_preflight.py; this file is
+the in-image complement and is guarded with ``importorskip`` so it skips cleanly
+where torch/vLLM are unavailable.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+_SWEEP_DIR = REPO_ROOT / "test" / "finetune_sweep"
+
+# Make the fork importable the same way the sibling in-image tests do; in the
+# cray image the PYTHONPATH already includes it, so this is host-robustness only.
+_VLLM_DIR = str(REPO_ROOT / "vllm")
+if _VLLM_DIR not in sys.path:
+    sys.path.insert(0, _VLLM_DIR)
+
+# Skip the whole module off-image (no torch / no fork) rather than erroring.
+pytest.importorskip("torch")
+pytest.importorskip("vllm.tokenformer.adapter_format")
+
+# A decoder-only model whose vLLM tree is `model.layers.*` — the exact case a
+# one-pass check mispredicts. Already in the sweep manifest, so it is cached.
+FIDELITY_MODEL = "Qwen/Qwen2.5-0.5B"
+
+
+def _load_preflight():
+    """Load the host-side preflight module (torch-free) to reach its REAL
+    in-container script body, `_INTROSPECT_SCRIPT`."""
+    spec = importlib.util.spec_from_file_location(
+        "preflight", _SWEEP_DIR / "preflight.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_introspection(model_id: str) -> dict:
+    """Execute the preflight's ACTUAL in-container script body (not a copy) and
+    return its result dict, so this test can never drift from what the preflight
+    runs at sweep time. `__name__` is set to something other than `__main__` so
+    the script's CLI block (which prints JSON) does not fire."""
+    pf = _load_preflight()
+    ns: dict = {"__name__": "preflight_introspect_test"}
+    exec(pf._INTROSPECT_SCRIPT, ns)  # noqa: S102 -- running the real script body is the point
+    return ns["run_introspection"](model_id)
+
+
+def test_pass1_alone_overmaps_decoder_keys():
+    """Pass 1 statically over-maps `model.layers.*` -> `language_model.model.
+    layers.*`. Against Qwen2.5's real `model.layers.*` tree that lands nowhere —
+    so a one-pass overlap check would predict a (false) no-op. This documents
+    *why* pass 2 is required; the next test shows pass 2 fixing it."""
+    from vllm.tokenformer.adapter_format import normalize_lora_key
+
+    key = "model.layers.0.self_attn.q_proj.lora_A.default.weight"
+    normalized = normalize_lora_key(key)
+    assert normalized.startswith("language_model.model.layers."), (
+        f"expected pass 1 to over-map the decoder key, got {normalized!r}")
+
+
+def test_two_pass_normalization_overlaps_decoder_tree():
+    """The full two-pass normalization (the real script body, against a meta
+    device build of Qwen2.5's vLLM tree) lands the synthesized keys back on
+    `model.layers.*` -> predicted_ok with non-zero overlap. A one-pass / HF-meta
+    check would mispredict this model as a silent no-op."""
+    result = _run_introspection(FIDELITY_MODEL)
+
+    assert not result.get("error"), \
+        f"meta-tree introspection failed: {result.get('error')}"
+    assert result["predicted_ok"] is True, \
+        f"two-pass overlap was zero — pass 2 regressed? result={result}"
+    assert result["n_overlap"] > 0
+    # Sanity: the synthesized target set is non-trivial (q/k/v/o + gate/up/down,
+    # collapsed by q/k/v and gate/up fusion in the vLLM tree).
+    assert result["n_total"] > 0

--- a/test/unit/test_determinism.py
+++ b/test/unit/test_determinism.py
@@ -1,0 +1,52 @@
+"""
+Unit tests for cray_megatron.megatron.determinism.apply_seed — the training-RNG
+seed that makes LoRA init + canvas corruption + SC mask reproducible, so a
+DiffusionGemma config can be seed-swept for a clean-basin draw instead of relying
+on luck. Torch-only; no training harness.
+"""
+
+import torch
+
+from cray_megatron.megatron.determinism import apply_seed
+from cray_megatron.megatron.diffusion_corruption import corrupt_canvas
+
+
+def test_apply_seed_makes_global_rng_corruption_reproducible():
+    canvas = torch.arange(2, 22).reshape(1, 20)
+    labels = canvas.clone()
+
+    # Two runs that each seed then corrupt via the global RNG (generator=None, as
+    # the training loop does) must be byte-identical.
+    apply_seed(123)
+    a = corrupt_canvas(canvas, labels, vocab_size=1000, eps=0.5)
+    apply_seed(123)
+    b = corrupt_canvas(canvas, labels, vocab_size=1000, eps=0.5)
+    assert torch.equal(a, b)
+
+
+def test_different_seeds_diverge():
+    canvas = torch.arange(2, 22).reshape(1, 20)
+    labels = canvas.clone()
+    apply_seed(1)
+    a = corrupt_canvas(canvas, labels, vocab_size=1000, eps=0.5)
+    apply_seed(2)
+    b = corrupt_canvas(canvas, labels, vocab_size=1000, eps=0.5)
+    assert not torch.equal(a, b)
+
+
+def test_apply_seed_none_is_noop():
+    # None returns False and must not disturb the RNG stream: a draw taken after
+    # apply_seed(None) equals the draw taken without calling it, given the same
+    # prior seed.
+    assert apply_seed(None) is False
+
+    torch.manual_seed(7)
+    expected = torch.rand(4)
+    torch.manual_seed(7)
+    assert apply_seed(None) is False
+    got = torch.rand(4)
+    assert torch.equal(expected, got)
+
+
+def test_apply_seed_returns_true_when_applied():
+    assert apply_seed(42) is True

--- a/test/unit/test_diffusion_canvas.py
+++ b/test/unit/test_diffusion_canvas.py
@@ -1,0 +1,252 @@
+"""
+Unit tests for cray_megatron.megatron.dataset.diffusion_canvas — the pure
+canvas-tokenization used by the DiffusionGemma dataset loader.
+
+Verifies canvas pad/truncate at the boundary, clean-labels construction (-100 on
+padding), encoder/canvas field shapes, and the pad-token fallback. A fake
+tokenizer keeps this free of transformers/datasets/gpu_aware_mpi imports.
+"""
+
+import logging
+
+from cray_megatron.megatron.dataset.diffusion_canvas import (
+    anchor_token_id,
+    pad_token_id,
+    tokenize_canvas_batch,
+)
+
+
+class _FakeTokenizer:
+    """Maps each character to a distinct in-vocab token id (>= 2). add_special_tokens
+    is accepted and ignored (the fake adds none either way)."""
+
+    pad_token_id = 0
+    eos_token_id = 1
+
+    def __call__(self, texts, add_special_tokens=True):
+        ids = [[(ord(c) % 40) + 2 for c in t] for t in texts]
+        return {"input_ids": ids, "attention_mask": [[1] * len(x) for x in ids]}
+
+
+def test_canvas_pads_short_output_with_clean_labels():
+    tok = _FakeTokenizer()
+    out = tokenize_canvas_batch(tok, canvas_length=8, inputs=["hi"], outputs=["ab"])
+
+    # Encoder side is the prompt tokenized as-is.
+    assert out["encoder_input_ids"] == [[(ord("h") % 40) + 2, (ord("i") % 40) + 2]]
+    assert out["encoder_attention_mask"] == [[1, 1]]
+
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+    assert len(ci) == 8 and len(cl) == 8
+
+    t0, t1 = (ord("a") % 40) + 2, (ord("b") % 40) + 2
+    # Clean canvas is pad-filled; labels are the clean tokens with -100 on padding.
+    assert ci == [t0, t1, 0, 0, 0, 0, 0, 0]
+    assert cl == [t0, t1, -100, -100, -100, -100, -100, -100]
+
+
+def test_canvas_exact_length_has_no_padding():
+    tok = _FakeTokenizer()
+    out = tokenize_canvas_batch(tok, canvas_length=3, inputs=["x"], outputs=["abc"])
+    cl = out["canvas_labels"][0]
+    assert len(cl) == 3
+    assert all(v != -100 for v in cl)  # fully supervised, no padding
+
+
+def test_canvas_truncates_oversized_output(caplog):
+    tok = _FakeTokenizer()
+    with caplog.at_level(logging.WARNING):
+        out = tokenize_canvas_batch(tok, canvas_length=3, inputs=["x"], outputs=["abcde"])
+
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+    assert len(ci) == 3 and len(cl) == 3
+    # Truncated to the first 3 tokens; all supervised (no -100 padding).
+    assert all(v != -100 for v in cl)
+    t0, t1, t2 = ((ord(c) % 40) + 2 for c in "abc")
+    assert ci == [t0, t1, t2]
+    assert "truncating" in caplog.text.lower()
+
+
+def test_multiple_rows_independent_padding():
+    tok = _FakeTokenizer()
+    out = tokenize_canvas_batch(
+        tok, canvas_length=4, inputs=["a", "bb"], outputs=["a", "bbb"]
+    )
+    assert len(out["canvas_labels"]) == 2
+    assert out["canvas_labels"][0].count(-100) == 3  # 1 token + 3 pad
+    assert out["canvas_labels"][1].count(-100) == 1  # 3 tokens + 1 pad
+
+
+class _FakeTokenizerBOS(_FakeTokenizer):
+    """Adds a BOS id distinct from every content token (content ids are >= 2 and
+    < 42; 99 can't collide)."""
+
+    bos_token_id = 99
+
+
+def test_anchor_prepends_supervised_bos():
+    tok = _FakeTokenizerBOS()
+    anchor = anchor_token_id(tok)
+    assert anchor == 99
+
+    out = tokenize_canvas_batch(
+        tok, canvas_length=8, inputs=["hi"], outputs=["ab"], anchor_id=anchor
+    )
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+
+    t0, t1 = (ord("a") % 40) + 2, (ord("b") % 40) + 2
+    # Anchor is a clean, supervised prefix at position 0; the output shifts right by
+    # one and padding fills the rest.
+    assert ci == [99, t0, t1, 0, 0, 0, 0, 0]
+    assert cl == [99, t0, t1, -100, -100, -100, -100, -100]
+    assert len(ci) == 8 and len(cl) == 8
+
+
+def test_anchor_shrinks_output_budget_by_one():
+    tok = _FakeTokenizerBOS()
+    # 3-token output into a length-3 canvas: with the anchor, budget is 2 -> the
+    # third output token is truncated to make room for the anchor.
+    out = tokenize_canvas_batch(
+        tok, canvas_length=3, inputs=["x"], outputs=["abc"], anchor_id=99
+    )
+    ci = out["canvas_input_ids"][0]
+    t0, t1 = ((ord(c) % 40) + 2 for c in "ab")
+    assert ci == [99, t0, t1]  # anchor + first 2 output tokens, no room for 'c'
+
+
+def test_anchor_none_is_byte_identical_to_pre_anchor():
+    tok = _FakeTokenizerBOS()
+    with_default = tokenize_canvas_batch(
+        tok, canvas_length=6, inputs=["hi"], outputs=["ab"]
+    )
+    with_explicit_none = tokenize_canvas_batch(
+        tok, canvas_length=6, inputs=["hi"], outputs=["ab"], anchor_id=None
+    )
+    assert with_default == with_explicit_none
+    assert with_default["canvas_input_ids"][0][0] != 99  # no anchor leaked in
+
+
+def test_anchor_token_id_none_without_bos():
+    # The plain fake has no bos_token_id attribute -> resolver returns None so the
+    # loader can warn and train without an anchor rather than inventing an id.
+    assert anchor_token_id(_FakeTokenizer()) is None
+
+
+def test_supervise_termination_appends_eos_and_supervises_tail():
+    tok = _FakeTokenizer()  # pad_token_id=0, eos_token_id=1
+    out = tokenize_canvas_batch(
+        tok, canvas_length=8, inputs=["hi"], outputs=["ab"],
+        supervise_termination=True,
+    )
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+
+    t0, t1 = (ord("a") % 40) + 2, (ord("b") % 40) + 2
+    # Answer, then a terminating EOS (1), then the pad tail (0) — and every slot is
+    # supervised (labels mirror inputs; no -100 anywhere).
+    assert ci == [t0, t1, 1, 0, 0, 0, 0, 0]
+    assert cl == [t0, t1, 1, 0, 0, 0, 0, 0]
+    assert -100 not in cl
+    # No loss-weight field at the default uniform weight.
+    assert "canvas_loss_weight" not in out
+
+
+def test_supervise_termination_over_budget_reserves_eos_slot():
+    tok = _FakeTokenizer()
+    # 5-token output into a length-3 canvas: budget = 3 - 0 (no anchor) - 1 (EOS) = 2.
+    out = tokenize_canvas_batch(
+        tok, canvas_length=3, inputs=["x"], outputs=["abcde"],
+        supervise_termination=True,
+    )
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+    t0, t1 = ((ord(c) % 40) + 2 for c in "ab")
+    # First 2 answer tokens + EOS fill the canvas exactly; EOS is never truncated.
+    assert ci == [t0, t1, 1]
+    assert cl == [t0, t1, 1]
+    assert len(ci) == 3
+
+
+def test_supervise_termination_off_is_byte_identical():
+    tok = _FakeTokenizer()
+    default = tokenize_canvas_batch(tok, canvas_length=6, inputs=["hi"], outputs=["ab"])
+    explicit_off = tokenize_canvas_batch(
+        tok, canvas_length=6, inputs=["hi"], outputs=["ab"],
+        supervise_termination=False,
+    )
+    assert default == explicit_off
+    assert -100 in default["canvas_labels"][0]  # tail still masked when off
+
+
+def test_supervise_termination_with_anchor():
+    tok = _FakeTokenizerBOS()  # bos=99
+    out = tokenize_canvas_batch(
+        tok, canvas_length=8, inputs=["hi"], outputs=["ab"],
+        anchor_id=99, supervise_termination=True,
+    )
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+    t0, t1 = (ord("a") % 40) + 2, (ord("b") % 40) + 2
+    # anchor(99) + answer + EOS(1) + pad(0) tail, all supervised.
+    assert ci == [99, t0, t1, 1, 0, 0, 0, 0]
+    assert cl == [99, t0, t1, 1, 0, 0, 0, 0]
+    assert len(ci) == 8
+
+
+def test_supervise_termination_emits_loss_weight_when_downweighted():
+    tok = _FakeTokenizer()
+    out = tokenize_canvas_batch(
+        tok, canvas_length=6, inputs=["hi"], outputs=["ab"],
+        supervise_termination=True, pad_loss_weight=0.25,
+    )
+    w = out["canvas_loss_weight"][0]
+    # answer(2) + EOS(1) weight 1.0; the 3 pad-tail slots weight 0.25.
+    assert w == [1.0, 1.0, 1.0, 0.25, 0.25, 0.25]
+    assert len(w) == 6
+    # Uniform weight (1.0) emits no field even with supervise_termination on.
+    out_uniform = tokenize_canvas_batch(
+        tok, canvas_length=6, inputs=["hi"], outputs=["ab"],
+        supervise_termination=True, pad_loss_weight=1.0,
+    )
+    assert "canvas_loss_weight" not in out_uniform
+
+
+def test_supervise_termination_no_eos_token():
+    class NoEos(_FakeTokenizer):
+        eos_token_id = None
+        pad_token_id = 3
+
+    out = tokenize_canvas_batch(
+        NoEos(), canvas_length=5, inputs=["x"], outputs=["ab"],
+        supervise_termination=True,
+    )
+    ci = out["canvas_input_ids"][0]
+    cl = out["canvas_labels"][0]
+    t0, t1 = (ord("a") % 40) + 2, (ord("b") % 40) + 2
+    # No EOS to append -> answer + supervised pad(3) tail, no reserved EOS slot.
+    assert ci == [t0, t1, 3, 3, 3]
+    assert cl == [t0, t1, 3, 3, 3]
+    assert -100 not in cl
+
+
+def test_pad_token_id_fallbacks():
+    class NoPad:
+        pad_token_id = None
+        eos_token_id = 7
+
+    assert pad_token_id(NoPad()) == 7
+
+    class NoPadNoEos:
+        pad_token_id = None
+        eos_token_id = None
+
+    assert pad_token_id(NoPadNoEos()) == 0
+
+    class HasPad:
+        pad_token_id = 5
+        eos_token_id = 9
+
+    assert pad_token_id(HasPad()) == 5

--- a/test/unit/test_diffusion_corruption.py
+++ b/test/unit/test_diffusion_corruption.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for cray_megatron.megatron.diffusion_corruption.corrupt_canvas.
+
+DiffusionGemma trains by corrupting a clean canvas with uniform-vocabulary noise
+(sample t ~ U(eps, 1) per example, replace each supervised position with a random
+vocab token w.p. t — no [MASK] token) and learning to denoise it. These tests pin
+the invariants: replacements stay in-vocabulary, padding is never corrupted, the
+schedule is reproducible under a seeded generator, and high t corrupts heavily.
+Torch-only — no training harness or GPU.
+"""
+
+import torch
+
+from cray_megatron.megatron.diffusion_corruption import corrupt_canvas
+
+
+def _gen(seed):
+    g = torch.Generator()
+    g.manual_seed(seed)
+    return g
+
+
+def test_corruption_stays_in_vocab():
+    canvas = torch.tensor([[5, 6, 7, 0, 0]])
+    labels = torch.tensor([[5, 6, 7, -100, -100]])
+    vocab = 50
+    out = corrupt_canvas(canvas, labels, vocab, eps=0.5, generator=_gen(0))
+    assert out.shape == canvas.shape
+    assert out.dtype == canvas.dtype
+    assert int(out.min()) >= 0
+    assert int(out.max()) < vocab
+
+
+def test_padding_never_corrupted():
+    # Even at maximal corruption (t ~= 1), padding positions (labels == -100) are
+    # supervised=False and must retain the clean pad token.
+    canvas = torch.tensor([[5, 6, 7, 0, 0]])
+    labels = torch.tensor([[5, 6, 7, -100, -100]])
+    out = corrupt_canvas(canvas, labels, vocab_size=50, eps=1.0 - 1e-9, generator=_gen(1))
+    assert out[0, 3].item() == 0
+    assert out[0, 4].item() == 0
+
+
+def test_corruption_reproducible_with_seed():
+    canvas = torch.tensor([[5, 6, 7, 8, 9]])
+    labels = torch.tensor([[5, 6, 7, 8, 9]])
+    a = corrupt_canvas(canvas, labels, 50, 0.3, generator=_gen(42))
+    b = corrupt_canvas(canvas, labels, 50, 0.3, generator=_gen(42))
+    assert torch.equal(a, b)
+
+
+def test_high_t_corrupts_most_supervised_positions():
+    # t forced near 1 => nearly every supervised position is replaced. With a large
+    # vocab, collisions (random == clean) are negligible, so most positions differ.
+    canvas = torch.arange(2, 22).reshape(1, 20)
+    labels = canvas.clone()
+    out = corrupt_canvas(canvas, labels, vocab_size=1000, eps=1.0 - 1e-6, generator=_gen(7))
+    changed = int((out != canvas).sum())
+    assert changed > 10
+
+
+def test_protect_prefix_keeps_anchor_clean_at_max_t():
+    # Tier-2 anchor: position 0 is supervised (label != -100) but must stay clean
+    # every step. Even at t ~= 1, protect_prefix=1 keeps it equal to the input while
+    # the rest of the supervised canvas is heavily corrupted.
+    canvas = torch.arange(2, 22).reshape(1, 20)
+    labels = canvas.clone()  # fully supervised, no padding
+    out = corrupt_canvas(
+        canvas, labels, vocab_size=1000, eps=1.0 - 1e-6, generator=_gen(7), protect_prefix=1
+    )
+    assert out[0, 0].item() == canvas[0, 0].item()  # anchor untouched
+    assert int((out[:, 1:] != canvas[:, 1:]).sum()) > 10  # rest still corrupted
+
+
+def test_protect_prefix_zero_matches_default():
+    canvas = torch.tensor([[5, 6, 7, 8, 9]])
+    labels = canvas.clone()
+    a = corrupt_canvas(canvas, labels, 50, 0.3, generator=_gen(42))
+    b = corrupt_canvas(canvas, labels, 50, 0.3, generator=_gen(42), protect_prefix=0)
+    assert torch.equal(a, b)
+
+
+def test_low_t_corrupts_few_positions():
+    # t drawn from [eps, 1) with a tiny eps and a seed that yields a small t => few
+    # positions flip. This is a distributional check, not an exact count, so allow
+    # a generous bound: at eps=0.001 the expected corruption fraction is low.
+    canvas = torch.arange(2, 102).reshape(1, 100)
+    labels = canvas.clone()
+    out = corrupt_canvas(canvas, labels, vocab_size=1000, eps=0.001, generator=_gen(3))
+    changed = int((out != canvas).sum())
+    # Some corruption is possible but it must not be near-total at this eps/seed.
+    assert changed < 90

--- a/test/unit/test_doc_mask_decision.py
+++ b/test/unit/test_doc_mask_decision.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for cray_megatron.megatron.doc_mask.doc_mask_decision.
+
+The trainer packs short documents into one block and builds a 4D
+block-diagonal+causal attention mask so packed docs don't attend across each
+other. Text decoders accept the 4D mask; some ...ForConditionalGeneration
+wrappers (e.g. Gemma3ForConditionalGeneration) compute their loss internally and
+index the logits by a *2D* attention_mask, so a 4D mask raises
+`IndexError: too many indices for tensor of dimension 3` — the gemma-3-4b-it
+TRAIN_FAILED. For those models we fall back to the 2D mask. These tests use
+lightweight fakes (a dict batch + a config stub) so they don't import the heavy
+training_loop module (gpu_aware_mpi / mpi).
+"""
+
+from types import SimpleNamespace
+
+from cray_megatron.megatron.doc_mask import (
+    BUILD,
+    NONE,
+    SKIP_MULTIMODAL,
+    SKIP_SEQLEN,
+    SKIP_SSM,
+    doc_mask_decision,
+    has_ssm_layers,
+    is_multimodal,
+)
+
+CAP = 16384
+
+
+def _text_config():
+    return SimpleNamespace(model_type="llama")  # no vision_config attribute
+
+
+def _multimodal_config():
+    return SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+
+
+def _nemotron_h_config():
+    # NemotronH: per-layer block-type list naming a mamba block + the
+    # hybrid_override_pattern marker (verified against the real config.json).
+    return SimpleNamespace(
+        model_type="nemotron_h",
+        layers_block_type=["mamba", "mamba", "attention", "mlp"],
+        hybrid_override_pattern="M-M*-M-",
+    )
+
+
+def _falcon_h1_config():
+    # FalconH1: Mamba-2 ‖ attention, no per-layer block-type list — recognized by
+    # model_type alone.
+    return SimpleNamespace(model_type="falcon_h1")
+
+
+def test_packed_text_model_builds_4d_mask():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, 128, _text_config(), CAP) == BUILD
+
+
+def test_multimodal_skips_4d_mask_even_when_packed_and_short():
+    batch = {"document_ids": object()}
+    # The whole point of the fix: a vision-config wrapper must NOT get the 4D mask.
+    assert doc_mask_decision(batch, 128, _multimodal_config(), CAP) == SKIP_MULTIMODAL
+
+
+def test_seqlen_over_cap_skips_for_text_model():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _text_config(), CAP) == SKIP_SEQLEN
+
+
+def test_multimodal_skip_takes_precedence_over_seqlen():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _multimodal_config(), CAP) == SKIP_MULTIMODAL
+
+
+def test_ssm_hybrid_skips_4d_mask_even_when_packed_and_short():
+    # The Nemotron-H fix: a hybrid Mamba/SSM model must NOT get the 4D mask — its
+    # kernel-less mixer path multiplies by a 2D mask and a 4D one broadcasts to 5D.
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, 128, _nemotron_h_config(), CAP) == SKIP_SSM
+    # FalconH1 (no block-type list) is caught by model_type.
+    assert doc_mask_decision(batch, 128, _falcon_h1_config(), CAP) == SKIP_SSM
+
+
+def test_ssm_skip_takes_precedence_over_seqlen():
+    batch = {"document_ids": object()}
+    assert doc_mask_decision(batch, CAP + 1, _nemotron_h_config(), CAP) == SKIP_SSM
+
+
+def test_unpacked_ssm_batch_is_none():
+    # No packing → no special handling needed, even for an SSM model.
+    assert doc_mask_decision({}, 128, _nemotron_h_config(), CAP) == NONE
+
+
+def test_has_ssm_layers_predicate():
+    assert has_ssm_layers(_nemotron_h_config()) is True
+    assert has_ssm_layers(_falcon_h1_config()) is True
+    assert has_ssm_layers(_text_config()) is False
+    assert has_ssm_layers(_multimodal_config()) is False
+    assert has_ssm_layers(None) is False
+    # A block-type list with no mamba block is not SSM.
+    assert has_ssm_layers(
+        SimpleNamespace(model_type="x", layers_block_type=["attention", "mlp"])
+    ) is False
+
+
+def test_unpacked_batch_is_none():
+    assert doc_mask_decision({}, 128, _text_config(), CAP) == NONE
+    # Even a multimodal model with no packing needs no special handling.
+    assert doc_mask_decision({}, 128, _multimodal_config(), CAP) == NONE
+
+
+def test_is_multimodal_predicate():
+    assert is_multimodal(_multimodal_config()) is True
+    assert is_multimodal(_text_config()) is False
+    assert is_multimodal(None) is False
+    # vision_config present but None must read as not-multimodal.
+    assert is_multimodal(SimpleNamespace(vision_config=None)) is False

--- a/test/unit/test_job_config_diffusion.py
+++ b/test/unit/test_job_config_diffusion.py
@@ -1,0 +1,63 @@
+"""
+Unit tests for the per-job `diffusion` block on JobConfig.
+
+Contract under test: train_args["diffusion"] = {canvas_length, eps} passed via the
+SDK round-trips into JobConfig.diffusion and reaches the DiffusionGemma dataset
+loader / training step. Nested config blocks are exactly what the Pydantic model
+silently drops when a field isn't declared (the same footgun as `trust_remote_code`
+and `dtype`), so this pins that the block survives and defaults are sane.
+"""
+
+from cray_infra.util.default_job_config import JobConfig
+
+
+REQUIRED_FIELDS = {
+    "job_directory": "/tmp/job",
+    "training_data_path": "/tmp/dataset.jsonlines",
+    "dataset_hash": "abc",
+}
+
+
+def test_diffusion_defaults_to_none():
+    # Non-diffusion jobs carry no diffusion block; is_diffusion() gates whether it
+    # is ever read, so None is the correct "not applicable" default.
+    cfg = JobConfig(**REQUIRED_FIELDS).dict()
+    assert cfg["diffusion"] is None
+
+
+def test_diffusion_block_survives_roundtrip():
+    cfg = JobConfig(
+        **REQUIRED_FIELDS,
+        diffusion={"canvas_length": 128, "eps": 0.002},
+    ).dict()
+    assert cfg["diffusion"]["canvas_length"] == 128
+    assert cfg["diffusion"]["eps"] == 0.002
+    # self_conditioning_prob is unspecified here -> its DiffusionConfig default.
+    assert cfg["diffusion"]["self_conditioning_prob"] == 0.5
+    # anchor_token defaults off so prior runs stay byte-identical.
+    assert cfg["diffusion"]["anchor_token"] is False
+    # Termination-supervision defaults off; pad weight uniform.
+    assert cfg["diffusion"]["supervise_termination"] is False
+    assert cfg["diffusion"]["pad_loss_weight"] == 1.0
+
+
+def test_diffusion_supervise_termination_survives_roundtrip():
+    cfg = JobConfig(
+        **REQUIRED_FIELDS,
+        diffusion={"supervise_termination": True, "pad_loss_weight": 0.3},
+    ).dict()
+    assert cfg["diffusion"]["supervise_termination"] is True
+    assert cfg["diffusion"]["pad_loss_weight"] == 0.3
+
+
+def test_diffusion_anchor_token_survives_roundtrip():
+    cfg = JobConfig(**REQUIRED_FIELDS, diffusion={"anchor_token": True}).dict()
+    assert cfg["diffusion"]["anchor_token"] is True
+
+
+def test_diffusion_block_defaults_fill_missing_fields():
+    # A partial block still parses; the unspecified field takes the DiffusionConfig
+    # default (canvas_length 256, eps 0.001).
+    cfg = JobConfig(**REQUIRED_FIELDS, diffusion={"canvas_length": 512}).dict()
+    assert cfg["diffusion"]["canvas_length"] == 512
+    assert cfg["diffusion"]["eps"] == 0.001

--- a/test/unit/test_job_config_trust_remote_code.py
+++ b/test/unit/test_job_config_trust_remote_code.py
@@ -1,0 +1,41 @@
+"""
+Unit tests for the per-job `trust_remote_code` override.
+
+Contract under test: train_args["trust_remote_code"] passed via the SDK
+round-trips into JobConfig.trust_remote_code and reaches load_model, so
+models that ship custom modeling code (InternVL3, Molmo, GLM-4/ChatGLM,
+...) can be TRAINED. Before this fix the field was missing from JobConfig
+(Pydantic silently dropped it), so get_job_config() always returned the
+False default and load_model called AutoConfig.from_pretrained WITHOUT
+trust_remote_code — raising "contains custom code which must be executed
+... pass trust_remote_code=True" and TRAIN_FAILED, even though config.yaml
+carried `trust_remote_code: true`. Same failure mode as the historical
+`dtype` drop (see test_job_config_dtype.py).
+"""
+
+from cray_infra.util.default_job_config import JobConfig
+
+
+REQUIRED_FIELDS = {
+    "job_directory": "/tmp/job",
+    "training_data_path": "/tmp/dataset.jsonlines",
+    "dataset_hash": "abc",
+}
+
+
+def test_trust_remote_code_defaults_to_false():
+    cfg = JobConfig(**REQUIRED_FIELDS).dict()
+    assert cfg["trust_remote_code"] is False
+
+
+def test_trust_remote_code_override_survives_roundtrip():
+    # The regression: this key must NOT be dropped by the Pydantic model.
+    cfg = JobConfig(**REQUIRED_FIELDS, trust_remote_code=True).dict()
+    assert cfg["trust_remote_code"] is True
+
+
+def test_trust_remote_code_present_in_default_dict():
+    # load_model does job_config.get("trust_remote_code", False); the key
+    # should exist explicitly (not rely on the .get default) so the field
+    # is a first-class part of the job contract.
+    assert "trust_remote_code" in JobConfig(**REQUIRED_FIELDS).dict()

--- a/test/unit/test_nara_prototype.py
+++ b/test/unit/test_nara_prototype.py
@@ -1,0 +1,166 @@
+"""Runnable demonstration of the NaRA prototype against our diffusion corruption.
+
+Run:
+    PYTHONPATH=ml uv run --with pytest --with torch python -m pytest \
+        test/unit/test_nara_prototype.py -v
+
+These tests assert the three properties that make NaRA "correct" as a drop-in for our
+DiffusionGemma decoder-only LoRA, using the real ``corrupt_canvas`` as the noise source:
+
+1. At init, NaRA == plain LoRA (the zero-init mapper => Ceff == I residual).
+2. C(lambda) actually depends on the noise level once the mapper is non-trivial.
+3. The two-stage schedule freezes/unfreezes the mapper as intended, and a few
+   optimizer steps on a toy canvas-denoising loss reduce the loss (grad flows).
+"""
+
+import torch
+import torch.nn as nn
+
+from cray_megatron.megatron.diffusion_corruption import corrupt_canvas
+from adapters.nara_prototype import (
+    NaRAConfig,
+    NaRAContext,
+    NaRALinear,
+    inject_nara,
+)
+
+
+def _toy_canvas(batch=4, length=16, vocab=64, seed=0):
+    """A clean canvas with a few padded (label == -100) tail positions per row."""
+    g = torch.Generator().manual_seed(seed)
+    ids = torch.randint(0, vocab, (batch, length), generator=g)
+    labels = ids.clone()
+    labels[:, -3:] = -100  # simulate padding
+    ids[:, -3:] = 0
+    return ids, labels
+
+
+def test_corrupt_canvas_returns_noise_level():
+    """The hook NaRA needs: corrupt_canvas can now hand back the per-example lambda."""
+    ids, labels = _toy_canvas()
+    g = torch.Generator().manual_seed(1)
+    out = corrupt_canvas(ids, labels, vocab_size=64, eps=0.001, generator=g,
+                         return_noise_level=True)
+    assert isinstance(out, tuple) and len(out) == 2
+    decoder_input_ids, t = out
+    assert decoder_input_ids.shape == ids.shape
+    assert t.shape == (ids.shape[0], 1)
+    assert torch.all(t >= 0.001) and torch.all(t < 1.0)  # t ~ U(eps, 1)
+
+    # Backward compatible: default still returns just the tensor.
+    g2 = torch.Generator().manual_seed(1)
+    only = corrupt_canvas(ids, labels, vocab_size=64, eps=0.001, generator=g2)
+    assert torch.is_tensor(only)
+
+
+def test_nara_equals_plain_lora_at_init():
+    """Zero-init mapper => Ceff == I => delta is exactly the plain-LoRA delta."""
+    torch.manual_seed(0)
+    cfg = NaRAConfig(r=8, lora_alpha=16, lora_dropout=0.0)
+    base = nn.Linear(32, 48, bias=False)
+    ctx = NaRAContext(cfg)
+    layer = NaRALinear(base, ctx, cfg)
+    # Give B a nonzero value so the adapter is actually active (init B is zero).
+    with torch.no_grad():
+        layer.lora_B.copy_(torch.randn_like(layer.lora_B))
+
+    x = torch.randn(4, 10, 32)
+    t = torch.rand(4, 1) * 0.999 + 0.001
+    ctx.set_noise_level(t)  # mapper is zero-init => C == 0 => Ceff == I
+
+    got = layer(x)
+    # Reference plain-LoRA delta: scaling * (x @ A^T) @ B^T
+    ref = base(x) + cfg.lora_alpha / cfg.r * (x @ layer.lora_A.T) @ layer.lora_B.T
+    assert torch.allclose(got, ref, atol=1e-5), "NaRA must reduce to plain LoRA at init"
+
+
+def test_ceff_depends_on_noise_level():
+    """Once the mapper's last layer is non-zero, Ceff varies with lambda."""
+    torch.manual_seed(0)
+    cfg = NaRAConfig(r=8)
+    ctx = NaRAContext(cfg)
+    # Perturb the zero-init last layer so C(lambda) != 0.
+    last = [m for m in ctx.mapper.net if isinstance(m, nn.Linear)][-1]
+    with torch.no_grad():
+        last.weight.copy_(torch.randn_like(last.weight) * 0.5)
+
+    ctx.set_noise_level(torch.tensor([[0.1]]))
+    ceff_low = ctx.ceff.clone()
+    ctx.set_noise_level(torch.tensor([[0.9]]))
+    ceff_high = ctx.ceff.clone()
+
+    assert not torch.allclose(ceff_low, ceff_high), "Ceff should move with the noise level"
+    # Per-example batching: a (B,1) lambda yields a (B, r, r) stack.
+    ctx.set_noise_level(torch.rand(5, 1))
+    assert ctx.ceff.shape == (5, cfg.r, cfg.r)
+
+
+def test_two_stage_grad_flow():
+    """Stage 1 freezes the mapper (A/B only); stage 2 trains it too."""
+    cfg = NaRAConfig(r=8)
+    ctx = NaRAContext(cfg)
+    ctx.set_training_stage(1)
+    assert all(not p.requires_grad for p in ctx.mapper.parameters())
+    ctx.set_training_stage(2)
+    assert all(p.requires_grad for p in ctx.mapper.parameters())
+
+
+def test_toy_denoising_step_reduces_loss():
+    """End-to-end: corrupt a canvas, condition NaRA on its lambda, train a toy denoiser,
+    and confirm the loss drops. Exercises the exact call sequence prod would use."""
+    torch.manual_seed(0)
+    vocab, dim, length = 64, 32, 16
+    ids, labels = _toy_canvas(batch=8, length=length, vocab=vocab)
+
+    # Toy "denoiser": embed -> frozen linear tower (NaRA-adapted) -> vocab head.
+    class ToyDenoiser(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.emb = nn.Embedding(vocab, dim)
+            self.proj = nn.Linear(dim, dim)   # will be NaRA-adapted
+            self.head = nn.Linear(dim, vocab)
+
+        def forward(self, tokens):
+            return self.head(torch.tanh(self.proj(self.emb(tokens))))
+
+    model = ToyDenoiser()
+    ctx = inject_nara(model, target_modules=["proj"], config=NaRAConfig(r=8))
+    assert isinstance(model.proj, NaRALinear)
+
+    # Freeze everything except the adapter + mapper (LoRA-style), like create_lora_model.
+    trainable = []
+    for n, p in model.named_parameters():
+        p.requires_grad_("lora_" in n)
+    trainable += [p for p in model.parameters() if p.requires_grad]
+    trainable += list(ctx.parameters())
+    opt = torch.optim.AdamW(trainable, lr=1e-2)
+
+    def step():
+        g = torch.Generator().manual_seed(123)
+        decoder_input_ids, t = corrupt_canvas(
+            ids, labels, vocab_size=vocab, eps=0.001, generator=g, return_noise_level=True
+        )
+        ctx.set_noise_level(t)                 # <-- the NaRA hook
+        logits = model(decoder_input_ids)
+        return torch.nn.functional.cross_entropy(
+            logits.reshape(-1, vocab).float(), labels.reshape(-1), ignore_index=-100
+        )
+
+    first = step().item()
+    for _ in range(50):
+        opt.zero_grad()
+        loss = step()
+        loss.backward()
+        opt.step()
+    last = step().item()
+
+    assert last < first, f"loss did not drop: {first:.3f} -> {last:.3f}"
+
+
+if __name__ == "__main__":
+    test_corrupt_canvas_returns_noise_level()
+    test_nara_equals_plain_lora_at_init()
+    test_ceff_depends_on_noise_level()
+    test_two_stage_grad_flow()
+    test_toy_denoising_step_reduces_loss()
+    print("all NaRA prototype checks passed")

--- a/test/unit/test_nara_wiring.py
+++ b/test/unit/test_nara_wiring.py
@@ -1,0 +1,186 @@
+"""Wiring test: config flag -> create_lora_model NaRA branch -> checkpoint keys ->
+the training-step noise-level hook. Exercises the real integration seams on a tiny
+model (the actual DiffusionGemma-26B needs a GPU). See ADR 0012.
+
+Run:
+    PYTHONPATH=ml:infra uv run --with pytest --with torch --with pydantic \
+        python -m pytest test/unit/test_nara_wiring.py -v
+"""
+
+import torch
+import torch.nn as nn
+import pytest
+
+from adapters.nara_prototype import NaRALinear, NaRAContext, find_nara_context
+
+
+class TinyModel(nn.Module):
+    """Two 'decoder' linears with the leaf names resolve_target_modules would emit."""
+
+    def __init__(self, dim=16, vocab=32):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.q_proj = nn.Linear(dim, dim, bias=False)
+        self.o_proj = nn.Linear(dim, dim, bias=False)
+        self.lm_head = nn.Linear(dim, vocab, bias=False)
+
+    def forward(self, input_ids):
+        h = self.emb(input_ids)
+        h = self.o_proj(torch.tanh(self.q_proj(h)))
+        return self.lm_head(h)
+
+
+class _Backbone(nn.Module):
+    """Inner backbone (the module ``unwrap_model`` checkpoints via ``self.model``)."""
+
+    def __init__(self, dim=16, vocab=32):
+        super().__init__()
+        self.emb = nn.Embedding(vocab, dim)
+        self.q_proj = nn.Linear(dim, dim, bias=False)
+        self.o_proj = nn.Linear(dim, dim, bias=False)
+
+    def forward(self, input_ids):
+        h = self.emb(input_ids)
+        return self.o_proj(torch.tanh(self.q_proj(h)))
+
+
+class WrappedModel(nn.Module):
+    """Reproduces the HF ``…ForXXX`` outer/inner split that hid the checkpoint bug:
+    the targeted linears live in ``self.model`` (the backbone), and ``unwrap_model``
+    saves ``self.model.state_dict()`` — so a context registered on the OUTER wrapper
+    is a sibling of the saved sub-tree and gets dropped. Mirrors DiffusionGemma."""
+
+    def __init__(self, dim=16, vocab=32):
+        super().__init__()
+        self.model = _Backbone(dim, vocab)
+        self.lm_head = nn.Linear(dim, vocab, bias=False)
+
+    def forward(self, input_ids):
+        return self.lm_head(self.model(input_ids))
+
+
+def _patch_job_config(monkeypatch, nara_block):
+    """Point create_lora_model.get_job_config at a fixed config dict."""
+    import adapters.create_lora_model as clm
+
+    cfg = {
+        "lora_config": {"r": 8, "lora_alpha": 16, "lora_dropout": 0.0,
+                        "target_modules": ["q_proj", "o_proj"]},
+        "diffusion": {"nara": nara_block},
+    }
+    monkeypatch.setattr(clm, "get_job_config", lambda: cfg)
+    return cfg
+
+
+def test_flag_off_uses_plain_lora(monkeypatch):
+    """nara.enabled=False (or absent) must NOT take the NaRA path — falls through to
+    PEFT LoRA. We only assert the branch is skipped (no NaRALinear injected)."""
+    from adapters.create_lora_model import _nara_config
+
+    assert _nara_config({"diffusion": {"nara": {"enabled": False}}}) is None
+    assert _nara_config({"diffusion": {}}) is None
+    assert _nara_config({}) is None
+    assert _nara_config({"diffusion": {"nara": {"enabled": True}}}) == {"enabled": True}
+
+
+def test_nara_branch_injects_and_marks_trainable(monkeypatch):
+    from adapters.create_lora_model import create_lora_model
+
+    _patch_job_config(monkeypatch, {"enabled": True, "c_scale": 0.1})
+    model = create_lora_model(TinyModel(), device="cpu", train_lm_head=False)
+
+    # Both targeted linears became NaRALinear; lm_head did not.
+    assert isinstance(model.q_proj, NaRALinear)
+    assert isinstance(model.o_proj, NaRALinear)
+    assert not isinstance(model.lm_head, NaRALinear)
+
+    # One shared context is reachable and registered exactly once.
+    ctx = find_nara_context(model)
+    assert isinstance(ctx, NaRAContext)
+    n_ctx = sum(1 for m in model.modules() if isinstance(m, NaRAContext))
+    assert n_ctx == 1, "context must be registered once, not per-layer"
+
+    # Base weights frozen; adapter + mapper trainable.
+    assert not model.q_proj.base.weight.requires_grad
+    assert model.q_proj.lora_A.requires_grad and model.q_proj.lora_B.requires_grad
+    assert any(p.requires_grad for p in ctx.mapper.parameters())
+
+
+def test_checkpoint_keys_include_mapper_no_duplicates(monkeypatch):
+    """filter_checkpoint saves requires_grad params. The NaRA branch must contribute
+    lora_A/lora_B AND the shared mapper — the mapper exactly once (weakref, not a
+    per-layer submodule)."""
+    from adapters.create_lora_model import create_lora_model, filter_checkpoint
+
+    _patch_job_config(monkeypatch, {"enabled": True})
+    model = create_lora_model(TinyModel(), device="cpu", train_lm_head=False)
+
+    saved = filter_checkpoint(model, model.state_dict())
+    lora_keys = [k for k in saved if "lora_" in k]
+    mapper_keys = [k for k in saved if "nara_context.mapper" in k]
+
+    assert any("q_proj.lora_A" in k for k in lora_keys)
+    assert any("o_proj.lora_B" in k for k in lora_keys)
+    assert mapper_keys, "shared hypernetwork weights must be checkpointed"
+    # Mapper registered once => no 'q_proj.context...'/'o_proj.context...' duplicates.
+    assert not [k for k in saved if ".context." in k]
+
+
+def test_checkpoint_survives_outer_wrapper(monkeypatch):
+    """Regression: with a HF-style outer/inner wrapper, the REAL save path
+    (model.unwrap_model() -> filter_checkpoint(self.model, ...)) must still carry the
+    shared mapper. Before the fix the context sat on the outer wrapper, outside the
+    checkpointed backbone, and the mapper was silently dropped (plain-LoRA .pt)."""
+    from adapters.create_lora_model import create_lora_model
+
+    _patch_job_config(monkeypatch, {"enabled": True})
+    model = create_lora_model(WrappedModel(), device="cpu", train_lm_head=False)
+
+    saved = model.unwrap_model()  # the exact path the training loop checkpoints with
+    mapper_keys = [k for k in saved if "nara_context.mapper" in k]
+    lora_keys = [k for k in saved if "lora_" in k]
+
+    assert mapper_keys, f"mapper dropped from checkpoint; got keys={sorted(saved)[:8]}"
+    assert any("q_proj.lora_A" in k for k in lora_keys)
+    assert any("o_proj.lora_B" in k for k in lora_keys)
+    # Exactly one shared mapper, no per-layer duplication.
+    assert not [k for k in saved if ".context." in k]
+    # Keys are backbone-relative (no leaked outer 'model.' prefix on the mapper).
+    assert all(k.startswith("nara_context.mapper") for k in mapper_keys)
+
+
+def test_training_step_hook_sets_noise_level(monkeypatch):
+    """Simulate _diffusion_training_step_accumulate's hook: corrupt -> set_noise_level
+    -> forward. Assert the adapter's cached Ceff reflects the corruption level and that
+    a backward populates grads on lora + mapper."""
+    from adapters.create_lora_model import create_lora_model
+    from cray_megatron.megatron.diffusion_corruption import corrupt_canvas
+
+    _patch_job_config(monkeypatch, {"enabled": True})
+    model = create_lora_model(TinyModel(vocab=32), device="cpu", train_lm_head=True)
+    ctx = find_nara_context(model)
+    # Make the mapper non-trivial so Ceff actually depends on t.
+    last = [m for m in ctx.mapper.net if isinstance(m, nn.Linear)][-1]
+    with torch.no_grad():
+        last.weight.copy_(torch.randn_like(last.weight) * 0.3)
+
+    ids = torch.randint(0, 32, (4, 12))
+    labels = ids.clone()
+    labels[:, -2:] = -100
+    g = torch.Generator().manual_seed(7)
+    decoder_input_ids, t = corrupt_canvas(ids, labels, vocab_size=32, eps=0.001,
+                                          generator=g, return_noise_level=True)
+    ctx.set_noise_level(t)                       # the hook under test
+    assert ctx.ceff.shape == (4, 8, 8)           # per-example (B, r, r)
+
+    logits = model(decoder_input_ids)
+    loss = torch.nn.functional.cross_entropy(
+        logits.reshape(-1, 32).float(), labels.reshape(-1), ignore_index=-100
+    )
+    loss.backward()
+    assert model.q_proj.lora_A.grad is not None
+    assert any(p.grad is not None for p in ctx.mapper.parameters())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/unit/test_resolve_target_modules.py
+++ b/test/unit/test_resolve_target_modules.py
@@ -1,0 +1,1018 @@
+"""
+Unit tests for adapters.resolve_target_modules.resolve_target_modules.
+
+PEFT's "all-linear" shorthand fails to expand for some architectures
+(notably MoE: Qwen3MoeForCausalLM under peft 0.19 + transformers 5.x). PEFT
+falls back to iterating the literal string as a set of characters and raises
+`Target modules {'-','l','n','r','i','a','e'} not found in the base model`,
+which is the qwen3-moe TRAIN_FAILED in the cuda-spark sweep. We resolve the
+shorthand ourselves from the live model, so these tests use small synthetic
+nn.Modules rather than HF downloads.
+"""
+
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from adapters.resolve_target_modules import (
+    resolve_target_modules,
+    resolve_target_parameters,
+)
+
+
+class _DenseLike(nn.Module):
+    """A miniature ...ForCausalLM: attention + MLP projections + an output head,
+    with several layers so leaf names repeat (as in a real stacked model)."""
+
+    def __init__(self, n_layers=3):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+class _NoOutputEmbeddings(nn.Module):
+    """A model whose get_output_embeddings() returns None (some configs do);
+    the output head must still be excluded by its conventional leaf name."""
+
+    def __init__(self):
+        super().__init__()
+        self.q_proj = nn.Linear(8, 8, bias=False)
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return None
+
+
+class _GroupedExperts(nn.Module):
+    """Qwen3MoE-style *grouped* experts: batched weights held as `nn.Parameter`s
+    (no per-expert `nn.Linear`), matching transformers-5.x `Qwen3MoeExperts`. PEFT
+    adapts these on its own via `ParamWrapper` and the grouped serve converter
+    handles the fused export, so the resolver — which targets `nn.Linear` — never
+    lists them. (The real `qwen3-moe-tiny-random` loads as this grouped module,
+    per the PEFT `ParamWrapper(Qwen3MoeExperts)` tree in the 2026-06-30 report;
+    the earlier per-expert-`nn.Linear` stub was inaccurate for Qwen3MoE.)"""
+
+    def __init__(self, n_experts, dim=8, inter=8):
+        super().__init__()
+        self.gate_up_proj = nn.Parameter(torch.zeros(n_experts, dim, 2 * inter))
+        self.down_proj = nn.Parameter(torch.zeros(n_experts, inter, dim))
+
+
+class _MoeLike(nn.Module):
+    """A miniature Qwen3MoE-style ...ForCausalLM mirroring `decoder_sparse_step`:
+    some decoder layers carry a *dense* MLP (`gate_proj`/`up_proj`/`down_proj`)
+    and others a *sparse* MLP with a router (`gate`) + GROUPED routed experts
+    (`_GroupedExperts`, nn.Parameters — not per-expert Linears). By default layer 0
+    is dense and layer 1 is sparse — the real `qwen3-moe-tiny-random` layout
+    (decoder_sparse_step=2). The grouped experts are adapted by PEFT itself and the
+    router can't be served from a .pt adapter, so resolution adapts attention + the
+    dense MLP only — and by *full path*, since the dense MLP shares leaf names with
+    (other) MoE submodules. See `_SeparateMoeLike` for the Mixtral/PhiMoE layout."""
+
+    def __init__(self, sparse_layers=(1,), n_layers=2, n_experts=4, router_name="gate"):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _sparse_mlp():
+            return nn.ModuleDict(
+                {
+                    # The MoE router. Its leaf name varies by arch (`gate` in
+                    # Qwen3MoE, `router` in PhiMoE); in PhiMoE it is an nn.Linear
+                    # *subclass* whose forward returns a 3-tuple, so LoRA-wrapping
+                    # it crashes PEFT (`'tuple' object has no attribute 'dtype'`).
+                    # Resolution must exclude it by name regardless.
+                    router_name: nn.Linear(8, n_experts, bias=False),
+                    "experts": _GroupedExperts(n_experts),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mlp": _sparse_mlp() if i in sparse_layers else _dense_mlp(),
+                }
+            )
+            for i in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_moe_adapts_attention_and_dense_mlp_excluding_experts_and_router():
+    # Layer 0 dense, layer 1 sparse (the real qwen3-moe-tiny-random layout).
+    model = _MoeLike(sparse_layers=(1,), n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    # Full paths: attention on every layer + the DENSE MLP (layer 0 only),
+    # but no experts, no router, no head.
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any(".experts." in name for name in result)  # no routed experts
+    assert not any(name.endswith(".gate") for name in result)  # no router
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_moe_excludes_router_named_router_phimoe():
+    # The router-leaf rule: a router named `router` (not `gate`) must be excluded
+    # too. PhiMoE names its router `mlp.router` and it is an nn.Linear subclass
+    # returning a tuple; LoRA-wrapping it crashes training. Exercised here on the
+    # grouped fixture (the rule is layout-independent); the full separate-expert
+    # PhiMoE layout is covered in test_separate_expert_moe_* below.
+    model = _MoeLike(sparse_layers=(1,), n_layers=2, router_name="router")
+    result = resolve_target_modules(model, "all-linear")
+    assert not any(name.endswith(".router") for name in result)  # router excluded
+    assert "layers.1.mlp.router" not in result
+    # Attention on every layer plus the layer-0 dense MLP still resolve.
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+
+
+def test_moe_all_layers_sparse_adapts_attention_only():
+    # If every layer is sparse (no dense MLP anywhere), only attention survives.
+    model = _MoeLike(sparse_layers=(0, 1), n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any("mlp" in name for name in result)
+
+
+def test_grouped_experts_yield_expert_target_parameters():
+    # A grouped experts module (named `experts`, as it always is in a real decoder)
+    # exposes its batched projections as the target_parameters PEFT needs —
+    # target_modules can't reach bare nn.Parameters.
+    holder = nn.ModuleDict({"experts": _GroupedExperts(n_experts=4)})
+    assert resolve_target_parameters(holder) == ["down_proj", "gate_up_proj"]
+
+
+def test_grouped_moe_target_parameters_regardless_of_dense_layer():
+    # Grouped MoE with a dense layer (Qwen3MoE-like) AND all-sparse (OLMoE-like):
+    # both must surface the grouped expert params. This is the fix — OLMoE/PhiMoE
+    # have no dense layer to seed PEFT's own conversion, so without naming these
+    # params their experts got no LoRA.
+    assert resolve_target_parameters(_MoeLike(sparse_layers=(1,), n_layers=2)) == [
+        "down_proj",
+        "gate_up_proj",
+    ]
+    assert resolve_target_parameters(_MoeLike(sparse_layers=(0, 1), n_layers=2)) == [
+        "down_proj",
+        "gate_up_proj",
+    ]
+
+
+def test_dense_model_has_no_expert_target_parameters():
+    assert resolve_target_parameters(_DenseLike()) == []
+
+
+class _SeparateMoeLike(nn.Module):
+    """A miniature Mixtral/PhiMoE-style ...ForCausalLM whose routed experts are a
+    `ModuleList` of per-expert `nn.Linear` projections (`mlp.experts.{i}.{w1,w2,w3}`)
+    rather than a grouped param module. Unlike grouped Qwen3MoE, PEFT does NOT
+    auto-adapt these per-expert Linears, so resolution must INCLUDE them (by full
+    path) to train the experts — while still excluding the router and output head.
+    The separate-expert serve converter then stacks them for FusedMoEWithLoRA."""
+
+    def __init__(self, sparse_layers=(0,), n_layers=1, n_experts=2, router_name="router"):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _expert():  # Mixtral/PhiMoE per-expert SwiGLU: w1=gate, w3=up, w2=down.
+            return nn.ModuleDict(
+                {
+                    "w1": nn.Linear(8, 8, bias=False),
+                    "w2": nn.Linear(8, 8, bias=False),
+                    "w3": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _sparse_mlp():
+            return nn.ModuleDict(
+                {
+                    router_name: nn.Linear(8, n_experts, bias=False),
+                    "experts": nn.ModuleList(_expert() for _ in range(n_experts)),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mlp": _sparse_mlp() if i in sparse_layers else _dense_mlp(),
+                }
+            )
+            for i in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_separate_expert_moe_includes_per_expert_linears():
+    # PhiMoE/Mixtral: per-expert nn.Linear experts (w1/w2/w3) ARE adapted — they
+    # carry memorization and the separate-expert converter can serve them, unlike
+    # grouped Qwen3MoE experts. Router (leaf `router`) and head stay excluded.
+    model = _SeparateMoeLike(sparse_layers=(0,), n_layers=1, n_experts=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.mlp.experts.0.w1",
+        "layers.0.mlp.experts.0.w2",
+        "layers.0.mlp.experts.0.w3",
+        "layers.0.mlp.experts.1.w1",
+        "layers.0.mlp.experts.1.w2",
+        "layers.0.mlp.experts.1.w3",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+    ]
+    assert any(".experts.0.w1" in name for name in result)  # experts INCLUDED
+    assert not any(name.endswith(".router") for name in result)  # router excluded
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_separate_expert_moe_includes_experts_and_dense_mlp():
+    # A mixed model (layer 0 dense, layer 1 sparse): the dense MLP AND the sparse
+    # layer's per-expert Linears are both adapted, plus attention on every layer.
+    model = _SeparateMoeLike(sparse_layers=(1,), n_layers=2, n_experts=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert "layers.0.mlp.gate_proj" in result  # dense MLP on the dense layer
+    assert "layers.1.mlp.experts.1.w2" in result  # per-expert on the sparse layer
+    assert "layers.0.self_attn.q_proj" in result
+    assert not any(name.endswith(".router") for name in result)
+    assert not any("lm_head" in name for name in result)
+
+
+class _MixtralLike(nn.Module):
+    """Mixtral names its MoE block `block_sparse_moe` with a `gate` router and
+    per-expert `experts.{i}.{w1,w2,w3}` Linears. Resolution must INCLUDE the
+    per-expert Linears (separate layout) while still excluding the `gate` router —
+    verifying the separate-expert branch fires before the `.block_sparse_moe`
+    grouped-exclusion (which is only meant for Granite's fused experts)."""
+
+    def __init__(self, n_experts=2):
+        super().__init__()
+
+        def _expert():
+            return nn.ModuleDict(
+                {
+                    "w1": nn.Linear(8, 8, bias=False),
+                    "w2": nn.Linear(8, 8, bias=False),
+                    "w3": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "self_attn": nn.ModuleDict(
+                            {
+                                "q_proj": nn.Linear(8, 8, bias=False),
+                                "k_proj": nn.Linear(8, 8, bias=False),
+                                "v_proj": nn.Linear(8, 8, bias=False),
+                                "o_proj": nn.Linear(8, 8, bias=False),
+                            }
+                        ),
+                        "block_sparse_moe": nn.ModuleDict(
+                            {
+                                "gate": nn.Linear(8, n_experts, bias=False),  # router
+                                "experts": nn.ModuleList(
+                                    _expert() for _ in range(n_experts)
+                                ),
+                            }
+                        ),
+                    }
+                )
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_mixtral_block_sparse_moe_separate_experts_included_router_excluded():
+    model = _MixtralLike(n_experts=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.block_sparse_moe.experts.0.w1",
+        "layers.0.block_sparse_moe.experts.0.w2",
+        "layers.0.block_sparse_moe.experts.0.w3",
+        "layers.0.block_sparse_moe.experts.1.w1",
+        "layers.0.block_sparse_moe.experts.1.w2",
+        "layers.0.block_sparse_moe.experts.1.w3",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+    ]
+    # The `gate` router under block_sparse_moe is excluded despite the experts
+    # under the same subtree being included.
+    assert not any(name.endswith(".gate") for name in result)
+
+
+class _GraniteHybridLike(nn.Module):
+    """A miniature GraniteMoeHybrid ...ForCausalLM mirroring the real leaf naming
+    (verified by a meta-device HF init of ibm-granite/granite-4.0-h-tiny):
+
+    - attention (attention layers only): self_attn.{q,k,v,o}_proj
+    - dense shared MLP (serveable, every layer): shared_mlp.{input_linear, output_linear}
+    - grouped routed experts (NOT .pt-serveable): block_sparse_moe.{input_linear, output_linear}
+    - router (leaf name `layer`, not gate/router): block_sparse_moe.router.layer
+    - Mamba-2 SSM (not adapted): mamba.{in_proj, out_proj}
+
+    There is NO `.experts` submodule — the resolver must detect MoE via
+    `block_sparse_moe`. Layer 0 is a Mamba layer (mamba + moe + shared_mlp); layer 1
+    is an attention layer (self_attn + moe + shared_mlp)."""
+
+    def __init__(self, n_experts=4):
+        super().__init__()
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _shared_mlp():
+            return nn.ModuleDict(
+                {
+                    "input_linear": nn.Linear(8, 16, bias=False),
+                    "output_linear": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _block_sparse_moe():
+            return nn.ModuleDict(
+                {
+                    # grouped experts: fused input/output linear, not .pt-serveable
+                    "input_linear": nn.Linear(8, 16, bias=False),
+                    "output_linear": nn.Linear(8, 8, bias=False),
+                    # router — leaf name is `layer` (block_sparse_moe.router.layer)
+                    "router": nn.ModuleDict({"layer": nn.Linear(8, n_experts, bias=False)}),
+                }
+            )
+
+        def _mamba():
+            return nn.ModuleDict(
+                {
+                    "in_proj": nn.Linear(8, 16, bias=False),
+                    "out_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "mamba": _mamba(),
+                        "block_sparse_moe": _block_sparse_moe(),
+                        "shared_mlp": _shared_mlp(),
+                    }
+                ),
+                nn.ModuleDict(
+                    {
+                        "self_attn": _attn(),
+                        "block_sparse_moe": _block_sparse_moe(),
+                        "shared_mlp": _shared_mlp(),
+                    }
+                ),
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_granite_hybrid_adapts_attention_and_shared_mlp_only():
+    # Granite has no `.experts` submodule — MoE detection must fire on
+    # `block_sparse_moe`, and resolution must exclude the grouped experts + router
+    # (`block_sparse_moe.*`) and the Mamba SSM (`mamba.*`), keeping attention and
+    # the dense shared MLP — by full path, since shared_mlp and the experts share
+    # the `input_linear`/`output_linear` leaf names.
+    model = _GraniteHybridLike()
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.shared_mlp.input_linear",
+        "layers.0.shared_mlp.output_linear",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+        "layers.1.shared_mlp.input_linear",
+        "layers.1.shared_mlp.output_linear",
+    ]
+    assert not any(".block_sparse_moe." in name for name in result)  # no experts/router
+    assert not any(".mamba." in name for name in result)  # no SSM projections
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+class _DeepseekV2Like(nn.Module):
+    """A miniature DeepseekV2ForCausalLM (DeepSeek-V2-Lite): MLA attention + a MoE MLP
+    with grouped routed experts, an always-on `shared_experts` MLP, and a `gate`
+    router. Mirrors the real leaf naming (verified against the trained adapter):
+
+    - MLA attention: self_attn.{q_proj, kv_a_proj_with_mqa, kv_b_proj, o_proj}
+      (q_lora_rank=None → plain `q_proj`, not q_a/q_b). On serve, vLLM absorbs
+      `kv_b_proj`/`kv_a_proj_with_mqa` into the latent-attention kernel, so LoRA on
+      them is dropped — they must be EXCLUDED; `q_proj`/`o_proj` serve clean and stay.
+    - MoE MLP (layer 1): grouped `experts` (nn.Parameters), `shared_experts.{gate,up,
+      down}_proj` (dense, serveable), `gate` router.
+    - dense MLP (layer 0): mlp.{gate,up,down}_proj.
+
+    Expected: attention `q_proj`/`o_proj` + dense MLP + shared_experts, excluding the
+    MLA latent projections, the grouped experts, and the router."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="deepseek_v2", vision_config=None)
+
+        def _mla_attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "kv_a_proj_with_mqa": nn.Linear(8, 8, bias=False),
+                    "kv_b_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _dense_mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _moe_mlp():
+            return nn.ModuleDict(
+                {
+                    "experts": _GroupedExperts(n_experts=4),
+                    "shared_experts": nn.ModuleDict(
+                        {
+                            "gate_proj": nn.Linear(8, 8, bias=False),
+                            "up_proj": nn.Linear(8, 8, bias=False),
+                            "down_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "gate": nn.Linear(8, 4, bias=False),  # router
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict({"self_attn": _mla_attn(), "mlp": _dense_mlp()}),
+                nn.ModuleDict({"self_attn": _mla_attn(), "mlp": _moe_mlp()}),
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_deepseek_v2_excludes_mla_latent_projections():
+    # DeepSeek-V2 MLA: the absorbed latent projections (kv_a_proj_with_mqa, kv_b_proj)
+    # must be excluded (vLLM absorbs them → LoRA dropped on serve = the NO_MEM
+    # near-miss), while q_proj/o_proj + dense MLP + shared_experts stay, and the
+    # grouped experts + router are excluded as usual.
+    model = _DeepseekV2Like()
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.mlp.down_proj",
+        "layers.0.mlp.gate_proj",
+        "layers.0.mlp.up_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.1.mlp.shared_experts.down_proj",
+        "layers.1.mlp.shared_experts.gate_proj",
+        "layers.1.mlp.shared_experts.up_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+    ]
+    assert not any("kv_a_proj_with_mqa" in n for n in result)  # MLA latent — absorbed
+    assert not any("kv_b_proj" in n for n in result)  # MLA up-proj — absorbed
+    assert not any(".experts." in n or n.endswith(".experts") for n in result)  # grouped experts off
+    assert not any(n.endswith(".gate") for n in result)  # router off
+
+
+def test_deepseek_v2_grouped_experts_via_target_parameters():
+    # The grouped routed experts still surface as target_parameters (served by the
+    # grouped converter) — the MLA exclusion only affects target_modules.
+    model = _DeepseekV2Like()
+    assert resolve_target_parameters(model) == ["down_proj", "gate_up_proj"]
+
+
+class _FalconH1Like(nn.Module):
+    """A miniature FalconH1ForCausalLM mirroring the real leaf naming (verified
+    against transformers 5.x modeling_falcon_h1.py: FalconH1DecoderLayer has
+    `self.self_attn`, `self.mamba`, `self.feed_forward`):
+
+    - attention (every layer): self_attn.{q,k,v,o}_proj  (uses `o_proj`)
+    - Mamba-2 mixer (every layer): mamba.{in_proj, out_proj} + a `conv1d`
+      (nn.Conv1d, not Linear) — the SSM runs ‖ attention, and it holds the
+      `out_proj` PEFT rejects on Mamba model_types.
+    - dense MLP (every layer): feed_forward.{gate,up,down}_proj
+
+    Dense (no MoE, no vision_config). `config.model_type == "falcon_h1"` so PEFT's
+    `_check_lora_target_modules_mamba` would fire if `out_proj` reached the targets.
+    Expected: LoRA on attention + MLP, with the whole `.mamba` subtree excluded."""
+
+    def __init__(self, n_layers=2):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="falcon_h1", vision_config=None)
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _mamba():
+            m = nn.ModuleDict(
+                {
+                    "in_proj": nn.Linear(8, 16, bias=False),
+                    "out_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+            # The 1-D short conv — an nn.Conv1d, not a Linear (so never a target
+            # anyway), but present in the real mixer and named `conv1d`.
+            m.conv1d = nn.Conv1d(8, 8, kernel_size=4, groups=8, bias=False)
+            return m
+
+        def _mlp():
+            return nn.ModuleDict(
+                {
+                    "gate_proj": nn.Linear(8, 8, bias=False),
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        self.layers = nn.ModuleList(
+            nn.ModuleDict(
+                {
+                    "self_attn": _attn(),
+                    "mamba": _mamba(),
+                    "feed_forward": _mlp(),
+                }
+            )
+            for _ in range(n_layers)
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_falcon_h1_dense_hybrid_adapts_attention_and_mlp_excluding_mamba():
+    # FalconH1: dense Mamba-2 ‖ attention. The `.mamba` mixer subtree (incl. its
+    # `out_proj`, which PEFT refuses on Mamba model_types) must be excluded, leaving
+    # attention + MLP on every layer — by full path.
+    model = _FalconH1Like(n_layers=2)
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.0.feed_forward.down_proj",
+        "layers.0.feed_forward.gate_proj",
+        "layers.0.feed_forward.up_proj",
+        "layers.0.self_attn.k_proj",
+        "layers.0.self_attn.o_proj",
+        "layers.0.self_attn.q_proj",
+        "layers.0.self_attn.v_proj",
+        "layers.1.feed_forward.down_proj",
+        "layers.1.feed_forward.gate_proj",
+        "layers.1.feed_forward.up_proj",
+        "layers.1.self_attn.k_proj",
+        "layers.1.self_attn.o_proj",
+        "layers.1.self_attn.q_proj",
+        "layers.1.self_attn.v_proj",
+    ]
+    assert not any(".mamba." in name for name in result)  # SSM mixer excluded
+    assert not any(name.endswith(".out_proj") for name in result)  # the PEFT-rejected leaf
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_falcon_h1_dense_hybrid_has_no_expert_target_parameters():
+    # FalconH1 is dense (no grouped experts) — no target_parameters.
+    assert resolve_target_parameters(_FalconH1Like()) == []
+
+
+class _NemotronHMambaMixer(nn.Module):
+    """NemotronH's Mamba-2 mixer: `in_proj`/`out_proj` (nn.Linear) + a `conv1d`
+    and the selective-scan `A_log`/`D`/`dt_bias` parameters. The `A_log` param is
+    what identifies it structurally — its module attribute is `mixer` (shared with
+    attention/MLP blocks), NOT `.mamba`, so a name check can't tell it apart."""
+
+    def __init__(self):
+        super().__init__()
+        self.in_proj = nn.Linear(8, 16, bias=False)
+        self.out_proj = nn.Linear(8, 8, bias=False)
+        self.conv1d = nn.Conv1d(8, 8, kernel_size=4, groups=8, bias=False)
+        self.A_log = nn.Parameter(torch.zeros(8))
+        self.D = nn.Parameter(torch.zeros(8))
+        self.dt_bias = nn.Parameter(torch.zeros(8))
+
+
+class _NemotronHLike(nn.Module):
+    """A miniature NemotronHForCausalLM mirroring the real module naming (verified
+    by meta-init of transformers 5.12 modeling_nemotron_h.py): every decoder layer
+    holds a single `.mixer` whose class varies by block type
+    (`hybrid_override_pattern`) —
+
+    - Mamba-2 mixer: mixer.{in_proj, out_proj} + a `conv1d` and an `A_log` param
+      (the selective-scan signature; the attribute is `.mixer`, NOT `.mamba`, so
+      only the signature tells it apart),
+    - attention mixer: mixer.{q,k,v,o}_proj (uses `o_proj`, not `out_proj`),
+    - MLP mixer: mixer.{up,down}_proj.
+
+    Dense (no MoE, no vision_config). `model_type == "nemotron_h"` is NOT in PEFT's
+    Mamba-incompatible set, so PEFT would NOT reject the SSM `out_proj` — but vLLM
+    drops LoRA on the SSM projections on serve, so they must still be excluded.
+    Expected: LoRA on attention + MLP with the whole `.mixer` Mamba subtree off."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(model_type="nemotron_h", vision_config=None)
+
+        def _attn():
+            return nn.ModuleDict(
+                {
+                    "q_proj": nn.Linear(8, 8, bias=False),
+                    "k_proj": nn.Linear(8, 8, bias=False),
+                    "v_proj": nn.Linear(8, 8, bias=False),
+                    "o_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        def _mlp():
+            return nn.ModuleDict(
+                {
+                    "up_proj": nn.Linear(8, 8, bias=False),
+                    "down_proj": nn.Linear(8, 8, bias=False),
+                }
+            )
+
+        # One of each block type, interleaved as NemotronH does.
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict({"mixer": _NemotronHMambaMixer()}),
+                nn.ModuleDict({"mixer": _mlp()}),
+                nn.ModuleDict({"mixer": _attn()}),
+            ]
+        )
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_nemotron_h_dense_hybrid_adapts_attention_and_mlp_excluding_mamba():
+    # NemotronH: dense Mamba-2 / attention / MLP interleave, mixer named `.mixer`.
+    # The Mamba mixer is detected by its `A_log` signature (not by name) and its
+    # in_proj/out_proj excluded, leaving attention + MLP — by full path.
+    model = _NemotronHLike()
+    result = resolve_target_modules(model, "all-linear")
+    assert result == [
+        "layers.1.mixer.down_proj",
+        "layers.1.mixer.up_proj",
+        "layers.2.mixer.k_proj",
+        "layers.2.mixer.o_proj",
+        "layers.2.mixer.q_proj",
+        "layers.2.mixer.v_proj",
+    ]
+    # The SSM mixer's own projections are excluded (in_proj/out_proj), even though
+    # PEFT would NOT reject them for model_type nemotron_h — vLLM drops them on serve.
+    assert not any(name.endswith(".in_proj") for name in result)
+    assert not any(name.endswith(".out_proj") for name in result)
+    assert not any("lm_head" in name for name in result)  # no output head
+
+
+def test_nemotron_h_dense_hybrid_has_no_expert_target_parameters():
+    # NemotronH-8B is dense (no grouped experts) — no target_parameters.
+    assert resolve_target_parameters(_NemotronHLike()) == []
+
+
+def test_no_expert_target_parameters_for_non_grouped_layouts():
+    # target_parameters is ONLY for grouped bare-nn.Parameter experts. Separate
+    # per-expert nn.Linear experts (Mixtral/PhiMoE-in-v4) are trained via
+    # target_modules, and Granite's nn.Linear-fused experts expose no bare param —
+    # all three must yield NO target_parameters (else PEFT double-wraps / errors).
+    assert resolve_target_parameters(_SeparateMoeLike(sparse_layers=(0,), n_layers=1)) == []
+    assert resolve_target_parameters(_MixtralLike(n_experts=2)) == []
+    assert resolve_target_parameters(_GraniteHybridLike()) == []
+
+
+def test_all_linear_expands_to_distinct_leaf_names_minus_head():
+    model = _DenseLike()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == [
+        "down_proj",
+        "gate_proj",
+        "k_proj",
+        "o_proj",
+        "q_proj",
+        "up_proj",
+        "v_proj",
+    ]
+    assert "lm_head" not in resolved
+
+
+def test_repeated_leaf_names_collapse_to_a_set():
+    # 3 layers × 7 projections, but only 7 distinct leaf names survive.
+    model = _DenseLike(n_layers=3)
+    resolved = resolve_target_modules(model, "all-linear")
+    assert len(resolved) == 7
+
+
+def test_output_head_excluded_by_name_when_no_output_embeddings():
+    model = _NoOutputEmbeddings()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == ["q_proj"]
+
+
+class _Decoder(nn.Module):
+    """A miniature language tower: one block of attention + MLP projections."""
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList(
+            [
+                nn.ModuleDict(
+                    {
+                        "q_proj": nn.Linear(8, 8, bias=False),
+                        "k_proj": nn.Linear(8, 8, bias=False),
+                        "v_proj": nn.Linear(8, 8, bias=False),
+                        "o_proj": nn.Linear(8, 8, bias=False),
+                    }
+                )
+            ]
+        )
+
+
+class _VisionTower(nn.Module):
+    """A vision encoder that REUSES the language tower's leaf names — the
+    Gemma3 case that defeats plain leaf-name targeting."""
+
+    def __init__(self):
+        super().__init__()
+        self.encoder = nn.ModuleDict(
+            {
+                "q_proj": nn.Linear(8, 8, bias=False),
+                "k_proj": nn.Linear(8, 8, bias=False),
+            }
+        )
+
+
+class _MultimodalModel(nn.Module):
+    """A ...ForConditionalGeneration-shaped wrapper: a `vision_config` on the
+    config, `get_decoder()` returning the language tower, a vision tower whose
+    linears share leaf names with the language tower, and a tied output head."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+        self.language_model = _Decoder()
+        self.vision_tower = _VisionTower()
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_multimodal_targets_full_paths_under_language_decoder_only():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    # Every target is a full path inside the language tower...
+    assert resolved == [
+        "language_model.layers.0.k_proj",
+        "language_model.layers.0.o_proj",
+        "language_model.layers.0.q_proj",
+        "language_model.layers.0.v_proj",
+    ]
+    # ...and nothing in the vision tower, despite the shared k_proj/q_proj names.
+    assert not any("vision_tower" in name for name in resolved)
+
+
+def test_multimodal_resolution_excludes_output_head():
+    model = _MultimodalModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert not any(name.endswith("lm_head") for name in resolved)
+
+
+class _MoeDecoder(nn.Module):
+    """A Qwen3.5-VL-MoE-style language decoder: HYBRID attention (full `self_attn`
+    + linear-attention `linear_attn` GatedDeltaNet) with an all-MoE MLP — grouped
+    routed experts (`_GroupedExperts` nn.Parameters), an always-on dense
+    `shared_expert`, a `shared_expert_gate`, and a `gate` router."""
+
+    def __init__(self, n_layers=2):
+        super().__init__()
+
+        def _layer():
+            return nn.ModuleDict(
+                {
+                    "self_attn": nn.ModuleDict(
+                        {
+                            "q_proj": nn.Linear(8, 8, bias=False),
+                            "k_proj": nn.Linear(8, 8, bias=False),
+                            "v_proj": nn.Linear(8, 8, bias=False),
+                            "o_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "linear_attn": nn.ModuleDict(
+                        {
+                            "in_proj_qkv": nn.Linear(8, 8, bias=False),
+                            "out_proj": nn.Linear(8, 8, bias=False),
+                        }
+                    ),
+                    "mlp": nn.ModuleDict(
+                        {
+                            "experts": _GroupedExperts(4),
+                            "shared_expert": nn.ModuleDict(
+                                {
+                                    "gate_proj": nn.Linear(8, 8, bias=False),
+                                    "up_proj": nn.Linear(8, 8, bias=False),
+                                    "down_proj": nn.Linear(8, 8, bias=False),
+                                }
+                            ),
+                            "shared_expert_gate": nn.Linear(8, 1, bias=False),
+                            "gate": nn.Linear(8, 4, bias=False),
+                        }
+                    ),
+                }
+            )
+
+        self.layers = nn.ModuleList([_layer() for _ in range(n_layers)])
+
+
+class _MultimodalMoeModel(nn.Module):
+    """Qwen3.5-VL-MoE-shaped (`Qwen3_5MoeForConditionalGeneration`): a multimodal
+    wrapper whose language decoder is itself MoE + hybrid-attention."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(vision_config=SimpleNamespace(hidden_size=8))
+        self.language_model = _MoeDecoder()
+        self.vision_tower = _VisionTower()
+        self.lm_head = nn.Linear(8, 32, bias=False)
+
+    def get_decoder(self):
+        return self.language_model
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+
+def test_multimodal_moe_confines_to_decoder_attention_and_shared_expert():
+    # Qwen3.5-VL-MoE: the multimodal branch is MoE-aware, so LoRA lands on the
+    # decoder's attention + dense shared_expert ONLY — never the vision tower, the
+    # router (`gate` / `shared_expert_gate`), the linear-attention SSM
+    # (`linear_attn`), or the grouped routed experts (those go via
+    # target_parameters). shared_expert carries memorization (granite precedent).
+    model = _MultimodalMoeModel()
+    resolved = resolve_target_modules(model, "all-linear")
+    assert resolved == [
+        "language_model.layers.0.mlp.shared_expert.down_proj",
+        "language_model.layers.0.mlp.shared_expert.gate_proj",
+        "language_model.layers.0.mlp.shared_expert.up_proj",
+        "language_model.layers.0.self_attn.k_proj",
+        "language_model.layers.0.self_attn.o_proj",
+        "language_model.layers.0.self_attn.q_proj",
+        "language_model.layers.0.self_attn.v_proj",
+        "language_model.layers.1.mlp.shared_expert.down_proj",
+        "language_model.layers.1.mlp.shared_expert.gate_proj",
+        "language_model.layers.1.mlp.shared_expert.up_proj",
+        "language_model.layers.1.self_attn.k_proj",
+        "language_model.layers.1.self_attn.o_proj",
+        "language_model.layers.1.self_attn.q_proj",
+        "language_model.layers.1.self_attn.v_proj",
+    ]
+    assert not any("vision_tower" in n for n in resolved)  # vision tower off
+    assert not any(".linear_attn." in n for n in resolved)  # SSM off
+    assert not any(".experts" in n for n in resolved)  # grouped experts off
+    assert not any(n.endswith(".gate") or n.endswith("_gate") for n in resolved)  # routers off
+
+
+def test_multimodal_moe_grouped_experts_via_target_parameters():
+    # The grouped routed experts are unreachable by target_modules (nn.Parameters),
+    # so resolve_target_parameters names them for PEFT's ParamWrapper — exactly the
+    # {gate_up_proj, down_proj} set (requires lora_dropout=0 at train time).
+    model = _MultimodalMoeModel()
+    assert resolve_target_parameters(model) == ["down_proj", "gate_up_proj"]
+
+
+def test_explicit_list_is_passed_through_unchanged():
+    model = _DenseLike()
+    explicit = ["q_proj", "v_proj"]
+    assert resolve_target_modules(model, explicit) is explicit
+
+
+def test_explicit_non_shorthand_string_passes_through():
+    model = _DenseLike()
+    # A regex/string that isn't the "all-linear" shorthand is PEFT's own
+    # to interpret — we must not touch it.
+    assert resolve_target_modules(model, "q_proj") == "q_proj"
+
+
+def test_none_passes_through():
+    model = _DenseLike()
+    assert resolve_target_modules(model, None) is None


### PR DESCRIPTION
Capstone feature. Adds the diffusion training path — canvas corruption/
denoising, two-pass self-conditioning, determinism seeding, and the NaRA
noise-aware-LoRA prototype — plus the diffusion-owned branches of the
resolver / create_lora / doc_mask / JobConfig files that the base PRs
deliberately left out.

WIP: the load_model DiffusionGemma routing branch ships separately (with
the deferred load_model PR), so the serve path is not wired end-to-end
here; the known train/serve decode paradigm gap remains. This PR is the
training path only.

Rebase onto main after #1/#2/#3/#5 merge. Tests: 41 pass.