### PR TITLE
fix(up): honor local Docker Compose override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 
 # Local vLLM clone for development
 vllm/***
+docker-compose.override.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Thumbs.db
 # Local vLLM clone for development
 vllm/***
 docker-compose.override.yaml
+docker-compose.override.yml

--- a/cmd/up_command.sh
+++ b/cmd/up_command.sh
@@ -45,9 +45,22 @@ mkdir -p chat-ui
 
 echo "SM arch is ${sm_arch}"
 
+# Explicit -f (not Compose's native override auto-discovery) keeps
+# compose-file selection deterministic: an inherited COMPOSE_FILE env var,
+# or a stray .env in this directory, would otherwise silently redirect
+# `docker compose` at an unrelated project when no -f is given at all.
+# Check both override extensions since Compose itself accepts either -- but
+# since both names are gitignored (so a stale one is invisible to `git
+# status`), fail loudly if both exist instead of silently picking one and
+# layering them, which would concatenate some config unexpectedly.
 compose_files=(-f docker-compose.yaml)
-if [ -f docker-compose.override.yaml ]; then
+if [ -f docker-compose.override.yaml ] && [ -f docker-compose.override.yml ]; then
+    echo "Both docker-compose.override.yaml and docker-compose.override.yml exist; remove one." >&2
+    exit 1
+elif [ -f docker-compose.override.yaml ]; then
     compose_files+=(-f docker-compose.override.yaml)
+elif [ -f docker-compose.override.yml ]; then
+    compose_files+=(-f docker-compose.override.yml)
 fi
 
 BASE_NAME=${target} VLLM_TARGET_DEVICE=${vllm_target_device} \

--- a/cmd/up_command.sh
+++ b/cmd/up_command.sh
@@ -45,6 +45,11 @@ mkdir -p chat-ui
 
 echo "SM arch is ${sm_arch}"
 
+compose_files=(-f docker-compose.yaml)
+if [ -f docker-compose.override.yaml ]; then
+    compose_files+=(-f docker-compose.override.yaml)
+fi
+
 BASE_NAME=${target} VLLM_TARGET_DEVICE=${vllm_target_device} \
     DOCKER_PLATFORM=${docker_platform} TORCH_CUDA_ARCH_LIST=${sm_arch} \
-    docker compose -f docker-compose.yaml up ${docker_compose_service} --build --force-recreate
+    docker compose "${compose_files[@]}" up ${docker_compose_service} --build --force-recreate


### PR DESCRIPTION
## Why

`./scalarlm up` explicitly passes `-f docker-compose.yaml`, which disables
Compose's normal override-file discovery. Hosts with local requirements—such
as CDI GPU device injection on DGX Spark—therefore had no supported local
configuration layer without editing the tracked base file or bypassing
ScalarLM's target and build configuration.

## What changed

- always select `docker-compose.yaml` explicitly;
- append `docker-compose.override.yaml` or `docker-compose.override.yml` when
  exactly one exists;
- fail clearly when both filenames exist instead of merging a stale file
  unexpectedly;
- keep explicit file selection so ambient `COMPOSE_FILE`, including values
  loaded from `.env`, cannot redirect the command; and
- gitignore both supported override filenames.

## Validation

At exact head `f1aaedf7344e9098970bea641da52e2456c1d309`, an isolated argv and
Compose harness verified:

| Case | Result |
|---|---|
| no override | base file only; exit 0 |
| `.yaml` only | base followed by `.yaml`; exit 0 |
| `.yml` only | base followed by `.yml`; exit 0 |
| both files | clear remove-one error; exit 1 |
| ambient `COMPOSE_FILE` | explicit base-file argv unchanged; exit 0 |

- `bash -n cmd/up_command.sh` and `git diff --check` pass.
- Iterative Codex, Agy/Gemini, and Claude reviews drove the dual-extension,
  conflict, and `COMPOSE_FILE` behavior recorded above; an independent Codex
  review of the current head found no actionable defect and returned `MERGE`.

The review comments retain the evolution of earlier revisions. This
description is the canonical behavior and evidence for the current head.

## Dependencies

None; this CLI/Compose fix can merge in any order.
