### PR TITLE
build: upgrade ScalarLM to vLLM v0.27.1 and PyTorch 2.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,17 +132,12 @@ RUN pip install setuptools-scm
 
 # Configure vLLM source - can use either local directory or remote repo.
 #
-# VLLM_BRANCH defaults to `main` on vllm-fork. The fixes that previously
-# required pinning to scalarlm-on-v0.19.0 at a specific SHA (TorchAllocator
-# crash, Triton scratch-allocator memleak, torch 2.10 ABI) are now merged
-# into vllm-fork's main branch, so the branch tip is sufficient.
-#
-# VLLM_COMMIT remains available as an opt-in pin if a deployment needs
-# reproducibility across time or wants to roll back to a specific SHA;
-# leave it empty to use BRANCH tip (the default).
+# Pin the exact vllm-fork v0.27.1 revision validated with this PyTorch
+# generation. VLLM_BRANCH still selects the clone source, while an explicit
+# empty VLLM_COMMIT opts back into tracking that branch tip for development.
 ARG VLLM_SOURCE=remote
 ARG VLLM_BRANCH=main
-ARG VLLM_COMMIT=
+ARG VLLM_COMMIT=281955fc63c823e8a439db82bf02ad9fffb199e2
 ARG VLLM_REPO=https://github.com/supermassive-intelligence/vllm-fork.git
 
 # Handle vLLM source - support both local and remote modes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV TORCH_COMPILE_DISABLE=1
 
 ###############################################################################
 # NVIDIA DGX SPARK BASE IMAGE
-# aarch64 Grace CPU + Blackwell GPU (SM 12.1). The NGC PyTorch image is
+# aarch64 Grace CPU + Blackwell GPU (SM 12.0). The NGC PyTorch image is
 # multi-arch, so pulling this tag on linux/arm64 yields the aarch64 variant.
 FROM nvidia AS spark
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,7 @@ RUN \
     fi && \
     uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt && \
     if [ "$VLLM_TARGET_DEVICE" = "cpu" ]; then \
-        python -c "import peft, sentence_transformers, torch, torchaudio, torchcodec, torchvision; assert torch.version.cuda is None; assert '+cpu' in torch.__version__, torch.__version__; assert '+cpu' in torchvision.__version__, torchvision.__version__; assert '+cpu' in torchaudio.__version__, torchaudio.__version__; assert '+cpu' in torchcodec.__version__, torchcodec.__version__"; \
+        python -c "import peft, sentence_transformers, torch, torchaudio, torchao, torchcodec, torchvision, vllm._C; assert torch.version.cuda is None; assert '+cpu' in torch.__version__, torch.__version__; assert '+cpu' in torchvision.__version__, torchvision.__version__; assert '+cpu' in torchaudio.__version__, torchaudio.__version__; assert '+cpu' in torchcodec.__version__, torchcodec.__version__"; \
     fi
 
 RUN mkdir -p ${INSTALL_ROOT}/jobs ${INSTALL_ROOT}/nfs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_NAME=cpu
 
 ###############################################################################
 # NVIDIA BASE IMAGE
-FROM nvcr.io/nvidia/pytorch:26.05-py3 AS nvidia
+FROM nvcr.io/nvidia/pytorch:26.07-py3 AS nvidia
 
 RUN apt-get update -y && apt-get install -y python3-venv slurm-wlm libslurm-dev
 
@@ -16,7 +16,7 @@ ENV PATH=$PATH:/opt/hpcx/ompi/bin
 ARG LD_LIBRARY_PATH=""
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/opt/hpcx/ompi/lib:/usr/local/lib/python3.12/dist-packages/torch/lib
 
-ARG TORCH_VERSION="2.9.1"
+ARG TORCH_VERSION="2.13.0"
 ARG TORCH_CUDA_ARCH_LIST="7.5"
 
 RUN pip install uv && \
@@ -36,7 +36,7 @@ ENV TORCH_COMPILE_DISABLE=1
 
 ###############################################################################
 # NVIDIA DGX SPARK BASE IMAGE
