### PR TITLE
fix: make scalarlm build/serve against vllm-fork v0.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,6 +163,19 @@ ENV CMAKE_BUILD_TYPE=Release
 # vLLM dependencies
 COPY ./infra/requirements-vllm.txt ${INSTALL_ROOT}/requirements-vllm.txt
 RUN uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements-vllm.txt && \
+    if [ "$VLLM_TARGET_DEVICE" = "cuda" ]; then \
+        # Shadow the NGC base image's bundled torch with the exact release
+        # wheel vllm-fork's pyproject.toml declares (torch == 2.11.0), only
+        # for the CUDA build: whatever torch a given NGC snapshot ships is
+        # either too old or an alpha snapshot that predates release APIs
+        # vllm's stable-ABI csrc code needs (torch::stable::from_blob).
+        # CUDA-only: doing this unconditionally would clobber the ROCm/CPU
+        # targets' correct torch builds, which don't hit this issue.
+        uv pip install --no-compile --no-cache-dir \
+            torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 \
+            --index-url https://download.pytorch.org/whl/cu130 \
+            --extra-index-url https://pypi.org/simple; \
+    fi && \
     python ${INSTALL_ROOT}/vllm/use_existing_torch.py --prefix
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,17 +124,15 @@ RUN pip install setuptools-scm
 
 # Configure vLLM source - can use either local directory or remote repo.
 #
-# VLLM_BRANCH defaults to `main` on vllm-fork. The fixes that previously
-# required pinning to scalarlm-on-v0.19.0 at a specific SHA (TorchAllocator
-# crash, Triton scratch-allocator memleak, torch 2.10 ABI) are now merged
-# into vllm-fork's main branch, so the branch tip is sufficient.
-#
-# VLLM_COMMIT remains available as an opt-in pin if a deployment needs
-# reproducibility across time or wants to roll back to a specific SHA;
-# leave it empty to use BRANCH tip (the default).
+# VLLM_BRANCH defaults to `main` on vllm-fork, but main is a moving target
+# that has already gone through multiple incompatible eras (v0.25.1-ish,
+# now the v0.26.0 rewrite) -- floating on branch tip has repeatedly broken
+# the build out from under us. Pin VLLM_COMMIT to the specific main-branch
+# commit this Dockerfile (torch version, entrypoints API usage below) is
+# actually verified against; bump it deliberately, not by drift.
 ARG VLLM_SOURCE=remote
 ARG VLLM_BRANCH=main
