### PR TITLE
fix(training): prevent malformed job status from flooding logs

### DIFF
--- a/infra/cray_infra/training/restart_megatron_jobs.py
+++ b/infra/cray_infra/training/restart_megatron_jobs.py
@@ -69,7 +69,9 @@ async def get_running_jobs():
 
             if not isinstance(status, dict):
                 logger.error(
-                    f"status.json for job {root} is not a JSON object: {status!r}"
+                    "status.json for job %s is not a JSON object (got %s)",
+                    root,
+                    type(status).__name__,
                 )
                 continue
 

--- a/infra/cray_infra/training/restart_megatron_jobs.py
+++ b/infra/cray_infra/training/restart_megatron_jobs.py
@@ -61,15 +61,30 @@ async def get_running_jobs():
             try:
                 with open(os.path.join(root, "status.json")) as f:
                     status = json.load(f)
-                    if (
-                        status["status"] == TrainingJobStatus.TRAINING
-                        or status["status"] == TrainingJobStatus.QUEUED
-                    ):
-                        yield root
             except Exception as e:
                 logger.error(f"Error reading status.json for job {root}: {e}")
                 # print exception info
                 traceback.print_exc()
+                continue
+
+            if not isinstance(status, dict):
+                logger.error(
+                    f"status.json for job {root} is not a JSON object: {status!r}"
+                )
+                continue
+
+            if "status" not in status:
+                logger.warning(
+                    f"status.json for job {root} has no 'status' key, skipping"
+                )
+                continue
+
+            job_status = status["status"]
+            if (
+                job_status == TrainingJobStatus.TRAINING
+                or job_status == TrainingJobStatus.QUEUED
+            ):
+                yield root
 
 
 async def get_slurm_jobs():

--- a/test/unit/test_restart_megatron_jobs.py
+++ b/test/unit/test_restart_megatron_jobs.py
@@ -70,6 +70,19 @@ def test_get_running_jobs_logs_and_skips_non_object_json(
     print_exc.assert_not_called()
 
 
+def test_get_running_jobs_does_not_log_large_non_object_payload(
+    monkeypatch, tmp_path, caplog
+):
+    marker = "private-payload-marker"
+    _write_status(tmp_path, "large-non-object", marker + ("x" * 100_000))
+    caplog.set_level(logging.ERROR, logger=subject.__name__)
+
+    assert _collect_running_jobs(monkeypatch, tmp_path) == []
+    assert "is not a JSON object (got str)" in caplog.text
+    assert marker not in caplog.text
+    assert len(caplog.text) < 1_000
+
+
 def test_get_running_jobs_keeps_traceback_for_malformed_json(
     monkeypatch, tmp_path, caplog
 ):

--- a/test/unit/test_restart_megatron_jobs.py
+++ b/test/unit/test_restart_megatron_jobs.py
@@ -1,0 +1,93 @@
+"""Regression tests for scanning persisted training-job status files."""
+
+import asyncio
+import json
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+import cray_infra.training.restart_megatron_jobs as subject
+
+
+def _write_status(tmp_path, job_name, contents, *, raw=False):
+    job_dir = tmp_path / job_name
+    job_dir.mkdir()
+    status_path = job_dir / "status.json"
+    if raw:
+        status_path.write_text(contents)
+    else:
+        status_path.write_text(json.dumps(contents))
+    return job_dir
+
+
+def _collect_running_jobs(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        subject,
+        "get_config",
+        lambda: {"training_job_directory": str(tmp_path)},
+    )
+
+    async def collect():
+        return [job async for job in subject.get_running_jobs()]
+
+    return asyncio.run(collect())
+
+
+def test_get_running_jobs_yields_only_training_and_queued(monkeypatch, tmp_path):
+    training = _write_status(tmp_path, "training", {"status": "TRAINING"})
+    queued = _write_status(tmp_path, "queued", {"status": "QUEUED"})
+    _write_status(tmp_path, "completed", {"status": "COMPLETED"})
+
+    assert set(_collect_running_jobs(monkeypatch, tmp_path)) == {
+        str(training),
+        str(queued),
+    }
+
+
+def test_get_running_jobs_warns_and_skips_missing_status(monkeypatch, tmp_path, caplog):
+    _write_status(tmp_path, "missing-status", {"message": "still starting"})
+    print_exc = Mock()
+    monkeypatch.setattr(subject.traceback, "print_exc", print_exc)
+    caplog.set_level(logging.WARNING, logger=subject.__name__)
+
+    assert _collect_running_jobs(monkeypatch, tmp_path) == []
+    assert "has no 'status' key, skipping" in caplog.text
+    print_exc.assert_not_called()
+
+
+@pytest.mark.parametrize("payload", [None, [], "TRAINING"])
+def test_get_running_jobs_logs_and_skips_non_object_json(
+    monkeypatch, tmp_path, caplog, payload
+):
+    _write_status(tmp_path, "non-object", payload)
+    print_exc = Mock()
+    monkeypatch.setattr(subject.traceback, "print_exc", print_exc)
+    caplog.set_level(logging.ERROR, logger=subject.__name__)
+
+    assert _collect_running_jobs(monkeypatch, tmp_path) == []
+    assert "is not a JSON object" in caplog.text
+    print_exc.assert_not_called()
+
+
+def test_get_running_jobs_keeps_traceback_for_malformed_json(
+    monkeypatch, tmp_path, caplog
+):
+    _write_status(tmp_path, "malformed", "{", raw=True)
+    print_exc = Mock()
+    monkeypatch.setattr(subject.traceback, "print_exc", print_exc)
+    caplog.set_level(logging.ERROR, logger=subject.__name__)
+
+    assert _collect_running_jobs(monkeypatch, tmp_path) == []
+    assert "Error reading status.json" in caplog.text
+    print_exc.assert_called_once_with()
+
+
+def test_get_running_jobs_does_not_call_null_status_missing(
+    monkeypatch, tmp_path, caplog
+):
+    _write_status(tmp_path, "null-status", {"status": None})
+    caplog.set_level(logging.WARNING, logger=subject.__name__)
+
+    assert _collect_running_jobs(monkeypatch, tmp_path) == []
+    assert "has no 'status' key" not in caplog.text


### PR DESCRIPTION
## Why

A malformed, older-schema, or externally created training job directory could
emit the same ERROR traceback every refresh cycle (30 seconds by default). The
exception was already caught, so this is not a stability fix; it prevents
persistent log pollution while retaining useful diagnostics for genuine read
and JSON-parse failures.

## What changed

`get_running_jobs()` now distinguishes malformed data from an object that
simply lacks `status`:

- unreadable or malformed JSON still logs ERROR with a traceback;
- non-object JSON logs a bounded ERROR and is skipped;
- an object missing `status` logs WARNING and is skipped;
- explicit `{"status": null}` is not misreported as a missing key; and
- only `TRAINING` and `QUEUED` jobs are yielded, as before.

## Validation

- Eight focused regressions cover valid states, missing keys, explicit null,
  malformed JSON, and non-object JSON, including a large payload that must not
  be copied into logs.
- Exact ScalarLM/vllm-fork v0.27.1 image: **8 passed**.
- Full unit suite with #227 overlaid: **532 passed**.
- Independent Codex, Gemini 3.6 Flash, and Sonnet 4.6 reviews found no
  actionable defect and returned `MERGE`.
- Black formatting and `git diff --check` pass.

## Dependencies

None; this training-log fix can merge in any order.
