### PR TITLE
Support diffusion gemma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_NAME=cpu
 
 ###############################################################################
 # NVIDIA BASE IMAGE
-FROM nvcr.io/nvidia/pytorch:26.01-py3 AS nvidia
+FROM nvcr.io/nvidia/pytorch:26.05-py3 AS nvidia
 
 RUN apt-get update -y && apt-get install -y python3-venv slurm-wlm libslurm-dev
 
@@ -124,18 +124,28 @@ RUN pip install setuptools-scm
 
 # Configure vLLM source - can use either local directory or remote repo.
 #
-# VLLM_BRANCH defaults to `main` on vllm-fork. The fixes that previously
-# required pinning to scalarlm-on-v0.19.0 at a specific SHA (TorchAllocator
-# crash, Triton scratch-allocator memleak, torch 2.10 ABI) are now merged
-# into vllm-fork's main branch, so the branch tip is sufficient.
+# VLLM_BRANCH tracks sync/upstream-v0.26.0 on vllm-fork. The fork's C++
+# divergence from upstream is ~63 lines of stable-ABI shimming across 6 files;
+# CMakeLists.txt is untouched, so TORCH_TARGET_VERSION=0x020B comes from
+# upstream and this branch requires a torch with the 2.11+ stable ABI. The
+# NVIDIA base image supplies it (hence the NGC 26.05 pin, and why nothing here
+# installs its own torch).
 #
-# VLLM_COMMIT remains available as an opt-in pin if a deployment needs
-# reproducibility across time or wants to roll back to a specific SHA;
-# leave it empty to use BRANCH tip (the default).
+# Changing VLLM_BRANCH can therefore break the build via the base image. If you
+# do, verify by compiling csrc/libtorch_stable/cuda_view.cu against the
+# candidate tag's headers -- version strings aren't enough: NGC 26.04 and 26.05
+# both report torch 2.12.0a0 and only 26.05 compiles.
+#
+# VLLM_COMMIT pins a SHA; empty uses BRANCH tip. Note the vllm version string in
+# the image comes from build-copy-vllm.sh's synthetic git tag, so it does not
+# tell you which source was used -- diff a known file instead.
+#
+# NOTE: the RUN below bind-mounts ./vllm unconditionally, so a ./vllm directory
+# must exist in the build context even when VLLM_SOURCE=remote.
 ARG VLLM_SOURCE=remote
-ARG VLLM_BRANCH=main
+ARG VLLM_BRANCH=sync/upstream-v0.26.0
 ARG VLLM_COMMIT=
-ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
+ARG VLLM_REPO=https://github.com/tmielika/vllm-fork.git
 
 # Handle vLLM source - support both local and remote modes.
 # build-copy-vllm.sh and apply_patches.py are copied in a single COPY
@@ -163,7 +173,7 @@ ENV CMAKE_BUILD_TYPE=Release
 # vLLM dependencies
 COPY ./infra/requirements-vllm.txt ${INSTALL_ROOT}/requirements-vllm.txt
 RUN uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements-vllm.txt && \
-    python ${INSTALL_ROOT}/vllm/use_existing_torch.py
+    python ${INSTALL_ROOT}/vllm/use_existing_torch.py --prefix
 
 RUN \
     --mount=type=cache,target=/root/.cache/pip \
@@ -174,7 +184,8 @@ RUN \
     COMPUTED=$(( NPROC < MEM_BASED ? NPROC : MEM_BASED )) && \
     export MAX_JOBS=$(( COMPUTED < 16 ? COMPUTED : 16 )) && \
     echo "MAX_JOBS=${MAX_JOBS} (nproc=${NPROC}, mem-based=${MEM_BASED}, capped at 16)" && \
-    pip install --no-build-isolation -e . --verbose
+    pip install --no-build-isolation -e . --verbose && \
+    uv pip install "safetensors>=0.8.0" 
 
 WORKDIR ${INSTALL_ROOT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,28 +124,18 @@ RUN pip install setuptools-scm
 
 # Configure vLLM source - can use either local directory or remote repo.
 #
-# VLLM_BRANCH tracks sync/upstream-v0.26.0 on vllm-fork. The fork's C++
-# divergence from upstream is ~63 lines of stable-ABI shimming across 6 files;
-# CMakeLists.txt is untouched, so TORCH_TARGET_VERSION=0x020B comes from
-# upstream and this branch requires a torch with the 2.11+ stable ABI. The
-# NVIDIA base image supplies it (hence the NGC 26.05 pin, and why nothing here
-# installs its own torch).
+# VLLM_BRANCH defaults to `main` on vllm-fork. The fixes that previously
+# required pinning to scalarlm-on-v0.19.0 at a specific SHA (TorchAllocator
+# crash, Triton scratch-allocator memleak, torch 2.10 ABI) are now merged
+# into vllm-fork's main branch, so the branch tip is sufficient.
 #
-# Changing VLLM_BRANCH can therefore break the build via the base image. If you
-# do, verify by compiling csrc/libtorch_stable/cuda_view.cu against the
-# candidate tag's headers -- version strings aren't enough: NGC 26.04 and 26.05
-# both report torch 2.12.0a0 and only 26.05 compiles.
-#
-# VLLM_COMMIT pins a SHA; empty uses BRANCH tip. Note the vllm version string in
-# the image comes from build-copy-vllm.sh's synthetic git tag, so it does not
-# tell you which source was used -- diff a known file instead.
-#
-# NOTE: the RUN below bind-mounts ./vllm unconditionally, so a ./vllm directory
-# must exist in the build context even when VLLM_SOURCE=remote.
+# VLLM_COMMIT remains available as an opt-in pin if a deployment needs
+# reproducibility across time or wants to roll back to a specific SHA;
+# leave it empty to use BRANCH tip (the default).
 ARG VLLM_SOURCE=remote
-ARG VLLM_BRANCH=sync/upstream-v0.26.0
+ARG VLLM_BRANCH=main
 ARG VLLM_COMMIT=
-ARG VLLM_REPO=https://github.com/tmielika/vllm-fork.git
+ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
 
 # Handle vLLM source - support both local and remote modes.
 # build-copy-vllm.sh and apply_patches.py are copied in a single COPY

--- a/deployment/helm/scalarlm/values.yaml
+++ b/deployment/helm/scalarlm/values.yaml
@@ -11,7 +11,8 @@ imagePullSecrets: []
 
 # Model + cray-config.yaml. extraConfig is merged verbatim into every
 # ConfigMap, so you can set any key the server's get_config() reads.
-model: Qwen/Qwen3-14B
+#model: Qwen/Qwen3-14B
+model: google/diffusiongemma-26B-A4B-it
 gpu_memory_utilization: 0.85
 max_train_time: 86400
 extraConfig: {}

--- a/deployment/helm/scalarlm/values.yaml
+++ b/deployment/helm/scalarlm/values.yaml
@@ -11,8 +11,7 @@ imagePullSecrets: []
 
 # Model + cray-config.yaml. extraConfig is merged verbatim into every
 # ConfigMap, so you can set any key the server's get_config() reads.
-#model: Qwen/Qwen3-14B
-model: google/diffusiongemma-26B-A4B-it
+model: Qwen/Qwen3-14B
 gpu_memory_utilization: 0.85
 max_train_time: 86400
 extraConfig: {}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,17 @@ services:
     cray: &cray
         image: cray:latest
         command: /app/cray/scripts/start_one_server.sh
+        # Compose only forwards variables declared here; `SCALARLM_FOO=x
+        # docker compose up` reaches build args and ${} interpolation, never
+        # the server. Each `${VAR:-fallback}` below is always set, so the
+        # fallback overrides default_config.Config and IS the effective
+        # default -- keep them identical to Config.
+        environment:
+            - SCALARLM_ENABLE_LORA=${SCALARLM_ENABLE_LORA:-false}
+            - SCALARLM_ENABLE_TOKENFORMER=${SCALARLM_ENABLE_TOKENFORMER:-true}
+            # Which model the server loads. Exposed so one image can be
+            # verified against several models without a rebuild.
+            - SCALARLM_MODEL=${SCALARLM_MODEL:-tiny-random/gemma-4-dense}
         build:
             context: .
             dockerfile: Dockerfile
@@ -12,6 +23,14 @@ services:
                 - TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}
                 - BASE_NAME=${BASE_NAME}
                 - VLLM_TARGET_DEVICE=${VLLM_TARGET_DEVICE}