-# aarch64 Grace CPU + Blackwell GPU (SM 12.0). The NGC PyTorch image is
+# aarch64 Grace CPU + Blackwell GPU (SM 12.1). The NGC PyTorch image is
 # multi-arch, so pulling this tag on linux/arm64 yields the aarch64 variant.
 FROM nvidia AS spark
 
@@ -57,8 +57,8 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN python3 -m venv $VIRTUAL_ENV && \
     . $VIRTUAL_ENV/bin/activate
 
-ARG TORCH_VERSION="2.11.0"
-ARG TORCHVISION_VERSION="0.26.0"
+ARG TORCH_VERSION="2.13.0"
+ARG TORCHVISION_VERSION="0.28.0"
 ARG TORCHAUDIO_VERSION="2.11.0"
 ARG TORCHCODEC_VERSION="0.14.0"
 
@@ -253,4 +253,3 @@ RUN /app/cray/infra/slurm_src/compile.sh
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${PYTHONPATH:-}:/usr/local/lib/slurm
 ENV SLURM_CONF=${INSTALL_ROOT}/nfs/slurm.conf
 ENV VLLM_CPU_MOE_PREPACK=0
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -224,7 +224,8 @@ RUN \
         # (those were only for flash-attn, which is no longer installed).
         uv pip install --no-deps --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements-megatron.txt; \
     fi && \
-    if [ "$VLLM_TARGET_DEVICE" != "cuda" ]; then \
+    # CPU-only dependencies must not replace the ROCm base's binary packages.
+    if [ "$VLLM_TARGET_DEVICE" = "cpu" ]; then \
         uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements-megatron-cpu.txt; \
     fi && \
     uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,18 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN python3 -m venv $VIRTUAL_ENV && \
     . $VIRTUAL_ENV/bin/activate
 
-ARG TORCH_VERSION="2.10.0"
+ARG TORCH_VERSION="2.11.0"
+ARG TORCHVISION_VERSION="0.26.0"
+ARG TORCHAUDIO_VERSION="2.11.0"
+ARG TORCHCODEC_VERSION="0.14.0"
 
 RUN pip install uv && \
-    uv pip install torch==${TORCH_VERSION}+cpu --index-url https://download.pytorch.org/whl/cpu && \
+    uv pip install \
+        torch==${TORCH_VERSION}+cpu \
+        torchvision==${TORCHVISION_VERSION}+cpu \
+        torchaudio==${TORCHAUDIO_VERSION}+cpu \
+        torchcodec==${TORCHCODEC_VERSION}+cpu \
+        --index-url https://download.pytorch.org/whl/cpu && \
     uv pip install ninja
 
 # Put torch on the LD_LIBRARY_PATH
@@ -219,7 +227,10 @@ RUN \
     if [ "$VLLM_TARGET_DEVICE" != "cuda" ]; then \
         uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements-megatron-cpu.txt; \
     fi && \
-    uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt
+    uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt && \
+    if [ "$VLLM_TARGET_DEVICE" = "cpu" ]; then \
+        python -c "import peft, sentence_transformers, torch, torchaudio, torchcodec, torchvision; assert torch.version.cuda is None; assert '+cpu' in torch.__version__, torch.__version__; assert '+cpu' in torchvision.__version__, torchvision.__version__; assert '+cpu' in torchaudio.__version__, torchaudio.__version__; assert '+cpu' in torchcodec.__version__, torchcodec.__version__"; \
+    fi
 
 RUN mkdir -p ${INSTALL_ROOT}/jobs ${INSTALL_ROOT}/nfs
 
@@ -242,5 +253,4 @@ RUN /app/cray/infra/slurm_src/compile.sh
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${PYTHONPATH:-}:/usr/local/lib/slurm
 ENV SLURM_CONF=${INSTALL_ROOT}/nfs/slurm.conf
 ENV VLLM_CPU_MOE_PREPACK=0