-ARG VLLM_COMMIT=
+ARG VLLM_COMMIT=e01dda4f7814d50275dca507759815e205c079f5
 ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
 
 # Handle vLLM source - support both local and remote modes.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,12 @@ services:
                 - VLLM_SOURCE=${VLLM_SOURCE:-remote}
                 - VLLM_BRANCH=${VLLM_BRANCH:-main}
                 - VLLM_REPO=${VLLM_REPO:-https://github.com/supermassive-intelligence/vllm-fork.git}
+                # Note the missing ':' -- unset uses the Dockerfile's verified
+                # pin, but `VLLM_COMMIT= docker compose build` (explicitly set
+                # to empty) opts out to track VLLM_BRANCH tip, e.g. when
+                # pointing VLLM_REPO/VLLM_BRANCH at a custom fork or branch
+                # that doesn't contain the pinned commit.
+                - VLLM_COMMIT=${VLLM_COMMIT-e01dda4f7814d50275dca507759815e205c079f5}
         ports:
             - "8000:8000"
             - "8001:8001"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,12 +34,14 @@ services:
                 - VLLM_SOURCE=${VLLM_SOURCE:-remote}
                 - VLLM_BRANCH=${VLLM_BRANCH:-main}
                 - VLLM_REPO=${VLLM_REPO:-https://github.com/supermassive-intelligence/vllm-fork.git}
-                # Note the missing ':' -- unset uses the Dockerfile's verified
-                # pin, but `VLLM_COMMIT= docker compose build` (explicitly set
-                # to empty) opts out to track VLLM_BRANCH tip, e.g. when
-                # pointing VLLM_REPO/VLLM_BRANCH at a custom fork or branch
-                # that doesn't contain the pinned commit.
-                - VLLM_COMMIT=${VLLM_COMMIT-e01dda4f7814d50275dca507759815e205c079f5}
+                # Bare name (no default here): unset means Compose omits this
+                # build-arg entirely, so the Dockerfile's own ARG default (the
+                # verified pin) is the single source of truth instead of
+                # duplicating the SHA in two files. `VLLM_COMMIT= docker
+                # compose build` (explicitly empty) still opts out to track
+                # VLLM_BRANCH tip, e.g. when pointing VLLM_REPO/VLLM_BRANCH at
+                # a custom fork or branch that doesn't contain the pin.
+                - VLLM_COMMIT
         ports:
             - "8000:8000"
             - "8001:8001"

--- a/infra/requirements-vllm.txt
+++ b/infra/requirements-vllm.txt
@@ -1,3 +1,10 @@
 fastapi-utils
 setuptools-rust>=1.9.0
 typing-inspect
+# vllm >= 0.25 build requirements that --no-build-isolation must find
+# preinstalled: setup.py imports setuptools_rust unconditionally (the
+# Rust extension itself is optional and skipped without cargo), and
+# pyproject uses PEP 639 license metadata (setuptools >= 77).
+setuptools-rust>=1.9.0
+setuptools>=77.0.3,<81.0.0
+setuptools-scm>=8.0


### PR DESCRIPTION
## Summary

vllm-fork's `main` branch is a total rewrite (confirmed: v0.26.0 is not an incremental patch series over v0.25.x), and it has broken this repo's build/serve path twice now: once around the v0.25.1 era, and again with the v0.26.0 rewrite (which is what's current on `main` as of this PR — tag `pre-v0.26.0-main`, commit `e01dda4f7814d50275dca507759815e205c079f5`).

This PR makes the build reproducible and verified working against that exact commit:

1. **Pin `VLLM_COMMIT`** to `e01dda4f7814d50275dca507759815e205c079f5` instead of floating on `VLLM_BRANCH=main` tip. Floating on a moving rewrite has repeatedly broken the build out from under us with no warning.
2. **`setuptools-rust` + `setuptools>=77`** preinstalled — vllm >= 0.25 needs it, wasn't previously.
3. **Release `torch==2.11.0+cu130`** installed into the vllm build venv (shadowing the NGC base image's bundled torch, just for vllm's build) instead of relying on whatever torch a given NGC snapshot ships. This exactly matches vllm-fork's own declared `torch == 2.11.0` pin in its `pyproject.toml`. Without this, the build fails compiling `csrc/libtorch_stable/cuda_view.cu` with a `torch::stable::from_blob` overload mismatch — confirmed this is what broke two other open PRs' builds overnight (#209, #215), both against NGC 26.01's bundled torch 2.10.
4. **`create_vllm.py`**: v0.26.0 moved `log_non_default_args` out of `vllm.entrypoints.utils` (`ModuleNotFoundError` on every server start) and made `setup_server()`'s `reuse_port` a required keyword-only arg (`TypeError`). Fixed version-tolerantly — drop the unused import instead of re-pointing it (nothing in this repo called it), and probe `setup_server`'s signature via `inspect` instead of hard-coding one API shape, so this keeps working whether `main` moves again. Also dropped a dead `reasoning_parser_plugin` block (`ReasoningParserManager` was never imported here — this would have `NameError`'d if ever taken, and on v0.26.0 fails earlier still since that setting moved into `structured_outputs_config`; vLLM performs this import itself now in `vllm/v1/structured_output/__init__.py`, so dropping it loses nothing).

## Why not the NGC-base-image-bump approach?

Two other in-flight things independently hit this same wall and worked around it by bumping the NGC base image instead (`sync/vllm-v0.25.1-build`'s sibling reasoning aside, #215 → NGC 26.04, #219 → NGC 26.05). Both of those land on **torch 2.12.0a0**, an alpha snapshot — not what vllm-fork actually declares (`torch == 2.11.0` exactly), and alpha snapshots are exactly what caused this class of failure in the first place per the original `ce146f8` diagnosis. This PR instead installs the precise released wheel vllm-fork asks for, verified end-to-end rather than by coincidence.

#219's `create_vllm.py` fix, however, is the best of the three attempts at that piece (version-tolerant via `inspect.signature`, already reasoned explicitly about v0.26.0) — adopted here as-is rather than reinventing it a fourth time.

## Verification

On this GB10 (harkkonen) box, pinned to the exact v0.26.0 commit above:
- `docker build` succeeds end-to-end (previously failed compiling `cuda_view.cu`).
- Container boots, SLURM starts, one_server comes up, `Application startup complete`.
- Real `/v1/chat/completions` request against `Qwen/Qwen3-0.6B` returns a coherent response.

## Follow-up for other open PRs

- **#215**, **#219**: once this merges, drop the now-redundant Dockerfile NGC-bump / `create_vllm.py` hunks and rebase onto `main`.
- **#209**, **#210**, **#211**, **#212**, **#216**: don't touch these files, should just rebase to pick this up — they were all going to hit the identical `ModuleNotFoundError`/compile failure regardless of their own changes, since none of them carried this fix themselves.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>