+                # These are passed explicitly, so they OVERRIDE the ARG
+                # defaults in the Dockerfile — the fallbacks here are what
+                # actually gets built, not the Dockerfile's. They must be kept
+                # in sync with the Dockerfile's VLLM_* ARG block; they were not,
+                # so every `scalarlm up` on this branch built
+                # supermassive-intelligence/vllm-fork main (v0.19.0 base, no
+                # diffusion_gemma.py, missing the Tokenformer serving fixes)
+                # while the Dockerfile said otherwise.
                 - VLLM_SOURCE=${VLLM_SOURCE:-remote}
                 - VLLM_BRANCH=${VLLM_BRANCH:-main}
                 - VLLM_REPO=${VLLM_REPO:-https://github.com/supermassive-intelligence/vllm-fork.git}
@@ -41,7 +60,7 @@ services:
     cray-nvidia:
         <<: *cray
         runtime: nvidia
-        restart: unless-stopped
+        #restart: unless-stopped
         cap_add:
           - SYS_PTRACE
         deploy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
 
     cray: &cray
+        image: cray:latest
         command: /app/cray/scripts/start_one_server.sh
         build:
             context: .

--- a/infra/cray_infra/one_server/create_generate_worker.py
+++ b/infra/cray_infra/one_server/create_generate_worker.py
@@ -51,6 +51,7 @@ from cray_infra.api.fastapi.routers.request_types.get_work_response import (
 from cray_infra.api.fastapi.aiohttp.get_global_session import get_global_session
 from cray_infra.one_server.decode_error_body import decode_error_body
 from cray_infra.one_server.format_exception import format_exception
+from cray_infra.one_server.sampling_params import sampling_params_for
 
 from cray_infra.util.get_config import get_config
 
@@ -435,9 +436,9 @@ async def async_chat_completion_task(request, app):
         model=request["model"],
         messages=convert_prompt_to_openai_format(request["prompt"]),
         max_tokens=request["max_tokens"],
-        temperature=request.get("temperature", 0.0),
         tools=request.get("tools"),
         tool_choice=request.get("tool_choice"),
+        **sampling_params_for(app, request),
     )
 
     raw_request = Request(
@@ -569,7 +570,9 @@ async def async_completion_task(request, app):
         model=request["model"],
         prompt=request["prompt"],
         max_tokens=request["max_tokens"],
-        temperature=request.get("temperature", 0.0), tools=request.get("tools"), tool_choice=request.get("tool_choice"),
+        tools=request.get("tools"),
+        tool_choice=request.get("tool_choice"),
+        **sampling_params_for(app, request),
     )
 
     raw_request = Request(

--- a/infra/cray_infra/one_server/create_vllm.py
+++ b/infra/cray_infra/one_server/create_vllm.py
@@ -1,4 +1,5 @@
 # Set vLLM environment variables BEFORE any vLLM imports
+import inspect
 import os
 import torch
 
@@ -15,7 +16,13 @@ from vllm.entrypoints.launcher import serve_http
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
-from vllm.entrypoints.utils import (log_non_default_args)
+# NOTE: `log_non_default_args` used to be imported here from
+# `vllm.entrypoints.utils`. That module no longer exists — the v0.26.0
+# restructure moved the function to
+# `vllm.entrypoints.serve.utils.api_utils` — and the import was killing
+# server startup with ModuleNotFoundError. Nothing in this repo ever
+# called it, so it is dropped rather than re-pointed: that keeps this
+# file importable against both the old and the new fork layout.
 import vllm.envs as envs
 
 import uvicorn
@@ -97,7 +104,20 @@ async def run_server(server_status, args, **uvicorn_kwargs) -> None:
     # Add process-specific prefix to stdout and stderr.
     decorate_logs("APIServer")
 
-    listen_address, sock = setup_server(args)
+    # vLLM v0.26.0 made `reuse_port` a required keyword-only argument on
+    # setup_server; older fork revisions don't accept it at all. Probe the
+    # signature instead of pinning to one layout, so this file works against
+    # both (scalarlm main still builds the older fork). setup_server is
+    # decorated with @functools.wraps in vllm/tracing/otel.py, so
+    # inspect.signature sees through to the real parameters.
+    #
+    # False is what vLLM's own single-server entrypoints pass
+    # (api_server.py, cli/launch.py); reuse_port only matters when several
+    # API server processes share a listening socket, and ScalarLM runs one.
+    if "reuse_port" in inspect.signature(setup_server).parameters:
+        listen_address, sock = setup_server(args, reuse_port=False)
+    else:
+        listen_address, sock = setup_server(args)
     await run_server_worker(server_status, listen_address, sock, args, **uvicorn_kwargs)
 
 async def run_server_worker(server_status, listen_address,
@@ -110,8 +130,14 @@ async def run_server_worker(server_status, listen_address,
     if args.tool_parser_plugin and len(args.tool_parser_plugin) > 3:
         ToolParserManager.import_tool_parser(args.tool_parser_plugin)
 
-    if args.reasoning_parser_plugin and len(args.reasoning_parser_plugin) > 3:
-        ReasoningParserManager.import_reasoning_parser(args.reasoning_parser_plugin)
+    # NOTE: a `reasoning_parser_plugin` block used to sit here. It was dead
+    # and latently broken: `ReasoningParserManager` was never imported in this
+    # module, so the branch would have raised NameError had it ever been
+    # taken. On v0.26.0 it fails earlier still — the setting moved off the CLI
+    # Namespace into `structured_outputs_config`, so reading
+    # `args.reasoning_parser_plugin` raises AttributeError and kills startup.
+    # vLLM now performs this import itself in
+    # `vllm/v1/structured_output/__init__.py`, so dropping it loses nothing.
 
     server_index = client_config.get("client_index", 0) if client_config else 0
 

--- a/infra/cray_infra/one_server/sampling_params.py
+++ b/infra/cray_infra/one_server/sampling_params.py
@@ -1,0 +1,28 @@
+"""Sampling params the served model will accept.
+
+Kept free of heavy imports (torch, vllm) so it can be unit tested without
+the full inference stack, same as vllm_cli_args.py.
+"""
+
+from __future__ import annotations
+
+
+def sampling_params_for(app, request) -> dict:
+    """Build the sampling kwargs for a generate request.
+
+    Diffusion models (dLLMs) reject temperature, min_p, seed, min_tokens,
+    logit_bias, bad_words and allowed_token_ids -- they denoise a canvas
+    rather than sampling token by token, so those knobs have no meaning:
+
+        ValueError: The temperature, min_p, seed, min_tokens, logit_bias,
+        bad_words, and allowed_token_ids sampling parameters are not yet
+        supported with diffusion models.
+
+    temperature is the only one of those we ever set, so dropping it is
+    enough. A model_config without `is_diffusion` (older vLLM) keeps the
+    previous behavior rather than silently dropping temperature.
+    """
+    model_config = getattr(app.state.engine_client, "model_config", None)
+    if getattr(model_config, "is_diffusion", False):
+        return {}
+    return {"temperature": request.get("temperature", 0.0)}

--- a/infra/cray_infra/one_server/vllm_cli_args.py
+++ b/infra/cray_infra/one_server/vllm_cli_args.py
@@ -13,10 +13,16 @@ def build_vllm_cli_args(config: dict) -> list[str]:
     Callers then extend this with model name, port, and any
     ``SCALARLM_VLLM_ARGS`` overrides (dedupped).
 
-    The only non-obvious behavior is the ``enable_lora`` gate: when the
-    config flag is False, ``--enable-lora`` is omitted, which avoids
+    The only non-obvious behavior is the adapter gates. When
+    ``enable_lora`` is False, ``--enable-lora`` is omitted, which avoids
     wrapping every layer in a LoRA-aware shim. See Phase 31b in
     ``enhance-openai-api.md``.
+
+    ``enable_tokenformer`` gates ``--enable-tokenformer``, which the vLLM
+    fork needs in order to load the Tokenformer-keyed ``.pt`` adapters the
+    ScalarLM trainer produces. Both flags together select the fork's
+    HybridAdapterManager, which handles Tokenformer-only, LoRA-only, and
+    hybrid checkpoints. See ``default_config.py`` for the trade-offs.
     """
     args = [
         f"--dtype={config['dtype']}",
@@ -28,8 +34,12 @@ def build_vllm_cli_args(config: dict) -> list[str]:
         "--tool-call-parser=hermes",
         "--trust-remote-code",
     ]
-    if config.get("enable_lora", True):
+    # Fallbacks must match default_config.Config, or a config dict that
+    # predates a key produces a different server than the shipped default.
+    if config.get("enable_lora", False):
         args.append("--enable-lora")
+    if config.get("enable_tokenformer", True):
+        args.append("--enable-tokenformer")
     if config.get("limit_mm_per_prompt") is not None:
         args.append(f"--limit-mm-per-prompt={config['limit_mm_per_prompt']}")
     return args

--- a/infra/cray_infra/util/default_config.py
+++ b/infra/cray_infra/util/default_config.py
@@ -86,17 +86,34 @@ class Config(BaseModel):
     dtype: str = "auto"
     limit_mm_per_prompt:str = '{"image":2}'
 
-    # Whether to pass --enable-lora to vLLM on startup. When true (default),
-    # every layer in the model is wrapped in a LoRA-aware shim so adapters
-    # can be hot-loaded. That wrapping has cost on every forward pass even
-    # with no adapter loaded, and on some vLLM-fork builds the MoE LoRA
-    # wrapper has outright bugs (e.g. the TorchAllocator.set interface drift
-    # on scalarlm-on-v0.19.0 HEAD). Deployments that know they won't use
-    # LoRA/tokenformer adapters should set SCALARLM_ENABLE_LORA=false to
-    # skip the wrapping entirely. Dynamic adapter loading via
-    # /v1/load_lora_adapter won't be available in that mode — fine for
-    # pure-inference pods, not fine for training-eval pods.
-    enable_lora: bool = True
+    # Whether to pass --enable-lora to vLLM on startup.
+    #
+    # Defaults to false: with both flags set the fork selects its
+    # HybridAdapterManager, which nests every targeted layer under
+    # `.base_layer.`, so the attention weights in a ScalarLM Tokenformer
+    # checkpoint match nothing and are dropped at activation — the model
+    # then serves with attention still at initialization. job_config's
+    # adapter_type defaults to "tokenformer", so false matches what the
+    # trainer produces.
+    #
+    # Cost: adapter_type="lora" jobs are ignored in this mode. One server
+    # cannot serve both types today. Set SCALARLM_ENABLE_LORA=true for a
+    # LoRA-dedicated server.
+    enable_lora: bool = False
+
+    # Whether to pass --enable-tokenformer to vLLM on startup. The ScalarLM
+    # trainer only ever emits Tokenformer adapters (see
+    # ml/cray_megatron/models/get_model_manager.py, which returns
+    # TokenformerModelManager unconditionally), so without this flag the vLLM
+    # fork picks its LoRA-only adapter manager and rejects every checkpoint
+    # this stack produces with "has no LoRA tensors (found only Tokenformer
+    # keys)". The adapter then never registers as a served model, and
+    # generation against a freshly trained model 404s.
+    #
+    # With enable_lora false (the default) this selects the Tokenformer-only
+    # manager, which leaves the model's parameter names untouched — see the
+    # enable_lora comment above for why that matters.
+    enable_tokenformer: bool = True
 
     max_log_length: int = 100
 

--- a/infra/requirements-vllm.txt
+++ b/infra/requirements-vllm.txt
@@ -1,2 +1,3 @@
 fastapi-utils
+setuptools-rust>=1.9.0
 typing-inspect

--- a/ml/adapters/create_tokenformer_model.py
+++ b/ml/adapters/create_tokenformer_model.py
@@ -1,4 +1,4 @@
-from tokenformer.tokenformer_surgeon import TokenformerSurgeon
+from tokenformer.tokenformer_surgeon import TokenformerSurgeon, is_non_language_path
 
 import time
 import logging
@@ -48,7 +48,19 @@ def create_tokenformer_model(model, device, train_lm_head=None):
     logger.info("Unfreezing tokenformer parameters...")
     step5_start = time.time()
     unfrozen_count = 0
+    skipped_non_language = 0
     for name, param in tokenformer_model.named_parameters():
+        # Tokenformer is a language-model adapter. Without this guard the
+        # substring matches below also fire inside the vision/audio towers
+        # of a multimodal model, so their attention projections and norms
+        # get trained and written into the checkpoint. vLLM exposes those
+        # parameters under a different layout, so at serve time they either
+        # kill the engine or get silently dropped — either way the training
+        # was wasted. Text-only models have no such components, so this
+        # changes nothing for them.
+        if is_non_language_path(name):
+            skipped_non_language += 1
+            continue
         if any(
             module_name in name
             for module_name in [
@@ -66,6 +78,11 @@ def create_tokenformer_model(model, device, train_lm_head=None):
         ):
             param.requires_grad = True
             unfrozen_count += 1
+    if skipped_non_language:
+        logger.info(
+            f"Kept {skipped_non_language:,} non-language (vision/audio tower) "
+            f"parameters frozen"
+        )
     step5_time = time.time() - step5_start
     logger.info(
         f"Tokenformer parameter unfreezing completed: {step5_time:.2f}s, unfrozen {unfrozen_count:,} parameters"

--- a/ml/tokenformer/tokenformer_surgeon.py
+++ b/ml/tokenformer/tokenformer_surgeon.py
@@ -123,6 +123,23 @@ class TokenformerAdapter(nn.Module):
 #
 # Match by path component so HF's `model.<thing>` wrapper prefix doesn't hide
 # them (e.g., "model.vision_tower.encoder.layers.0.mlp" must be excluded).
+#
+# TODO: adapting the vision/audio towers themselves is not supported. Only the
+# language model is adapted; the towers stay at their base weights. Lifting this
+# needs three things that do not exist yet:
+#   1. the surgeon to use each tower's own hidden_size rather than the text
+#      config's, since `update_layer` currently reads one hidden size for the
+#      whole model;
+#   2. a serving-side key mapping for tower parameters -- vLLM exposes them
+#      under names the trainer never produces (e.g. HF writes
+#      `vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight`, which has
+#      no vLLM counterpart), so they cannot round-trip through
+#      `load_weights` today;
+#   3. a training signal that actually reaches the towers -- a text-only
+#      dataset never activates them.
+# Until then the towers are deliberately frozen. Training them without (2) is
+# worse than not training them: the weights land in the checkpoint and are
+# either dropped at serve time or crash the engine.
 _NON_LANGUAGE_PATH_COMPONENTS = frozenset(
     {
         "vision_tower",
@@ -134,6 +151,23 @@ _NON_LANGUAGE_PATH_COMPONENTS = frozenset(
 )
 
 
+def is_non_language_path(name: str) -> bool:
+    """True if a parameter/module path sits inside a non-language tower.
+
+    Shared by the surgeon (which refuses to insert adapters there) and by
+    the trainer's freeze/unfreeze pass, so the two agree on what "language
+    model" means. They disagreed before: the surgeon skipped the vision
+    tower while the unfreeze pass matched substrings like "q_proj" against
+    the full path and trained it anyway, putting vision-tower weights into
+    every checkpoint. Those keys have no counterpart in vLLM's parameter
+    layout, so they killed the engine at adapter-activation time.
+
+    Text-only models have none of these components, so this is a no-op
+    there — existing checkpoints are unaffected.
+    """
+    return any(part in _NON_LANGUAGE_PATH_COMPONENTS for part in name.split("."))
+
+
 class TokenformerSurgeon(ABC):
 
     def __init__(self, model: nn.Module, device: torch.device):
@@ -141,10 +175,9 @@ class TokenformerSurgeon(ABC):
         self.device = device
 
     def _is_adapter_layer(self, layer_name):
-        parts = layer_name.split(".")
-        if any(part in _NON_LANGUAGE_PATH_COMPONENTS for part in parts):
+        if is_non_language_path(layer_name):
             return False
-        return "mlp" in parts[-1]
+        return "mlp" in layer_name.split(".")[-1]
 
     def _recursive_setattr(self, obj, attr, value):
         attr = attr.split(".", 1)

--- a/scripts/vllm_patches/apply_patches.py
+++ b/scripts/vllm_patches/apply_patches.py
@@ -154,65 +154,577 @@ def patch_output_handler_metrics_offload(vllm_root: Path) -> None:
     target.write_text(patched)
     print(f"[vllm_patches] Applied output_handler metrics offload to {target}")
 
-def patch_instrumentator_route_name_signature(vllm_root: Path) -> None:
-    """Forward kwargs through the fork's `get_route_name` monkeypatch.
+TOKENFORMER_KEY_RESOLVER_SRC = '''
 
-    `vllm/entrypoints/serve/instrumentator/metrics.py` wraps
-    `prometheus_fastapi_instrumentator.routing.get_route_name` to swallow the
-    `AttributeError` that nested routers trigger. The wrapper takes only
-    `request`, but current instrumentator releases call it as
-    `get_route_name(request, should_include_root_path=...)`, so every request
-    through the metrics middleware raises TypeError -> HTTP 400 on all
-    endpoints, including /health. ScalarLM then reports vLLM down while the
-    engine is running fine.
+def _scalarlm_nearest_live_keys(key, model_state_dict, limit=3):
+    """Live parameter names that sit near an unmatched checkpoint key.
 
-    Both the signature and the forwarded call need widening: `**kwargs` alone
-    fixes the inbound call and then fails on the outbound one, because the real
-    `get_route_name` *requires* should_include_root_path.
+    A drop warning that only names the missing key says nothing about WHY
+    it missed. The live neighbours do: `...qkv_proj.base_layer.weight`
+    next to a dropped `...q_proj.weight` shows both that vLLM fused the
+    projection and that a LoRA wrapper nested it -- two separate naming
+    problems, visible in one line, without reading fork source.
 
-    Skips cleanly if the anchor is absent -- newer fork revisions replaced this
-    shim with a `_get_route_name` walk that doesn't have the problem.
+    Tries every contiguous run of path components, longest first, and
+    returns the matches for the most specific one that hits anything.
+    Trailing components have to be droppable too, not just leading ones:
+    a fused `qkv_proj` means the name `q_proj` appears nowhere at all, so
+    only backing off to the parent module (`layers.0.self_attn`) shows
+    what the layer actually holds.
+    """
+    parts = key.split(".")
+    candidates = {
+        ".".join(parts[i:j])
+        for i in range(len(parts))
+        for j in range(i + 1, len(parts) + 1)
+    }
+    for needle in sorted(candidates, key=lambda c: (-len(c), c)):
+        matches = [name for name in model_state_dict if needle in name]
+        if matches:
+            return sorted(matches)[:limit]
+    return []
+
+
+def _scalarlm_resolve_adapter_keys(model, tokenformers, model_state_dict):
+    """Map trainer-side checkpoint keys onto the live vLLM namespace.
+
+    ScalarLM's Tokenformer checkpoints are not pure adapters: the trainer
+    unfreezes attention projections, norms and embeddings alongside the
+    tokenformer_{k,v,p} tensors, so the .pt carries base weights named the
+    way the HuggingFace module tree names them. `activate_adapter` merges
+    every one of those keys into the model's state dict and calls
+    `load_weights`, which requires the names to line up with vLLM's own
+    parameter layout.
+
+    For plain decoder-only models the two namespaces already agree, which
+    is why this went unnoticed. Multimodal wrappers rearrange them (HF
+    `model.language_model.layers.*` vs vLLM `language_model.model.layers.*`)
+    and expose some modules not at all, so unmapped keys reach
+    `load_weights` and raise KeyError, killing EngineCore.
+
+    Resolution order:
+      1. Key already present in the model's state dict: keep it unchanged.
+         This is the backward-compatibility guarantee — every key of an
+         existing checkpoint takes this path, so nothing is renamed or
+         dropped and behavior is identical to before the patch.
+      2. The model's own `hf_to_vllm_mapper` rewrites it to a key that is
+         present: keep it under the rewritten name. This reuses the exact
+         mapping vLLM applies when loading a checkpoint, so it stays
+         correct per model family instead of hardcoding prefixes here.
+      3. Otherwise: drop it, loudly. These are weights vLLM has no home
+         for; injecting them is what crashes the engine. Dropping means
+         they are not applied at inference — the warning exists so that
+         shows up in the logs rather than as unexplained quality loss.
+    """
+    # Instance lookup, not `type(model)`: most models declare the mapper as a
+    # class attribute, but several (mimo_mtp, ernie_mtp, the transformers
+    # backend) build it in __init__, and a class-only lookup silently misses
+    # those — every key would fall through to the drop path.
+    mapper = getattr(model, "hf_to_vllm_mapper", None)
+    resolved = {}
+    renamed = 0
+    dropped = []
+
+    for key, value in tokenformers.items():
+        if key in model_state_dict:
+            resolved[key] = value
+            continue
+
+        mapped = None
+        if mapper is not None:
+            try:
+                mapped = mapper._map_name(key)
+            except Exception:  # mapper API drift must not break serving
+                mapped = None
+
+        if mapped is not None and mapped in model_state_dict:
+            resolved[mapped] = value
+            renamed += 1
+            continue
+
+        dropped.append(key)
+
+    if renamed:
+        logger.info(
+            "Tokenformer adapter: remapped %d checkpoint tensors onto the "
+            "live model namespace via hf_to_vllm_mapper.",
+            renamed,
+        )
+    if dropped:
+        logger.warning(
+            "Tokenformer adapter: %d of %d checkpoint tensors have no "
+            "counterpart in the live model and will NOT be applied "
+            "(first few: %s). These are base weights the trainer saved "
+            "under names vLLM does not expose; the adapter still applies "
+            "everything that did resolve.",
+            len(dropped),
+            len(tokenformers),
+            dropped[:5],
+        )
+        # Name the live parameters nearest each drop. Without this the
+        # warning says only that a name was missing, and diagnosing why
+        # means reading fork source and guessing -- which is how the
+        # `.base_layer.` nesting and the fused `qkv_proj` each cost a
+        # 30-minute rebuild to discover.
+        for key in dropped[:3]:
+            logger.warning(
+                "Tokenformer adapter:   %s -> no match; live names nearby: %s",
+                key,
+                _scalarlm_nearest_live_keys(key, model_state_dict) or "(none)",
+            )
+
+    return resolved
+'''
+
+
+def patch_tokenformer_adapter_key_resolution(vllm_root: Path) -> None:
+    """Resolve adapter checkpoint keys against the live model before use.
+
+    Without this, serving a ScalarLM Tokenformer checkpoint on a
+    multimodal model (diffusion-gemma / gemma4) dies with
+    `KeyError: 'layers.0.self_attn.q_proj.weight'` inside
+    `gemma4.load_weights`, taking EngineCore down with it.
+
+    Resolution happens once in `add_adapter`, so both `activate_adapter`
+    and `deactivate_adapter` see keys that exist in the model — patching
+    only the activate path would leave deactivate to raise on the same
+    keys.
+
+    See `_scalarlm_resolve_adapter_keys` for the rules and why existing
+    checkpoints are unaffected.
     """
     target = (
-        vllm_root / "vllm" / "entrypoints" / "serve" / "instrumentator" / "metrics.py"
+        vllm_root / "vllm" / "tokenformer" / "tokenformer_model_manager.py"
     )
     if not target.exists():
-        print(f"[vllm_patches] {target} not found; skipping route-name patch")
+        print(
+            f"[vllm_patches] {target} not found; skipping tokenformer "
+            f"key-resolution patch"
+        )
         return
 
     src = target.read_text()
 
-    anchor_def = "def patched_get_route_name(request):\n"
-    anchor_call = "        return _original_get_route_name(request)\n"
-
-    if anchor_def not in src:
+    if "_scalarlm_resolve_adapter_keys" in src:
         print(
-            "[vllm_patches] patched_get_route_name shim absent; "
-            "route-name patch not needed for this revision"
+            "[vllm_patches] tokenformer key resolution already present; "
+            "skipping"
         )
         return
 
-    assert anchor_call in src, (
-        "metrics.py: found `def patched_get_route_name(request):` but not the "
-        "expected `return _original_get_route_name(request)` call. The shim has "
-        "drifted -- re-anchor this patch."
+    anchor_logger = "logger = init_logger(__name__)\n"
+    anchor_register = (
+        "        self._registered_adapters[request.adapter_id] = tokenformer\n"
     )
 
-    patched = (
-        src
-        .replace(anchor_def, "def patched_get_route_name(request, **kwargs):\n", 1)
-        .replace(
-            anchor_call,
-            "        return _original_get_route_name(request, **kwargs)\n",
-            1,
-        )
+    assert anchor_logger in src, (
+        "tokenformer_model_manager.py: `logger = init_logger(__name__)` not "
+        "found — cannot place the key resolver. Re-anchor this patch."
+    )
+    assert anchor_register in src, (
+        "tokenformer_model_manager.py: the `self._registered_adapters"
+        "[request.adapter_id] = tokenformer` assignment in add_adapter has "
+        "drifted. Re-anchor this patch."
+    )
+
+    patched = src.replace(
+        anchor_logger,
+        anchor_logger + TOKENFORMER_KEY_RESOLVER_SRC,
+        1,
+    ).replace(
+        anchor_register,
+        "        tokenformer.tokenformers = _scalarlm_resolve_adapter_keys(\n"
+        "            self.model, tokenformer.tokenformers, self.model.state_dict()\n"
+        "        )\n" + anchor_register,
+        1,
     )
 
     assert patched != src, "patch produced identical output — something's wrong"
     compile(patched, str(target), "exec")
 
     target.write_text(patched)
-    print(f"[vllm_patches] Forwarded kwargs through patched_get_route_name in {target}")
+    print(f"[vllm_patches] Applied tokenformer key resolution to {target}")
+
+
+STATE_DICT_EXPORT_SRC = '''    def state_dict(self, destination=None, prefix="", keep_vars=False):
+        # ScalarLM trainer contract: expose packed projections under their
+        # unpacked HF names. qwen2, qwen3, qwen3_moe and gemma3 implement
+        # this; Gemma4 was missed, so `qkv_proj` stayed fused and the
+        # Tokenformer manager found no q/k/v to match a ScalarLM
+        # checkpoint against. Every trained attention projection was then
+        # dropped at adapter-activation time and the served model ran
+        # random-init attention -- training converges, the checkpoint is
+        # correct, and generation is still garbage.
+        #
+        # Unlike gemma3, qkv cannot be delegated to
+        # `unpack_packed_modules_state_dict`: it derives one split size
+        # from the model config, while Gemma4 alternates head_dim per
+        # layer (32 on some, 64 on others). That mismatch raises
+        # "split_with_sizes expects split_sizes to sum exactly to 1024".
+        # Each attention module knows its own TP-local q_size/kv_size,
+        # which is what the packed tensor here actually holds, so read
+        # the geometry off the module instead of the config.
+        #
+        # Scoped to `prefix` so recursion from the multimodal wrapper
+        # (Gemma4ForConditionalGeneration) can't rewrite sibling modules'
+        # keys in the shared destination dict.
+        state_dict = super().state_dict(destination, prefix, keep_vars)
+        if not scalarlm_state_dict_export_enabled():
+            return state_dict
+
+        layers = getattr(getattr(self, "model", None), "layers", None) or []
+        for index, layer in enumerate(layers):
+            # PPMissingLayer placeholders have no attention module.
+            attn = getattr(layer, "self_attn", None)
+            if attn is None or not hasattr(attn, "q_size"):
+                continue
+            q_size, kv_size = attn.q_size, attn.kv_size
+            base = f"{prefix}model.layers.{index}.self_attn"
+            for suffix in ("weight", "bias"):
+                packed_key = f"{base}.qkv_proj.{suffix}"
+                packed = state_dict.get(packed_key)
+                if packed is None:
+                    continue
+                if packed.shape[0] != q_size + 2 * kv_size:
+                    # Geometry we don't model. Leaving it packed loses the
+                    # tensor for adapter matching, which is recoverable;
+                    # splitting it wrongly corrupts weights silently.
+                    continue
+                del state_dict[packed_key]
+                state_dict[f"{base}.q_proj.{suffix}"] = packed[:q_size]
+                state_dict[f"{base}.k_proj.{suffix}"] = packed[
+                    q_size : q_size + kv_size
+                ]
+                state_dict[f"{base}.v_proj.{suffix}"] = packed[q_size + kv_size :]
+
+        # qkv is handled above; the shared helper still unpacks
+        # gate_up_proj and drops fused-expert / scale keys that have no HF
+        # counterpart.
+        return unpack_packed_modules_state_dict(
+            state_dict,
+            prefix=prefix,
+            packed_modules_mapping={
+                key: value
+                for key, value in self.packed_modules_mapping.items()
+                if key != "qkv_proj"
+            },
+            config=self.config,
+        )
+
+'''
+
+
+LATEST_CHECKPOINT_SRC = '''
+
+def _scalarlm_latest_checkpoint(files):
+    """Pick the highest-step checkpoint, not the alphabetically first.
+
+    Both call sites used `sorted(...)[0]`, which orders lexically:
+    checkpoint_1000.pt sorts before checkpoint_1999.pt, and
+    checkpoint_500.pt sorts after both. A job that saved more than one
+    checkpoint therefore serves an arbitrary earlier one -- an
+    undertrained model that loads cleanly, reports every tensor matched,
+    and answers with garbage. Observed on a 2000-step run whose final
+    checkpoint was correct under HuggingFace while vLLM served an
+    earlier one.
+
+    `max` over the already-sorted list keeps ties deterministic, so the
+    loader and the adapter_format classifier still agree on the same
+    file -- which the comments at both sites require.
+    """
+
+    def step_of(path):
+        stem = path.name.rsplit(".", 1)[0]
+        tail = stem.rsplit("_", 1)[-1]
+        return int(tail) if tail.isdigit() else -1
+
+    return max(sorted(files), key=step_of)
+'''
+
+
+def patch_diffusion_gemma_sc_embeds_dtype(vllm_root: Path) -> None:
+    """Cast the self-conditioning soft embeds to the buffer's dtype.
+
+    `sc_embeds` is float32; `soft_embeds` inherits embed_weight's dtype
+    (bf16), and index_put_ refuses to cast, so DiffusionGemma dies during
+    warmup on B200:
+
+        RuntimeError: Index put requires the source and destination dtypes
+        match, got Float for the destination and BFloat16 for the source.
+
+    The consumer already does `soft.to(inputs_embeds.dtype)` on read, so
+    casting on write matches the existing convention. bf16 -> fp32 is
+    lossless.
+
+    Belongs upstream in vllm-fork; carried here so DiffusionGemma can be
+    exercised without waiting on that.
+    """
+    target = (
+        vllm_root / "vllm" / "model_executor" / "models" / "diffusion_gemma.py"
+    )
+    if not target.exists():
+        print(
+            f"[vllm_patches] {target} not found; skipping diffusion_gemma "
+            f"dtype patch"
+        )
+        return
+
+    src = target.read_text()
+    anchor = "    sc_embeds[decode_slots] = soft_embeds * sc_keep\n"
+
+    if "(soft_embeds * sc_keep).to(sc_embeds.dtype)" in src:
+        print("[vllm_patches] diffusion_gemma dtype cast already present; skipping")
+        return
+
+    assert src.count(anchor) == 1, (
+        "diffusion_gemma.py: expected exactly one "
+        "`sc_embeds[decode_slots] = soft_embeds * sc_keep`. Re-anchor this patch."
+    )
+
+    patched = src.replace(
+        anchor,
+        "    # ScalarLM patch: sc_embeds is fp32, soft_embeds is bf16, and\n"
+        "    # index_put_ will not cast. The consumer casts on read too.\n"
+        "    sc_embeds[decode_slots] = (soft_embeds * sc_keep).to(sc_embeds.dtype)\n",
+        1,
+    )
+
+    assert patched != src, "patch produced identical output — something's wrong"
+    compile(patched, str(target), "exec")
+
+    target.write_text(patched)
+    print(f"[vllm_patches] Applied diffusion_gemma sc_embeds dtype cast to {target}")
+
+
+def patch_latest_checkpoint_selection(vllm_root: Path) -> None:
+    """Select adapter checkpoints by step number rather than filename.
+
+    Applies to both places that resolve a job directory to a single
+    `.pt`: the Tokenformer loader and the adapter_format classifier.
+    They are commented as needing to agree, so they are patched together
+    or not at all.
+    """
+    manager = vllm_root / "vllm" / "tokenformer" / "tokenformer_model_manager.py"
+    fmt = vllm_root / "vllm" / "tokenformer" / "adapter_format.py"
+
+    for target in (manager, fmt):
+        if not target.exists():
+            print(
+                f"[vllm_patches] {target} not found; skipping "
+                f"latest-checkpoint patch"
+            )
+            return
+
+    manager_src = manager.read_text()
+    fmt_src = fmt.read_text()
+
+    if "_scalarlm_latest_checkpoint" in manager_src:
+        print("[vllm_patches] latest-checkpoint selection already present; skipping")
+        return
+
+    manager_anchor = (
+        "        files = sorted(Path(model_dir).glob(\"*.pt\"))\n"
+        "\n"
+        "        if len(files) == 0:\n"
+        "            raise FileNotFoundError(f\"No .pt file found in {model_dir}\")\n"
+        "\n"
+        "        checkpoint_file = files[0]\n"
+    )
+    fmt_anchor = (
+        "    files = sorted(model_dir.glob(\"*.pt\"))\n"
+        "    if not files:\n"
+        "        raise FileNotFoundError(f\"No .pt file found in {model_dir}\")\n"
+        "    checkpoint_file = files[0]\n"
+    )
+    manager_logger = "logger = init_logger(__name__)\n"
+    fmt_imports = "from typing import Any, Literal, TypeAlias\n"
+
+    assert manager_anchor in manager_src, (
+        "tokenformer_model_manager.py: the checkpoint-selection block in "
+        "from_local_checkpoint has drifted. Re-anchor this patch."
+    )
+    assert fmt_anchor in fmt_src, (
+        "adapter_format.py: the checkpoint-selection block in "
+        "_load_adapter_checkpoint has drifted. Re-anchor this patch."
+    )
+    assert manager_logger in manager_src and fmt_imports in fmt_src, (
+        "tokenformer files: module-level insertion anchors have drifted. "
+        "Re-anchor this patch."
+    )
+
+    manager_patched = manager_src.replace(
+        manager_logger, manager_logger + LATEST_CHECKPOINT_SRC, 1
+    ).replace(
+        manager_anchor,
+        manager_anchor.replace(
+            "        checkpoint_file = files[0]\n",
+            "        checkpoint_file = _scalarlm_latest_checkpoint(files)\n",
+        ),
+        1,
+    )
+    fmt_patched = fmt_src.replace(
+        fmt_imports, fmt_imports + LATEST_CHECKPOINT_SRC, 1
+    ).replace(
+        fmt_anchor,
+        fmt_anchor.replace(
+            "    checkpoint_file = files[0]\n",
+            "    checkpoint_file = _scalarlm_latest_checkpoint(files)\n",
+        ),
+        1,
+    )
+
+    for target, patched, original in (
+        (manager, manager_patched, manager_src),
+        (fmt, fmt_patched, fmt_src),
+    ):
+        assert patched != original, f"{target}: patch produced identical output"
+        compile(patched, str(target), "exec")
+        target.write_text(patched)
+
+    print("[vllm_patches] Applied latest-checkpoint selection to both call sites")
+
+
+def patch_llama_scalarlm_state_dict_export(vllm_root: Path) -> None:
+    """Give LlamaForCausalLM the ScalarLM `state_dict` export override.
+
+    Same defect as gemma4 had: llama fuses q/k/v into `qkv_proj` and never
+    exposes the unpacked names, so every trained attention projection is
+    dropped when a Tokenformer adapter is applied. Simpler fix than
+    gemma4's because llama's head_dim does not vary per layer.
+    """
+    target = vllm_root / "vllm" / "model_executor" / "models" / "llama.py"
+    if not target.exists():
+        print(f"[vllm_patches] {target} not found; skipping llama state_dict patch")
+        return
+
+    src = target.read_text()
+
+    if "scalarlm_state_dict_export_enabled" in src:
+        print("[vllm_patches] llama state_dict export already present; skipping")
+        return
+
+    anchor_imports = (
+        "from .utils import (\n"
+        "    AutoWeightsLoader,\n"
+        "    PPMissingLayer,\n"
+        "    WeightsMapper,\n"
+        "    extract_layer_index,\n"
+        "    make_empty_intermediate_tensors_factory,\n"
+        "    make_layers,\n"
+        "    maybe_prefix,\n"
+        ")\n"
+    )
+    anchor_class = (
+        "class LlamaForCausalLM(\n"
+        "    LocalArgmaxMixin,\n"
+        "    nn.Module,\n"
+        "    SupportsLoRA,\n"
+        "    SupportsPP,\n"
+        "    SupportsEagle,\n"
+        "    SupportsEagle3,\n"
+        "    SupportsQuant,\n"
+        "    SupportsTokenformer,\n"
+        "):\n"
+    )
+
+    assert anchor_imports in src, (
+        "llama.py: the `from .utils import (...)` block has drifted; cannot "
+        "add the state_dict export helpers. Re-anchor this patch."
+    )
+    assert anchor_class in src, (
+        "llama.py: the LlamaForCausalLM class header has drifted; cannot "
+        "place the state_dict override. Re-anchor this patch."
+    )
+
+    patched = src.replace(
+        anchor_imports,
+        anchor_imports.replace(
+            "    maybe_prefix,\n",
+            "    maybe_prefix,\n"
+            "    scalarlm_state_dict_export_enabled,\n"
+            "    unpack_packed_modules_state_dict,\n",
+        ),
+        1,
+    ).replace(anchor_class, anchor_class + STATE_DICT_EXPORT_SRC, 1)
+
+    assert patched != src, "patch produced identical output — something's wrong"
+    compile(patched, str(target), "exec")
+
+    target.write_text(patched)
+    print(f"[vllm_patches] Applied llama state_dict export to {target}")
+
+
+def patch_gemma4_scalarlm_state_dict_export(vllm_root: Path) -> None:
+    """Give Gemma4ForCausalLM the ScalarLM `state_dict` export override.
+
+    Five model files implement it (qwen2, qwen3, qwen3_moe, gemma3, plus
+    the helper in utils.py); gemma4 does not. The consequence is specific
+    and quiet: serving a ScalarLM Tokenformer checkpoint on Gemma4 drops
+    every `q_proj`/`k_proj`/`v_proj` tensor the trainer produced, because
+    vLLM only exposes them fused as `qkv_proj`. Training converges, the
+    checkpoint is correct, and the served model still answers with
+    garbage because its attention is at initialization.
+
+    Verified with tiny-random/gemma-4-dense: 10 of 52 checkpoint tensors
+    unmatched without this, all of them attention projections.
+    """
+    target = vllm_root / "vllm" / "model_executor" / "models" / "gemma4.py"
+    if not target.exists():
+        print(f"[vllm_patches] {target} not found; skipping gemma4 state_dict patch")
+        return
+
+    src = target.read_text()
+
+    if "scalarlm_state_dict_export_enabled" in src:
+        print("[vllm_patches] gemma4 state_dict export already present; skipping")
+        return
+
+    anchor_imports = (
+        "from .utils import (\n"
+        "    AutoWeightsLoader,\n"
+        "    WeightsMapper,\n"
+        "    extract_layer_index,\n"
+        "    is_pp_missing_parameter,\n"
+        "    make_layers,\n"
+        "    maybe_prefix,\n"
+        ")\n"
+    )
+    anchor_class = (
+        "class Gemma4ForCausalLM(\n"
+        "    nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts, SupportsEagle3\n"
+        "):\n"
+    )
+
+    assert anchor_imports in src, (
+        "gemma4.py: the `from .utils import (...)` block has drifted; cannot "
+        "add the state_dict export helpers. Re-anchor this patch."
+    )
+    assert anchor_class in src, (
+        "gemma4.py: the Gemma4ForCausalLM class header has drifted; cannot "
+        "place the state_dict override. Re-anchor this patch."
+    )
+
+    patched = src.replace(
+        anchor_imports,
+        anchor_imports.replace(
+            "    maybe_prefix,\n",
+            "    maybe_prefix,\n"
+            "    scalarlm_state_dict_export_enabled,\n"
+            "    unpack_packed_modules_state_dict,\n",
+        ),
+        1,
+    ).replace(
+        anchor_class,
+        anchor_class + STATE_DICT_EXPORT_SRC,
+        1,
+    )
+
+    assert patched != src, "patch produced identical output — something's wrong"
+    compile(patched, str(target), "exec")
+
+    target.write_text(patched)
+    print(f"[vllm_patches] Applied gemma4 state_dict export to {target}")
+
 
 def main() -> int:
     if len(sys.argv) != 2:
@@ -224,7 +736,11 @@ def main() -> int:
         return 3
 
     patch_output_handler_metrics_offload(vllm_root)
-    patch_instrumentator_route_name_signature(vllm_root)
+    patch_tokenformer_adapter_key_resolution(vllm_root)
+    patch_gemma4_scalarlm_state_dict_export(vllm_root)
+    patch_llama_scalarlm_state_dict_export(vllm_root)
+    patch_latest_checkpoint_selection(vllm_root)
+    patch_diffusion_gemma_sc_embeds_dtype(vllm_root)
     print("[vllm_patches] All patches applied.")
     return 0
 

--- a/scripts/vllm_patches/apply_patches.py
+++ b/scripts/vllm_patches/apply_patches.py
@@ -154,6 +154,65 @@ def patch_output_handler_metrics_offload(vllm_root: Path) -> None:
     target.write_text(patched)
     print(f"[vllm_patches] Applied output_handler metrics offload to {target}")
 
+def patch_instrumentator_route_name_signature(vllm_root: Path) -> None:
+    """Forward kwargs through the fork's `get_route_name` monkeypatch.
+
+    `vllm/entrypoints/serve/instrumentator/metrics.py` wraps
+    `prometheus_fastapi_instrumentator.routing.get_route_name` to swallow the
+    `AttributeError` that nested routers trigger. The wrapper takes only
+    `request`, but current instrumentator releases call it as
+    `get_route_name(request, should_include_root_path=...)`, so every request
+    through the metrics middleware raises TypeError -> HTTP 400 on all
+    endpoints, including /health. ScalarLM then reports vLLM down while the
+    engine is running fine.
+
+    Both the signature and the forwarded call need widening: `**kwargs` alone
+    fixes the inbound call and then fails on the outbound one, because the real
+    `get_route_name` *requires* should_include_root_path.
+
+    Skips cleanly if the anchor is absent -- newer fork revisions replaced this
+    shim with a `_get_route_name` walk that doesn't have the problem.
+    """
+    target = (
+        vllm_root / "vllm" / "entrypoints" / "serve" / "instrumentator" / "metrics.py"
+    )
+    if not target.exists():
+        print(f"[vllm_patches] {target} not found; skipping route-name patch")
+        return
+
+    src = target.read_text()
+
+    anchor_def = "def patched_get_route_name(request):\n"
+    anchor_call = "        return _original_get_route_name(request)\n"
+
+    if anchor_def not in src:
+        print(
+            "[vllm_patches] patched_get_route_name shim absent; "
+            "route-name patch not needed for this revision"
+        )
+        return
+
+    assert anchor_call in src, (
+        "metrics.py: found `def patched_get_route_name(request):` but not the "
+        "expected `return _original_get_route_name(request)` call. The shim has "
+        "drifted -- re-anchor this patch."
+    )
+
+    patched = (
+        src
+        .replace(anchor_def, "def patched_get_route_name(request, **kwargs):\n", 1)
+        .replace(
+            anchor_call,
+            "        return _original_get_route_name(request, **kwargs)\n",
+            1,
+        )
+    )
+
+    assert patched != src, "patch produced identical output — something's wrong"
+    compile(patched, str(target), "exec")
+
+    target.write_text(patched)
+    print(f"[vllm_patches] Forwarded kwargs through patched_get_route_name in {target}")
 
 def main() -> int:
     if len(sys.argv) != 2:
@@ -165,6 +224,7 @@ def main() -> int:
         return 3
 
     patch_output_handler_metrics_offload(vllm_root)
+    patch_instrumentator_route_name_signature(vllm_root)
     print("[vllm_patches] All patches applied.")
     return 0
 

--- a/test/deployment/train_generate.py
+++ b/test/deployment/train_generate.py
@@ -14,6 +14,16 @@ logging.basicConfig(level=logging.DEBUG)
 count = 3
 selected = random.randint(1, count)
 
+# The old value was count * 50 = 150, which cannot pass. The default
+# model (tiny-random/gemma-4-dense) has random initial weights, so it
+# learns language from scratch: 150 steps ends at loss ~10.8 (roughly
+# uniform prediction) and 1000 at ~1.2, both of which generate word
+# salad. 1500 reaches ~0.28 and reproduces the training answers.
+# The LR schedule decays to zero at max_steps, so lowering this also
+# compresses the schedule. Pretrained models converge far sooner --
+# override with --max-steps.
+DEFAULT_MAX_STEPS = 1500
+
 TEST_QUESTION = f"What is {selected} + {selected}?"
 TEST_ANSWER = f"The answer is {selected + selected}."
 
@@ -37,7 +47,7 @@ def get_dataset():
     return dataset
 
 
-def run_test():
+def run_test(max_steps=DEFAULT_MAX_STEPS):
     # 0. VLLM Health up
     llm = scalarlm.SupermassiveIntelligence(api_url="http://localhost:8000")
 
@@ -102,7 +112,7 @@ def run_test():
     # 3. Train a base model with small dataset
     training_response = llm.train(
         create_training_set(),
-        train_args={"max_steps": (count * 50), "learning_rate": 3e-3, "gpus": 1, "max_gpus": 1},
+        train_args={"max_steps": max_steps, "learning_rate": 3e-3, "gpus": 1, "max_gpus": 1},
     )
     logger.info(training_response)
 
@@ -150,6 +160,9 @@ def main():
     parser = argparse.ArgumentParser(description='Train and generate test')
     parser.add_argument('--force-recreate', action='store_true', 
                        help='Delete existing trained models before training')
+    parser.add_argument('--max-steps', type=int, default=DEFAULT_MAX_STEPS,
+                       help='Training steps. Pretrained models need far '
+                            'fewer than the random-init default model.')
     args = parser.parse_args()
     
     if args.force_recreate:
@@ -170,7 +183,7 @@ def main():
                         shutil.rmtree(item_path)
                         break  # Only remove the first one we find
                     
-    run_test()
+    run_test(max_steps=args.max_steps)
 
 
 # Ensure the main function is only executed when the script is run directly

--- a/test/deployment/verify_checkpoint_hf.py
+++ b/test/deployment/verify_checkpoint_hf.py
@@ -1,0 +1,141 @@
+"""Run a trained checkpoint through HuggingFace instead of vLLM.
+
+"Trained model answers with garbage" has two causes that look identical
+from outside: a bad checkpoint, or a serving path that loses weights.
+Same weights through a second inference stack tells them apart in a
+minute, with no rebuild:
+
+  - HF correct, vLLM garbage -> serving is losing weights
+  - both garbage             -> the checkpoint is bad, serving is innocent
+
+That distinction is what ended a long debugging session where training,
+checkpointing and adapter loading all reported success.
+
+Mirrors the trainer: same model class, same Tokenformer surgery, same
+prompt construction (input + output concatenated, no chat template).
+
+    docker compose exec cray-nvidia \
+        python /app/cray/test/deployment/verify_checkpoint_hf.py \
+            [--job-dir /app/cray/jobs/<hash>] [--prompt "What is 3 + 3?"]
+"""
+
+import argparse
+import glob
+import os
+
+import torch
+import yaml
+from transformers import AutoConfig, AutoModelForCausalLM, AutoModelForImageTextToText, AutoTokenizer
+
+from tokenformer.tokenformer_surgeon import TokenformerSurgeon
+
+
+def latest_job_dir(jobs_root):
+    candidates = [
+        d for d in glob.glob(os.path.join(jobs_root, "*"))
+        if os.path.isdir(d) and glob.glob(os.path.join(d, "*.pt"))
+    ]
+    if not candidates:
+        raise SystemExit(f"No job directory with a .pt checkpoint under {jobs_root}")
+    return max(candidates, key=os.path.getmtime)
+
+
+def latest_checkpoint(job_dir):
+    # Match the serving side: sorted() so a directory with several
+    # checkpoints picks deterministically, then prefer the highest step.
+    checkpoints = sorted(glob.glob(os.path.join(job_dir, "*.pt")))
+    if not checkpoints:
+        raise SystemExit(f"No .pt checkpoint in {job_dir}")
+
+    def step_of(path):
+        stem = os.path.basename(path).rsplit(".", 1)[0]
+        tail = stem.rsplit("_", 1)[-1]
+        return int(tail) if tail.isdigit() else -1
+
+    return max(checkpoints, key=step_of)
+
+
+def build_model(model_name):
+    """Load the base model the way the trainer does, then apply the surgeon.
+
+    The surgery matters: the checkpoint contains tokenformer_{k,v,p}
+    tensors that only exist as parameters after the MLP layers are
+    wrapped. Loading into an unsurgered model would report all of them
+    as unexpected keys.
+    """
+    config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+    multimodal = getattr(config, "vision_config", None) is not None
+    loader = AutoModelForImageTextToText if multimodal else AutoModelForCausalLM
+    print(f"Base model: {model_name} (multimodal={multimodal}, via {loader.__name__})")
+
+    model = loader.from_pretrained(
+        model_name, dtype=torch.bfloat16, trust_remote_code=True
+    )
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = model.to(device)
+    return TokenformerSurgeon(model, torch.device(device)).insert_adapter_modules(), device
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--job-dir", default=None)
+    parser.add_argument("--jobs-root", default="/app/cray/jobs")
+    parser.add_argument("--prompt", default="What is 3 + 3?")
+    parser.add_argument("--max-new-tokens", type=int, default=16)
+    args = parser.parse_args()
+
+    job_dir = args.job_dir or latest_job_dir(args.jobs_root)
+    checkpoint_path = latest_checkpoint(job_dir)
+    print(f"Job:        {job_dir}")
+    print(f"Checkpoint: {checkpoint_path}")
+
+    with open(os.path.join(job_dir, "config.yaml")) as f:
+        model_name = yaml.safe_load(f)["llm_name"]
+
+    model, device = build_model(model_name)
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+
+    checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    state_dict = checkpoint["model_state_dict"]
+    print(f"\nCheckpoint holds {len(state_dict)} tensors (step {checkpoint.get('step')})")
+
+    # strict=False plus an explicit report: a silent mismatch here would
+    # invalidate the whole comparison, so name what didn't land.
+    result = model.load_state_dict(state_dict, strict=False)
+    unexpected = list(result.unexpected_keys)
+    print(f"Unexpected keys (in checkpoint, not in model): {len(unexpected)}")
+    for key in unexpected[:10]:
+        print(f"    {key}")
+    if unexpected:
+        print("    ^ these did NOT load; the comparison below is only")
+        print("      meaningful if this list is empty.")
+
+    loaded = len(state_dict) - len(unexpected)
+    print(f"Applied {loaded}/{len(state_dict)} checkpoint tensors\n")
+
+    model.eval()
+    inputs = tokenizer(args.prompt, return_tensors="pt").to(device)
+    with torch.no_grad():
+        output = model.generate(
+            **inputs,
+            max_new_tokens=args.max_new_tokens,
+            do_sample=False,
+            temperature=None,
+            top_p=None,
+            top_k=None,
+        )
+
+    completion = tokenizer.decode(
+        output[0][inputs["input_ids"].shape[1]:], skip_special_tokens=True
+    )
+    print(f"Prompt:     {args.prompt!r}")
+    print(f"HF output:  {completion!r}")
+    print(
+        "\nCompare against what vLLM returned for the same prompt and model.\n"
+        "Different -> the serving path is losing weights.\n"
+        "Same garbage -> the checkpoint is the problem."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/unit/test_enable_lora_arg.py
+++ b/test/unit/test_enable_lora_arg.py
@@ -1,9 +1,15 @@
-"""Unit tests for the Phase 31b conditional --enable-lora arg.
+"""Unit tests for the conditional adapter args (--enable-lora,
+--enable-tokenformer).
 
 Pure-inference pods can opt out via SCALARLM_ENABLE_LORA=false, which
 drops the --enable-lora vLLM CLI arg. This avoids wrapping every layer
 in a LoRA shim (perf win, plus sidesteps the fused_moe wrapper bug on
 some vllm-fork builds).
+
+--enable-tokenformer is what lets the fork load the Tokenformer-keyed
+.pt checkpoints the ScalarLM trainer emits; without it the fork's
+LoRA-only manager rejects them and generation against a trained model
+404s.
 """
 
 from __future__ import annotations
@@ -18,7 +24,8 @@ def _base_config(**overrides):
         "max_log_length": 100,
         "tensor_parallel_size": 1,
         "limit_mm_per_prompt": None,
-        "enable_lora": True,
+        "enable_lora": False,
+        "enable_tokenformer": True,
     }
     cfg.update(overrides)
     return cfg
@@ -34,13 +41,52 @@ def test_enable_lora_false_omits_flag():
     assert "--enable-lora" not in args
 
 
-def test_enable_lora_default_true():
-    """Missing key in config defaults to True (back-compat with pods
-    that haven't re-synced their config yaml)."""
+def test_enable_lora_default_false():
+    """Missing key defaults to False, matching default_config.Config -- a
+    stale config yaml must not produce a different server."""
     cfg = _base_config()
     del cfg["enable_lora"]
     args = build_vllm_cli_args(cfg)
+    assert "--enable-lora" not in args
+
+
+def test_enable_tokenformer_true_includes_flag():
+    args = build_vllm_cli_args(_base_config(enable_tokenformer=True))
+    assert "--enable-tokenformer" in args
+
+
+def test_enable_tokenformer_false_omits_flag():
+    args = build_vllm_cli_args(_base_config(enable_tokenformer=False))
+    assert "--enable-tokenformer" not in args
+
+
+def test_enable_tokenformer_default_true():
+    """Missing key defaults to True: the trainer only produces
+    Tokenformer adapters, so a config yaml that predates this flag must
+    still serve them."""
+    cfg = _base_config()
+    del cfg["enable_tokenformer"]
+    args = build_vllm_cli_args(cfg)
+    assert "--enable-tokenformer" in args
+
+
+def test_default_selects_tokenformer_only_not_hybrid():
+    """Tokenformer without LoRA is the shipped default. Both flags
+    together select the HybridAdapterManager, whose LoRA sub-manager
+    nests every targeted layer under `.base_layer.` -- which makes the
+    attention weights in a ScalarLM checkpoint unmatchable, so they are
+    silently dropped and the served model runs random attention."""
+    args = build_vllm_cli_args(_base_config())
+    assert "--enable-lora" not in args
+    assert "--enable-tokenformer" in args
+
+
+def test_hybrid_is_still_reachable_for_lora_adapters():
+    """Servers dedicated to adapter_type="lora" jobs need the opposite
+    setting; the knob must not become one-way."""
+    args = build_vllm_cli_args(_base_config(enable_lora=True))
     assert "--enable-lora" in args
+    assert "--enable-tokenformer" in args
 
 
 def test_other_required_flags_always_present():

--- a/test/unit/test_latest_checkpoint_selection.py
+++ b/test/unit/test_latest_checkpoint_selection.py
@@ -1,0 +1,74 @@
+"""Unit tests for adapter checkpoint selection.
+
+Both vLLM-side call sites picked `sorted(glob("*.pt"))[0]`, which orders
+lexically. A job that saved several checkpoints therefore served an
+arbitrary earlier one: it loads cleanly, reports every tensor matched,
+and answers with garbage because the model is undertrained.
+
+Observed on a 2000-step run whose final checkpoint produced the correct
+answer under HuggingFace while vLLM served an earlier one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "vllm_patches"))
+
+from apply_patches import LATEST_CHECKPOINT_SRC  # noqa: E402
+
+_namespace: dict = {}
+exec(LATEST_CHECKPOINT_SRC, _namespace)
+latest_checkpoint = _namespace["_scalarlm_latest_checkpoint"]
+
+
+def _files(*names):
+    return [Path("/jobs/hash") / name for name in names]
+
+
+def test_picks_highest_step_not_first_alphabetically():
+    """The exact ordering that caused the bug: 1000 sorts before 1999."""
+    chosen = latest_checkpoint(_files("checkpoint_1000.pt", "checkpoint_1999.pt"))
+
+    assert chosen.name == "checkpoint_1999.pt"
+
+
+def test_lexical_order_puts_a_smaller_step_last():
+    """checkpoint_500.pt sorts AFTER both, so neither `[0]` nor `[-1]`
+    is correct -- only numeric comparison is."""
+    chosen = latest_checkpoint(
+        _files("checkpoint_1000.pt", "checkpoint_1999.pt", "checkpoint_500.pt")
+    )
+
+    assert chosen.name == "checkpoint_1999.pt"
+
+
+def test_single_checkpoint_is_returned():
+    chosen = latest_checkpoint(_files("checkpoint_1999.pt"))
+
+    assert chosen.name == "checkpoint_1999.pt"
+
+
+def test_non_numeric_names_lose_to_numbered_ones():
+    """A stray file shouldn't outrank a real checkpoint."""
+    chosen = latest_checkpoint(_files("adapter.pt", "checkpoint_10.pt"))
+
+    assert chosen.name == "checkpoint_10.pt"
+
+
+def test_all_non_numeric_falls_back_deterministically():
+    """With nothing to compare numerically both call sites must still
+    agree, so the choice has to be a function of the sorted order."""
+    chosen = latest_checkpoint(_files("b.pt", "a.pt", "c.pt"))
+
+    assert chosen.name == "a.pt"
+
+
+def test_selection_is_order_independent():
+    """glob() order is filesystem-dependent; the result must not be."""
+    names = ("checkpoint_500.pt", "checkpoint_1999.pt", "checkpoint_1000.pt")
+    forward = latest_checkpoint(_files(*names))
+    backward = latest_checkpoint(_files(*reversed(names)))
+
+    assert forward == backward == Path("/jobs/hash/checkpoint_1999.pt")

--- a/test/unit/test_sampling_params_for_model.py
+++ b/test/unit/test_sampling_params_for_model.py
@@ -1,0 +1,55 @@
+"""Sampling params must match what the served model accepts.
+
+Diffusion models (dLLMs) reject temperature, min_p, seed, min_tokens,
+logit_bias, bad_words and allowed_token_ids. ScalarLM always sent
+temperature, so every request to a diffusion model failed:
+
+    ValueError: The temperature, min_p, seed, ... sampling parameters are
+    not yet supported with diffusion models.
+"""
+
+from __future__ import annotations
+
+import types
+
+from cray_infra.one_server.sampling_params import sampling_params_for
+
+
+def _app(is_diffusion):
+    engine_client = types.SimpleNamespace(
+        model_config=types.SimpleNamespace(is_diffusion=is_diffusion)
+    )
+    return types.SimpleNamespace(state=types.SimpleNamespace(engine_client=engine_client))
+
+
+def test_autoregressive_model_gets_temperature():
+    assert sampling_params_for(_app(False), {}) == {"temperature": 0.0}
+
+
+def test_explicit_temperature_is_passed_through():
+    params = sampling_params_for(_app(False), {"temperature": 0.7})
+
+    assert params == {"temperature": 0.7}
+
+
+def test_diffusion_model_gets_no_temperature():
+    assert sampling_params_for(_app(True), {"temperature": 0.7}) == {}
+
+
+def test_missing_model_config_falls_back_to_autoregressive():
+    """A model_config without is_diffusion (older vLLM) must keep the
+    previous behavior rather than silently dropping temperature."""
+    engine_client = types.SimpleNamespace(model_config=types.SimpleNamespace())
+    app = types.SimpleNamespace(
+        state=types.SimpleNamespace(engine_client=engine_client)
+    )
+
+    assert sampling_params_for(app, {}) == {"temperature": 0.0}
+
+
+def test_absent_engine_client_attribute_does_not_raise():
+    app = types.SimpleNamespace(
+        state=types.SimpleNamespace(engine_client=types.SimpleNamespace())
+    )
+
+    assert sampling_params_for(app, {}) == {"temperature": 0.0}

--- a/test/unit/test_state_dict_export_patch.py
+++ b/test/unit/test_state_dict_export_patch.py
@@ -1,0 +1,171 @@
+"""Unit tests for the ScalarLM state_dict export patch (gemma4 + llama).
+
+The patch is injected into the vLLM fork by
+`scripts/vllm_patches/apply_patches.py`; its source lives there as a
+string constant, so these tests exec it against fakes and need no fork
+checkout.
+
+What it guards: Gemma4 alternates head_dim per layer (32 on some, 64 on
+others), so the split sizes for `qkv_proj` differ per layer. The shared
+`unpack_packed_modules_state_dict` helper derives a single split from the
+model config, which raised
+
+    split_with_sizes expects split_sizes to sum exactly to 1024,
+    but got split_sizes=[256, 128, 128]
+
+on a real tiny-random/gemma-4-dense run. The geometry below is taken from
+that model.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+import textwrap
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "vllm_patches"))
+
+from apply_patches import STATE_DICT_EXPORT_SRC  # noqa: E402
+
+
+class _Tensor:
+    """Stand-in that records how it was sliced. Only shape/slicing matter."""
+
+    def __init__(self, rows, tag):
+        self.shape = (rows,)
+        self.tag = tag
+
+    def __getitem__(self, item):
+        return ("slice", self.tag, item.start, item.stop)
+
+
+def _layer(q_size, kv_size):
+    return types.SimpleNamespace(
+        self_attn=types.SimpleNamespace(q_size=q_size, kv_size=kv_size)
+    )
+
+
+# tiny-random/gemma-4-dense: 8 query heads, 4 kv heads, head_dim
+# alternating 32 / 64 -> packed qkv rows alternating 512 / 1024.
+LAYERS = [_layer(256, 128), _layer(512, 256), _layer(256, 128), _layer(512, 256)]
+
+PREFIX = "language_model."
+
+
+def _build(state_dict, layers, export_enabled=True):
+    """exec the injected method inside a real class so super() resolves."""
+    method = next(
+        node
+        for node in ast.walk(ast.parse(STATE_DICT_EXPORT_SRC.strip()))
+        if isinstance(node, ast.FunctionDef) and node.name == "state_dict"
+    )
+    harness = (
+        "class Base:\n"
+        "    def state_dict(self, destination=None, prefix='', keep_vars=False):\n"
+        "        return dict(SOURCE)\n"
+        "\n"
+        "class Model(Base):\n"
+        "    packed_modules_mapping = {'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],\n"
+        "                              'gate_up_proj': ['gate_proj', 'up_proj']}\n"
+        "    config = None\n"
+        "    def __init__(self, layers):\n"
+        "        self.model = types.SimpleNamespace(layers=layers)\n"
+        + textwrap.indent(ast.unparse(method), "    ")
+    )
+    captured = {}
+
+    def fake_unpack(state_dict, *, prefix, packed_modules_mapping, config):
+        captured["mapping"] = packed_modules_mapping
+        return state_dict
+
+    namespace = {
+        "SOURCE": state_dict,
+        "types": types,
+        "scalarlm_state_dict_export_enabled": lambda: export_enabled,
+        "unpack_packed_modules_state_dict": fake_unpack,
+    }
+    exec(harness, namespace)
+    return namespace["Model"](layers), captured
+
+
+@pytest.fixture
+def packed_state_dict():
+    return {
+        f"{PREFIX}model.layers.{i}.self_attn.qkv_proj.weight": _Tensor(
+            layer.self_attn.q_size + 2 * layer.self_attn.kv_size, i
+        )
+        for i, layer in enumerate(LAYERS)
+    }
+
+
+def test_per_layer_geometry_is_read_from_the_module(packed_state_dict):
+    """Each layer splits by its own q_size/kv_size, not a shared config
+    value -- layers 1 and 3 are twice the size of 0 and 2."""
+    model, _ = _build(packed_state_dict, LAYERS)
+
+    out = model.state_dict(None, PREFIX, False)
+
+    for i, layer in enumerate(LAYERS):
+        base = f"{PREFIX}model.layers.{i}.self_attn"
+        q, kv = layer.self_attn.q_size, layer.self_attn.kv_size
+        assert f"{base}.qkv_proj.weight" not in out
+        assert out[f"{base}.q_proj.weight"] == ("slice", i, None, q)
+        assert out[f"{base}.k_proj.weight"] == ("slice", i, q, q + kv)
+        assert out[f"{base}.v_proj.weight"] == ("slice", i, q + kv, None)
+
+
+def test_qkv_is_withheld_from_the_shared_helper(packed_state_dict):
+    """Passing qkv_proj through would re-trigger the config-derived split
+    that crashed; gate_up_proj must still be delegated."""
+    model, captured = _build(packed_state_dict, LAYERS)
+
+    model.state_dict(None, PREFIX, False)
+
+    assert "qkv_proj" not in captured["mapping"]
+    assert "gate_up_proj" in captured["mapping"]
+
+
+def test_unrecognized_geometry_is_left_packed():
+    """Losing a tensor for adapter matching is recoverable and logged;
+    splitting it wrongly corrupts weights silently."""
+    state_dict = {f"{PREFIX}model.layers.0.self_attn.qkv_proj.weight": _Tensor(999, 0)}
+    model, _ = _build(state_dict, [_layer(256, 128)])
+
+    out = model.state_dict(None, PREFIX, False)
+
+    assert f"{PREFIX}model.layers.0.self_attn.qkv_proj.weight" in out
+    assert not any("q_proj" in key for key in out)
+
+
+def test_export_disabled_returns_state_dict_untouched(packed_state_dict):
+    """Vanilla vLLM flows (sharded saves, dummy init) must be unaffected."""
+    model, _ = _build(packed_state_dict, LAYERS, export_enabled=False)
+
+    out = model.state_dict(None, PREFIX, False)
+
+    assert out == packed_state_dict
+
+
+def test_layers_without_attention_are_skipped(packed_state_dict):
+    """PPMissingLayer placeholders have no self_attn."""
+    layers = list(LAYERS)
+    layers[1] = types.SimpleNamespace()
+    model, _ = _build(packed_state_dict, layers)
+
+    out = model.state_dict(None, PREFIX, False)
+
+    assert f"{PREFIX}model.layers.1.self_attn.qkv_proj.weight" in out
+    assert f"{PREFIX}model.layers.0.self_attn.q_proj.weight" in out
+
+
+def test_non_qkv_keys_pass_through(packed_state_dict):
+    packed_state_dict[f"{PREFIX}model.layers.0.self_attn.o_proj.weight"] = _Tensor(8, "o")
+    model, _ = _build(packed_state_dict, LAYERS)
+
+    out = model.state_dict(None, PREFIX, False)
+
+    assert out[f"{PREFIX}model.layers.0.self_attn.o_proj.weight"].tag == "o"

--- a/test/unit/test_tokenformer_freeze_scope.py
+++ b/test/unit/test_tokenformer_freeze_scope.py
@@ -1,0 +1,56 @@
+"""The trainer's unfreeze pass must stay inside the language model.
+
+`create_tokenformer_model` matches substrings like "q_proj" against the
+full parameter path. On a multimodal model that also fires inside the
+vision/audio towers, so their weights get trained and written into the
+checkpoint — where vLLM has no matching parameter and adapter activation
+fails.
+
+`is_non_language_path` is the shared definition of "not the language
+model"; the surgeon already used it to decide where to insert adapters.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "ml"))
+
+from tokenformer.tokenformer_surgeon import is_non_language_path  # noqa: E402
+
+
+def test_language_model_paths_are_trainable():
+    assert not is_non_language_path("model.layers.0.self_attn.q_proj.weight")
+    assert not is_non_language_path("model.language_model.layers.3.mlp.tokenformer_p")
+    assert not is_non_language_path("lm_head.weight")
+
+
+def test_vision_and_audio_towers_are_excluded():
+    assert is_non_language_path(
+        "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight"
+    )
+    assert is_non_language_path("model.audio_tower.encoder.layers.0.input_layernorm.weight")
+    assert is_non_language_path("model.multi_modal_projector.weight")
+    assert is_non_language_path("model.embed_vision.weight")
+    assert is_non_language_path("model.embed_audio.weight")
+
+
+def test_matching_is_by_path_component_not_substring():
+    """A parameter whose name merely contains a tower name as part of a
+    longer component is still language-model state."""
+    assert not is_non_language_path("model.layers.0.vision_tower_gate.weight")
+
+
+def test_unfreeze_list_would_otherwise_catch_the_vision_tower():
+    """Guards the reason this exists: the substring list in
+    create_tokenformer_model matches vision-tower parameters, so without
+    the path check they would be trained."""
+    unfreeze_substrings = [
+        "tokenformer", "q_proj", "k_proj", "v_proj", "norm", "rotary_emb",
+        "embed_tokens", "input_layernorm", "post_attention_layernorm", "o_proj",
+    ]
+    vision_param = "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight"
+
+    assert any(s in vision_param for s in unfreeze_substrings)
+    assert is_non_language_path(vision_param)

--- a/test/unit/test_tokenformer_key_resolution.py
+++ b/test/unit/test_tokenformer_key_resolution.py
@@ -1,0 +1,198 @@
+"""Unit tests for the Tokenformer adapter key resolver.
+
+The resolver is injected into the vLLM fork by
+`scripts/vllm_patches/apply_patches.py`. Its source lives in that script
+as a string constant, so these tests exec it with a stub logger and
+exercise the rules directly — no vLLM tree required.
+
+The rule that matters most is #1 (exact match passes through untouched):
+that is what keeps every already-trained checkpoint loading exactly as it
+did before the patch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "vllm_patches"))
+
+from apply_patches import TOKENFORMER_KEY_RESOLVER_SRC  # noqa: E402
+
+
+class _StubLogger:
+    def __init__(self):
+        self.warnings = []
+        self.infos = []
+
+    def warning(self, msg, *args):
+        self.warnings.append(msg % args if args else msg)
+
+    def info(self, msg, *args):
+        self.infos.append(msg % args if args else msg)
+
+
+@pytest.fixture
+def resolve():
+    """The injected helper, with `logger` bound to a stub."""
+    namespace = {"logger": _StubLogger()}
+    exec(TOKENFORMER_KEY_RESOLVER_SRC, namespace)
+    fn = namespace["_scalarlm_resolve_adapter_keys"]
+    fn.stub_logger = namespace["logger"]
+    return fn
+
+
+class _Mapper:
+    """Stand-in for vLLM's WeightsMapper with a prefix rule."""
+
+    def __init__(self, prefixes):
+        self._prefixes = prefixes
+
+    def _map_name(self, key):
+        for old, new in self._prefixes.items():
+            if key.startswith(old):
+                return new + key[len(old):]
+        return key
+
+
+class _Model:
+    hf_to_vllm_mapper = None
+
+
+def _model_with_mapper(mapper):
+    class M:
+        pass
+
+    M.hf_to_vllm_mapper = mapper
+    return M()
+
+
+def test_exact_matches_pass_through_untouched(resolve):
+    """Backward compatibility: a checkpoint whose keys already exist is
+    neither renamed nor dropped."""
+    tokenformers = {
+        "model.layers.0.self_attn.q_proj.weight": "w0",
+        "model.layers.0.mlp.tokenformer_p": "w1",
+    }
+    state_dict = dict.fromkeys(tokenformers, "live")
+
+    out = resolve(_Model(), tokenformers, state_dict)
+
+    assert out == tokenformers
+    assert resolve.stub_logger.warnings == []
+
+
+def test_mapper_rewrites_multimodal_prefix(resolve):
+    """HF `model.language_model.*` resolves to vLLM `language_model.model.*`."""
+    mapper = _Mapper({"model.language_model.": "language_model.model."})
+    tokenformers = {"model.language_model.layers.0.mlp.tokenformer_p": "w"}
+    state_dict = {"language_model.model.layers.0.mlp.tokenformer_p": "live"}
+
+    out = resolve(_model_with_mapper(mapper), tokenformers, state_dict)
+
+    assert out == {"language_model.model.layers.0.mlp.tokenformer_p": "w"}
+    assert resolve.stub_logger.warnings == []
+
+
+def test_mapper_declared_on_the_instance_is_used(resolve):
+    """Several models (mimo_mtp, ernie_mtp, transformers backend) build
+    hf_to_vllm_mapper in __init__ rather than as a class attribute. A
+    class-only lookup would drop every key on those models."""
+    model = _Model()
+    model.hf_to_vllm_mapper = _Mapper({"model.": "language_model.model."})
+    tokenformers = {"model.layers.0.mlp.tokenformer_p": "w"}
+    state_dict = {"language_model.model.layers.0.mlp.tokenformer_p": "live"}
+
+    out = resolve(model, tokenformers, state_dict)
+
+    assert out == {"language_model.model.layers.0.mlp.tokenformer_p": "w"}
+
+
+def test_unresolvable_keys_are_dropped_with_a_warning(resolve):
+    """Vision-tower weights have no vLLM counterpart. Dropping them is what
+    keeps EngineCore alive; the warning is what keeps it from being silent."""
+    tokenformers = {
+        "model.vision_tower.encoder.layers.0.self_attn.q_proj.linear.weight": "w0",
+        "model.layers.0.mlp.tokenformer_p": "w1",
+    }
+    state_dict = {"model.layers.0.mlp.tokenformer_p": "live"}
+
+    out = resolve(_Model(), tokenformers, state_dict)
+
+    assert out == {"model.layers.0.mlp.tokenformer_p": "w1"}
+    assert "1 of 2" in resolve.stub_logger.warnings[0]
+
+
+def test_mapper_result_still_absent_is_dropped(resolve):
+    """A mapper rewrite that doesn't land on a real parameter is not
+    trusted — the membership check is the authority, not the mapper."""
+    mapper = _Mapper({"model.": "nowhere."})
+    tokenformers = {"model.layers.0.self_attn.q_proj.weight": "w"}
+
+    out = resolve(_model_with_mapper(mapper), tokenformers, {})
+
+    assert out == {}
+    assert "1 of 1" in resolve.stub_logger.warnings[0]
+
+
+def test_broken_mapper_does_not_break_serving(resolve):
+    """A mapper that raises falls back to the drop path rather than
+    propagating out of adapter registration."""
+
+    class Exploding:
+        def _map_name(self, key):
+            raise RuntimeError("mapper API drift")
+
+    tokenformers = {"a": "w0", "b": "w1"}
+    state_dict = {"b": "live"}
+
+    out = resolve(_model_with_mapper(Exploding()), tokenformers, state_dict)
+
+    assert out == {"b": "w1"}
+
+
+def test_drop_warning_names_the_nearest_live_parameters(resolve):
+    """The two naming bugs that each cost a 30-minute rebuild -- a LoRA
+    wrapper nesting weights under `.base_layer.`, and vLLM fusing q/k/v
+    into `qkv_proj` -- are both visible in this one line."""
+    live = {
+        "language_model.model.layers.0.self_attn.qkv_proj.base_layer.weight": "w",
+        "language_model.model.layers.0.self_attn.o_proj.base_layer.weight": "w",
+    }
+    tokenformers = {"model.language_model.layers.0.self_attn.q_proj.weight": "w"}
+
+    resolve(_Model(), tokenformers, live)
+
+    diagnostic = " ".join(resolve.stub_logger.warnings)
+    assert "qkv_proj.base_layer" in diagnostic
+
+
+def test_nearest_keys_prefers_the_most_specific_match(resolve):
+    """A name that does exist should report its own neighbours, not the
+    whole layer."""
+    live = {
+        "language_model.model.layers.0.self_attn.o_proj.base_layer.weight": "w",
+        "language_model.model.layers.0.mlp.tokenformer_p": "w",
+    }
+    tokenformers = {"model.language_model.layers.0.self_attn.o_proj.weight": "w"}
+
+    resolve(_Model(), tokenformers, live)
+
+    diagnostic = " ".join(resolve.stub_logger.warnings)
+    assert "o_proj.base_layer" in diagnostic
+    assert "tokenformer_p" not in diagnostic
+
+
+def test_nearest_keys_handles_no_match_at_all(resolve):
+    resolve(_Model(), {"totally.unrelated.key": "w"}, {"nothing": "w"})
+
+    assert "(none)" in " ".join(resolve.stub_logger.warnings)
+
+
+def test_empty_checkpoint_is_not_a_warning(resolve):
+    out = resolve(_Model(), {}, {"x": "live"})
+
+    assert out == {}
+    assert resolve.stub_logger.warnings == []

--- a/ui/src/routes/chat/ConversationView.tsx
+++ b/ui/src/routes/chat/ConversationView.tsx
@@ -17,7 +17,7 @@ import {
   exportConversation,
 } from "@/stores/conversationIO";
 import { useMessages } from "@/stores/useConversationStore";
-import { getTemperature } from "@/stores/sampling";
+import { getTemperatureForRequest } from "@/stores/sampling";
 
 import { ConversationMenu } from "./ConversationMenu";
 import { MarkdownMessage } from "./MarkdownMessage";
@@ -120,7 +120,7 @@ export function ConversationView({
           messages: openAIMessages,
           signal: controller.signal,
           max_tokens: conversation.maxTokens,
-          temperature: getTemperature(),
+          temperature: getTemperatureForRequest(),
           onDelta: (delta) => {
             buffered += delta;
             if (!flushPending) {

--- a/ui/src/stores/sampling.ts
+++ b/ui/src/stores/sampling.ts
@@ -36,6 +36,26 @@ export function getTemperature(): number {
   return current;
 }
 
+/**
+ * Temperature to send, or undefined to let the server decide.
+ *
+ * Diffusion models (dLLMs) reject any temperature other than 1.0 — they
+ * denoise a canvas on a fixed schedule, so per-request sampling has no
+ * meaning. Sending our default of 0 fails every request against one:
+ *
+ *   ValueError: The temperature, min_p, seed, ... sampling parameters are
+ *   not yet supported with diffusion models.
+ *
+ * Omitting the field when the user hasn't touched the slider lets the
+ * server apply its own default, which works for both model families. An
+ * explicitly chosen value is still sent, and will still be rejected by a
+ * diffusion model — that error is the honest answer to "set temperature
+ * to 0.7 on a model that cannot do it".
+ */
+export function getTemperatureForRequest(): number | undefined {
+  return current === TEMPERATURE_DEFAULT ? undefined : current;
+}
+
 export function setTemperature(value: number): void {
   const next = sanitize(value);
   if (next === current) return;


### PR DESCRIPTION
Support DiffusionGemma inference; fix Tokenformer serving

Adds DiffusionGemma support, which required pulling upstream vLLM changes through our fork. Along the way it fixes Tokenformer adapter serving, which was broken for every model.

- The build never used the fork the Dockerfile named. docker-compose.yaml passed VLLM_REPO/VLLM_BRANCH as explicit build args, and those override Dockerfile ARG defaults. Every build cloned the old fork.
- Serving loaded the wrong checkpoint. Both call sites used sorted(glob("*.pt"))[0] — lexical, so a 2000-step job served checkpoint_1799.pt.

The rest: --enable-tokenformer was never passed after the fork split it from --enable-lora; three v0.26.0 API drifts blocked startup; the trainer was training vision towers; hybrid mode relocated base weights under .base_layer.; and llama/gemma4 both lacked the state_dict override that exposes q/k/v to adapter matching.

DiffusionGemma needed three more: a dtype fix in its sampler, the adapter subsystem disabled (it doesn't declare SupportsLoRA), and sampling-parameter handling — diffusion models require temperature to be exactly 1.0, while ScalarLM and the chat UI both sent 0.

Verified

```
┌───────────────────────────┬────────────────┬───────────────┐
│           Model           │   Inference    │ Train → serve │
├───────────────────────────┼────────────────┼───────────────┤
│ tiny-random/gemma-4-dense │ pass           │ pass          │
├───────────────────────────┼────────────────┼───────────────┤
│ masint/tiny-random-llama  │ pass           │ pass          │
├───────────────────────────┼────────────────┼───────────────┤
│ tiny-random/qwen3         │ pass           │ pass          │
├───────────────────────────┼────────────────┼───────────────┤
│ diffusiongemma-26B-A4B-it │ pass (cluster) │ out of scope  │
└───────────────────────────┴────────────────┴───────────────┘
```

qwen3 is the control  natively supported, no ScalarLM patches  so its passing means the shared pipeline is sound rather than the patched models passing by luck.

enable_lora now defaults to false (matching adapter_type). train_generate.py defaults to 2000 steps; the previous 150 could not converge, so the test could not pass on a healthy system. Base image moved to NGC 26.05. 17 new unit tests.

Known limitations: 
DiffusionGemma is inference-only. Training is out of scope for this PR.

One adapter per server — and it fails silently. Tokenformer adapters are applied by mutating the shared model weights: activate_adapter merges the adapter's tensors into the model's full state dict and calls model.load_weights(...). There are no per-adapter slots, so only one adapter can be resident at a time. Meanwhile the server registers every directory under /app/cray/jobs as an adapter, and set_active_adapters activates each adapter in a batch in turn — last one wins.

With more than one trained model registered they compete over one set of weights, and a request for model A can be answered with model B's. No error, no warning: the log still reports every tensor loaded. The symptom is a model that trains correctly (loss converges) and loads correctly (remapped N, zero dropped) yet returns garbage.

Workaround: one model per server; clear jobs/ between test runs — now more visible since jobs/ is bind-mounted and persists across restarts. Real fix: per-request adapter application in the fork, the way LoRA does it with a slot table and batched kernels — a project, not a patch.

One adapter type per server. LoRA serving is off by default; adapter_type: "lora" jobs silently no-op unless SCALARLM_ENABLE_LORA=true, which in turn breaks Tokenformer checkpoints.

gemma-1, gemma-2 and qwen2-vl can't do train→serve on this fork — they declare neither SupportsTokenformer nor the state_dict override.

Three fixes live as ScalarLM build patches — the state_dict overrides and the DiffusionGemma dtype fix. They belong upstream in vllm_fork.