-
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,9 @@ services:
                 - VLLM_SOURCE=${VLLM_SOURCE:-remote}
                 - VLLM_BRANCH=${VLLM_BRANCH:-main}
                 - VLLM_REPO=${VLLM_REPO:-https://github.com/supermassive-intelligence/vllm-fork.git}
+                # Unset: use the Dockerfile's verified v0.27.1 pin. Setting
+                # VLLM_COMMIT (including explicitly empty) overrides it.
+                - VLLM_COMMIT
         ports:
             - "8000:8000"
             - "8001:8001"
@@ -96,4 +99,3 @@ services:
 networks:
   cray-network:
     name: cray_network
-

--- a/infra/requirements-megatron-cpu.txt
+++ b/infra/requirements-megatron-cpu.txt
@@ -4,4 +4,6 @@ torchao>=0.16.1
 transformers>=5.5.0
 huggingface_hub>=0.37
 peft
-torchvision==0.25.0
+# Torch-family binary wheels are installed together from PyTorch's CPU wheel
+# index in the CPU base stage. Keeping any of them here would let PyPI replace
+# the CPU build with a CUDA-linked aarch64 wheel.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # These are infra dependencies
 # Don't put vLLM or Megatron dependencies in here because they will bloat the api
-numpy<2.0.0
+numpy>=2.0.0,<2.5.0
 jsonlines
 aiofiles
 persist-queue
@@ -14,4 +14,3 @@ atomicwrites
 cryptography==46.0.0
 sortedcontainers
 datasets
-

--- a/scripts/vllm_patches/apply_patches.py
+++ b/scripts/vllm_patches/apply_patches.py
@@ -368,7 +368,11 @@ STATE_DICT_EXPORT_SRC = '''    def state_dict(self, destination=None, prefix="",
         # Scoped to `prefix` so recursion from the multimodal wrapper
         # (Gemma4ForConditionalGeneration) can't rewrite sibling modules'
         # keys in the shared destination dict.
-        state_dict = super().state_dict(destination, prefix, keep_vars)
+        state_dict = super().state_dict(
+            destination=destination,
+            prefix=prefix,
+            keep_vars=keep_vars,
+        )
         if not scalarlm_state_dict_export_enabled():
             return state_dict
 

--- a/test/integration/vllm/test_cpu_tokenformer_integration.py
+++ b/test/integration/vllm/test_cpu_tokenformer_integration.py
@@ -43,8 +43,10 @@ def temp_adapter_path():
 
         # Create a mock adapter file
         mock_weights = {
-            "tokenformer.weight": torch.rand(10, 10),
-            "lm_head.weight": torch.rand(10),
+            "model_state_dict": {
+                "tokenformer.weight": torch.rand(10, 10),
+                "lm_head.weight": torch.rand(10),
+            },
         }
         torch.save(mock_weights, adapter_dir / "model.pt")
 
@@ -77,13 +79,17 @@ class TestCPUTokenformerIntegration:
         from vllm.tokenformer.tokenformer_model_manager import TokenformerModel
 
         # Test loading a tokenformer model from checkpoint
-        try:
-            tokenformer = TokenformerModel.from_local_checkpoint(temp_adapter_path)
-            assert tokenformer is not None
-            assert hasattr(tokenformer, "adapter_data")
-            print("✓ TokenformerModel loaded successfully")
-        except Exception as e:
-            pytest.skip(f"TokenformerModel loading not fully implemented: {e}")
+        tokenformer = TokenformerModel.from_local_checkpoint(
+            temp_adapter_path, torch.device("cpu")
+        )
+
+        assert set(tokenformer.tokenformers) == {
+            "tokenformer.weight",
+            "lm_head.weight",
+        }
+        assert all(
+            tensor.device.type == "cpu" for tensor in tokenformer.tokenformers.values()
+        )
 
     def test_tokenformer_integration_with_runner_mixin(self):
         """Test LoRAModelRunnerMixin integration with tokenformer"""

--- a/test/integration/vllm/test_cpu_tokenformer_integration.py
+++ b/test/integration/vllm/test_cpu_tokenformer_integration.py
@@ -13,16 +13,23 @@ import sys
 from pathlib import Path
 
 # Add vllm to path
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))), 'vllm'))
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+        "vllm",
+    ),
+)
 
 
 class SimpleModel(nn.Module):
     """Simple model for testing that supports LoRA"""
+
     def __init__(self):
         super().__init__()
         self.linear = nn.Linear(10, 10)
         self.supports_lora = True
-    
+
     def forward(self, x):
         return self.linear(x)
 
@@ -33,117 +40,124 @@ def temp_adapter_path():
     with tempfile.TemporaryDirectory() as tmpdir:
         adapter_dir = Path(tmpdir) / "adapter1"
         adapter_dir.mkdir()
-        
+
         # Create a mock adapter file
         mock_weights = {
             "tokenformer.weight": torch.rand(10, 10),
-            "lm_head.weight": torch.rand(10)
+            "lm_head.weight": torch.rand(10),
         }
         torch.save(mock_weights, adapter_dir / "model.pt")
-        
+
         yield str(adapter_dir)
 
 
 class TestCPUTokenformerIntegration:
     """Integration tests for CPU tokenformer functionality"""
-    
+
     def test_tokenformer_manager_initialization(self):
         """Test that tokenformer manager can be initialized"""
         import torch.nn as nn
         from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
-        
+
         # Create a simple mock model
         class SimpleModel(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.lm_head = nn.Linear(10, 10)
-        
+
         model = SimpleModel()
         device = torch.device("cpu")
         manager = TokenformerModelManager(model=model, device=device)
-        
+
         assert manager.device == device
         assert manager.model is not None
-    
+
     def test_tokenformer_model_creation(self, temp_adapter_path):
         """Test creating and loading a tokenformer model"""
-        import torch.nn as nn
         from vllm.tokenformer.tokenformer_model_manager import TokenformerModel
-        
+
         # Test loading a tokenformer model from checkpoint
         try:
             tokenformer = TokenformerModel.from_local_checkpoint(temp_adapter_path)
             assert tokenformer is not None
-            assert hasattr(tokenformer, 'adapter_data')
+            assert hasattr(tokenformer, "adapter_data")
             print("✓ TokenformerModel loaded successfully")
         except Exception as e:
             pytest.skip(f"TokenformerModel loading not fully implemented: {e}")
-    
+
     def test_tokenformer_integration_with_runner_mixin(self):
         """Test LoRAModelRunnerMixin integration with tokenformer"""
         import torch.nn as nn
         from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
         from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-        
-        # Create a mock model that supports lora/tokenformer  
+
+        # Create a mock model that supports lora/tokenformer
         class MockLLMModel(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.lm_head = nn.Linear(768, 50257)
-        
+
         model = MockLLMModel()
         device = torch.device("cpu")
-        
+
         # Test TokenformerModelManager as used in LoRAModelRunnerMixin
         manager = TokenformerModelManager(model=model, device=device)
-        
+
         assert manager.model is not None
         assert manager.device == device
         print("✓ TokenformerModelManager integration successful")
 
 
-@pytest.mark.parametrize("has_lora_config", [True, False])  
+@pytest.mark.parametrize("has_lora_config", [True, False])
 def test_cpu_runner_lora_config_handling(has_lora_config):
     """Test that LoRAModelRunnerMixin correctly handles presence/absence of LoRA config"""
     import torch.nn as nn
     from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-    from vllm.config import ModelConfig, SchedulerConfig, LoRAConfig
+    from vllm.config import LoRAConfig, VllmConfig
+    from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
     from unittest.mock import MagicMock
-    
-    # Create mock configs  
-    model_config = MagicMock(spec=ModelConfig)
-    model_config.hf_config = MagicMock()
-    model_config.hf_config.get_text_config.return_value = MagicMock()
-    
-    scheduler_config = MagicMock(spec=SchedulerConfig)
-    lora_config = MagicMock(spec=LoRAConfig) if has_lora_config else None
-    
+
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.lora_config = (
+        LoRAConfig(
+            enable_tokenformer=True,
+            max_lora_rank=8,
+            max_loras=2,
+            max_cpu_loras=2,
+        )
+        if has_lora_config
+        else None
+    )
+
     # Create a mock model that supports lora
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
             self.lm_head = nn.Linear(10, 10)
-        
+
         @property
         def supports_lora(self):
             return True
-    
+
     model = MockModel()
     device = torch.device("cpu")
-    
+
     # Create runner mixin instance
     mixin = LoRAModelRunnerMixin()
-    
+
     if has_lora_config:
         # Patch supports_lora to return True for our mock model
         from unittest.mock import patch
-        with patch('vllm.v1.worker.lora_model_runner_mixin.supports_lora', return_value=True), \
-             patch('vllm.model_executor.models.supports_lora', return_value=True):
+
+        with patch(
+            "vllm.v1.worker.lora_model_runner_mixin.supports_lora",
+            return_value=True,
+        ):
             # Test loading model with LoRA config
-            result_model = mixin.load_lora_model(model, model_config, scheduler_config, lora_config, device)
+            result_model = mixin.load_lora_model(model, vllm_config, device)
             assert result_model is not None
-            assert hasattr(mixin, 'lora_manager')
-            assert mixin.lora_manager is not None
+            assert isinstance(mixin.lora_manager, TokenformerModelManager)
+            assert result_model is mixin.lora_manager.model
     else:
         pytest.skip("No LoRA config test - mixin only used when LoRA enabled")
 

--- a/test/integration/vllm/test_tokenformer_cpu_integration.py
+++ b/test/integration/vllm/test_tokenformer_cpu_integration.py
@@ -4,13 +4,13 @@ Integration test for tokenformer support in CPUModelRunner
 This test runs inside the Docker container where vLLM is properly built
 """
 
-import asyncio
 import sys
-import os
+
+import pytest
 
 # Add paths for Docker container
-sys.path.insert(0, '/app/cray/vllm')
-sys.path.insert(0, '/app/cray/infra')
+sys.path.insert(0, "/app/cray/vllm")
+sys.path.insert(0, "/app/cray/infra")
 
 
 def test_tokenformer_manager_basic():
@@ -18,23 +18,23 @@ def test_tokenformer_manager_basic():
     import torch
     import torch.nn as nn
     from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
-    
+
     print("Testing TokenformerModelManager initialization...")
-    
+
     # Create a simple mock model
     class SimpleModel(nn.Module):
         def __init__(self):
             super().__init__()
             self.lm_head = nn.Linear(10, 10)
-    
+
     model = SimpleModel()
     device = torch.device("cpu")
     manager = TokenformerModelManager(model=model, device=device)
-    
+
     assert manager.device == device
     assert manager.model is not None
-    assert hasattr(manager, 'model')
-    
+    assert hasattr(manager, "model")
+
     print("✓ TokenformerModelManager initialized successfully")
 
 
@@ -43,25 +43,25 @@ def test_cpu_model_runner_initialization():
     import torch
     import torch.nn as nn
     from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
-    
+
     print("Testing TokenformerModelManager with model runner context...")
-    
+
     # Create a mock model that supports lora/tokenformer
     class MockLLMModel(nn.Module):
         def __init__(self):
             super().__init__()
             self.lm_head = nn.Linear(768, 50257)  # GPT-2 like dimensions
             self.supports_lora = True
-    
+
     model = MockLLMModel()
     device = torch.device("cpu")
-    
+
     # Initialize TokenformerModelManager as done in LoRAModelRunnerMixin
     manager = TokenformerModelManager(model=model, device=device)
-    
+
     assert manager.model is not None
     assert manager.device == device
-    
+
     print("✓ TokenformerModelManager integration with model runner successful")
 
 
@@ -69,53 +69,59 @@ def test_tokenformer_with_lora_config():
     """Test LoRAModelRunnerMixin with LoRA config uses TokenformerModelManager"""
     import torch
     import torch.nn as nn
-    from vllm.config import ModelConfig, SchedulerConfig, LoRAConfig
+    from vllm.config import LoRAConfig, VllmConfig
+    from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
     from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
     from unittest.mock import MagicMock, patch
-    
+
     print("Testing LoRAModelRunnerMixin with LoRA config...")
-    
-    # Create minimal configs
-    model_config = MagicMock(spec=ModelConfig)
-    model_config.hf_config = MagicMock()
-    model_config.hf_config.get_text_config.return_value = MagicMock()
-    
-    scheduler_config = MagicMock(spec=SchedulerConfig)
-    lora_config = MagicMock(spec=LoRAConfig)
-    
+
+    vllm_config = MagicMock(spec=VllmConfig)
+    vllm_config.lora_config = LoRAConfig(
+        enable_tokenformer=True,
+        max_lora_rank=8,
+        max_loras=2,
+        max_cpu_loras=2,
+    )
+
     # Create a mock model that supports lora
     class MockModel(nn.Module):
         def __init__(self):
             super().__init__()
             self.lm_head = nn.Linear(10, 10)
-    
+
     model = MockModel()
     device = torch.device("cpu")
-    
+
     # Test LoRAModelRunnerMixin
     mixin = LoRAModelRunnerMixin()
-    
-    with patch('vllm.v1.worker.lora_model_runner_mixin.supports_lora', return_value=True), \
-         patch('vllm.model_executor.models.supports_lora', return_value=True):
-        result_model = mixin.load_lora_model(model, model_config, scheduler_config, lora_config, device)
-        
+
+    with patch(
+        "vllm.v1.worker.lora_model_runner_mixin.supports_lora",
+        return_value=True,
+    ):
+        result_model = mixin.load_lora_model(model, vllm_config, device)
+
         assert result_model is not None
-        assert hasattr(mixin, 'lora_manager')
-        assert mixin.lora_manager is not None
+        assert isinstance(mixin.lora_manager, TokenformerModelManager)
+        assert result_model is mixin.lora_manager.model
         print("✓ LoRAModelRunnerMixin uses TokenformerModelManager successfully")
 
 
 def test_tokenformer_model_manager():
     """Test TokenformerModelManager is available"""
     try:
-        from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager, TokenformerModel
-        
+        from vllm.tokenformer.tokenformer_model_manager import (
+            TokenformerModelManager,
+            TokenformerModel,
+        )
+
         print("Testing TokenformerModelManager availability...")
-        
+
         # Check classes are importable
         assert TokenformerModelManager is not None
         assert TokenformerModel is not None
-        
+
         print("✓ TokenformerModelManager and TokenformerModel are available")
     except ImportError as e:
         print(f"⚠ TokenformerModelManager not available: {e}")

--- a/test/integration/vllm/test_tokenformer_docker.py
+++ b/test/integration/vllm/test_tokenformer_docker.py
@@ -5,13 +5,13 @@ This test should ONLY be run inside the Docker container where vLLM is properly 
 """
 
 import sys
-import os
+
 import pytest
 import torch
 
 # Add paths for Docker container
-sys.path.insert(0, '/app/cray/vllm')
-sys.path.insert(0, '/app/cray/infra')
+sys.path.insert(0, "/app/cray/vllm")
+sys.path.insert(0, "/app/cray/infra")
 
 
 @pytest.mark.asyncio
@@ -19,20 +19,20 @@ async def test_tokenformer_manager_in_docker():
     """Test TokenformerModelManager works in Docker environment"""
     import torch.nn as nn
     from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
-    
+
     # Create a simple mock model
     class SimpleModel(nn.Module):
         def __init__(self):
             super().__init__()
             self.lm_head = nn.Linear(10, 10)
-    
+
     model = SimpleModel()
     device = torch.device("cpu")
     manager = TokenformerModelManager(model=model, device=device)
-    
+
     assert manager is not None
     assert manager.device == device
-    assert hasattr(manager, '_registered_adapters')
+    assert hasattr(manager, "_registered_adapters")
     assert manager.model is not None
 
 
@@ -41,12 +41,16 @@ async def test_cpu_model_runner_with_tokenformer():
     """Test CPUModelRunner can use tokenformer in Docker"""
     from vllm.v1.worker.cpu_model_runner import CPUModelRunner
     from vllm.config import (
-        VllmConfig, ModelConfig, CacheConfig, 
-        SchedulerConfig, ParallelConfig, LoRAConfig,
-        DeviceConfig, LoadConfig, SpeculativeConfig,
-        ObservabilityConfig
+        VllmConfig,
+        ModelConfig,
+        CacheConfig,
+        SchedulerConfig,
+        ParallelConfig,
+        LoRAConfig,
+        DeviceConfig,
+        LoadConfig,
     )
-    
+
     # Create minimal configs for testing
     model_config = ModelConfig(
         model="microsoft/DialoGPT-small",
@@ -55,29 +59,25 @@ async def test_cpu_model_runner_with_tokenformer():
         trust_remote_code=False,
         dtype="float32",
         seed=0,
-        max_model_len=256
+        max_model_len=256,
     )
-    
+
     cache_config = CacheConfig(
-        block_size=16,
-        gpu_memory_utilization=0.3,
-        cache_dtype="auto"
+        block_size=16, gpu_memory_utilization=0.3, cache_dtype="auto"
     )
-    
-    scheduler_config = SchedulerConfig(
+
+    scheduler_config = SchedulerConfig.default_factory(
         max_num_batched_tokens=256,
         max_num_seqs=128,
-        max_model_len=256
+        max_model_len=256,
+        is_encoder_decoder=model_config.is_encoder_decoder,
     )
-    
-    parallel_config = ParallelConfig(
-        pipeline_parallel_size=1,
-        tensor_parallel_size=1
-    )
-    
+
+    parallel_config = ParallelConfig(pipeline_parallel_size=1, tensor_parallel_size=1)
+
     device_config = DeviceConfig(device="cpu")
     load_config = LoadConfig()
-    
+
     # Create VllmConfig
     vllm_config = VllmConfig(
         model_config=model_config,
@@ -88,21 +88,18 @@ async def test_cpu_model_runner_with_tokenformer():
         load_config=load_config,
         speculative_config=None,
         lora_config=None,
-        observability_config=None
     )
-    
+
     # Test that CPUModelRunner can be created successfully
     runner = CPUModelRunner(vllm_config, torch.device("cpu"))
     assert runner is not None
     assert runner.device == torch.device("cpu")
-    
+
     # Test with LoRA config
     lora_config = LoRAConfig(
-        max_lora_rank=8,
-        max_loras=2,
-        max_cpu_loras=2
+        enable_tokenformer=True, max_lora_rank=8, max_loras=2, max_cpu_loras=2
     )
-    
+
     vllm_config_with_lora = VllmConfig(
         model_config=model_config,
         cache_config=cache_config,
@@ -112,9 +109,8 @@ async def test_cpu_model_runner_with_tokenformer():
         load_config=load_config,
         speculative_config=None,
         lora_config=lora_config,
-        observability_config=None
     )
-    
+
     runner_with_lora = CPUModelRunner(vllm_config_with_lora, torch.device("cpu"))
     assert runner_with_lora is not None
     assert vllm_config_with_lora.lora_config is not None
@@ -125,24 +121,30 @@ async def test_cpu_model_runner_with_tokenformer():
 async def test_tokenformer_imports():
     """Test all tokenformer-related imports work in Docker"""
     # These imports should all work
-    from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager, TokenformerModel
-    from vllm.tokenformer.tokenformer_surgeon import TokenformerSurgeon, TokenformerAttentionAdapter
+    from vllm.tokenformer.tokenformer_model_manager import (
+        TokenformerModelManager,
+        TokenformerModel,
+    )
+    from vllm.tokenformer.tokenformer_surgeon import (
+        TokenformerAdapter,
+        TokenformerSurgeon,
+    )
     from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-    
+
     assert TokenformerModelManager is not None
     assert TokenformerModel is not None
     assert TokenformerSurgeon is not None
-    assert TokenformerAttentionAdapter is not None
+    assert TokenformerAdapter is not None
     assert LoRAModelRunnerMixin is not None
 
 
 if __name__ == "__main__":
     import asyncio
-    
+
     async def run_tests():
         print("🐳 Testing Tokenformer in Docker Container")
         print("=" * 50)
-        
+
         print("1️⃣ Testing tokenformer imports...")
         try:
             await test_tokenformer_imports()
@@ -150,7 +152,7 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"   ❌ Imports: FAILED - {e}")
             return False
-        
+
         print("\n2️⃣ Testing TokenformerModelManager...")
         try:
             await test_tokenformer_manager_in_docker()
@@ -158,7 +160,7 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"   ❌ TokenformerModelManager: FAILED - {e}")
             return False
-        
+
         print("\n3️⃣ Testing Docker integration...")
         try:
             await test_cpu_model_runner_with_tokenformer()
@@ -166,10 +168,10 @@ if __name__ == "__main__":
         except Exception as e:
             print(f"   ❌ Docker integration: FAILED - {e}")
             return False
-        
+
         print("\n" + "=" * 50)
         print("🎉 ALL TOKENFORMER TESTS PASSED!")
         return True
-    
+
     result = asyncio.run(run_tests())
     sys.exit(0 if result else 1)

--- a/test/unit/test_state_dict_export_patch.py
+++ b/test/unit/test_state_dict_export_patch.py
@@ -65,7 +65,7 @@ def _build(state_dict, layers, export_enabled=True):
     )
     harness = (
         "class Base:\n"
-        "    def state_dict(self, destination=None, prefix='', keep_vars=False):\n"
+        "    def state_dict(self, *, destination=None, prefix='', keep_vars=False):\n"
         "        return dict(SOURCE)\n"
         "\n"
         "class Model(Base):\n"


### PR DESCRIPTION
## Why

vLLM v0.27.1 builds its CUDA and CPU targets against PyTorch 2.13 and uses
torchvision 0.28. Keeping ScalarLM on the older PyTorch generation risks
compiled-extension ABI and dependency incompatibilities. ScalarLM's serving
images, compatibility patches, and integration tests must move together to
make the upgraded runtime reproducible.

## What changed

- move the NVIDIA/Spark base to NGC PyTorch 26.07;
- include the CPU-wheel integrity fix from closed #230 and bump CPU PyTorch
  and torchvision from 2.11.0/0.26.0 to 2.13.0/0.28.0;
- install the complete CPU Torch binary family from the official CPU index and
  verify TorchAO plus native `vllm._C` after every package transaction;
- allow compatible NumPy 2.x releases while retaining the upper bound required
  by the resolved SciPy and Numba stack;
- pass `state_dict` arguments by keyword for PyTorch's current signature;
- update three legacy Tokenformer integration files to the current vllm-fork
  adapter, runner, and scheduler APIs;
- keep CPU-only Megatron dependencies off the ROCm target; and
- pin builds to the exact validated vllm-fork v0.27.1 revision while
  preserving explicit branch-tip and custom-commit overrides.

## Validation

- Built the complete DGX Spark image with NGC 26.07, PyTorch 2.13.0a0
  nv26.07, and CUDA 13.3.
- Built the exact stacked CPU image with `torch==2.13.0+cpu`,
  `torchvision==0.28.0+cpu`, `torchaudio==2.11.0+cpu`, and
  `torchcodec==0.14.0+cpu`.
- Re-ran the strengthened, network-disabled final gate in that exact image:
  PEFT, Sentence Transformers, TorchAO 0.18.0, and native `vllm._C` imported;
  every Torch-family package reported `+cpu`; and PyTorch reported no CUDA
  runtime.
- Native stable-libtorch, MoE, QuTLASS, FlashKDA, custom ops, resampling, and
  codec-backed WAV decoding loaded successfully.
- State-dict regression suite: **6 passed**.
- Unit suite: **523 passed**; the sole failure is the independent stale
  assertion fixed by #227.
- Updated Tokenformer files: **11 passed, 1 intentional skip**; the four tests
  that failed against the old APIs now pass.
- Served Qwen3-0.6B and Qwen3.6-35B-A3B-FP8 through direct vLLM, queued
  ScalarLM, and streaming ScalarLM paths; all requests returned HTTP 200.
- The #225 live harness passed all five serving checks twice against this
  image, with cold and warm model caches.
- Independent Codex review of the exact stack found no actionable defect and
  returned `MERGE`.

The ScalarLM team's broader Blackwell image verification is proceeding
separately from this PR's DGX Spark and CPU evidence.

## Dependencies

None. This PR subsumes closed #230, including its final native-import
hardening; #230 must not be merged afterward because its v0.26 defaults would
replace this PR's v0.27 values.
