### PR TITLE
test: add self-contained live serving smoke tests

### DIFF
--- a/cmd/bashly.yml
+++ b/cmd/bashly.yml
@@ -51,7 +51,8 @@ commands:
       collectives  Standalone SHM-channel Python tests (host, no MPI).
       fast         unit + ui + collectives. Matches the CI "fast" profile.
       cpu          fast + component + e2e. Matches the CI "cpu" profile.
-      all          Every level.
+      live         Opt-in live-server inference smoke tests in Docker.
+      all          Every non-live level. Live is opt-in because it needs a model.
 
     If a test-path is provided it overrides --level and is passed straight to
     pytest inside the container. Combine --keyword / --mark with --level to
@@ -65,7 +66,7 @@ commands:
       arg: level
       help: Which test level to run. See command help for values.
       default: "cpu"
-      allowed: ["unit", "component", "e2e", "ui", "collectives", "fast", "cpu", "all"]
+      allowed: ["unit", "component", "e2e", "ui", "collectives", "fast", "cpu", "live", "all"]
     - long: --keyword
       short: -k
       arg: keyword
@@ -96,6 +97,19 @@ commands:
       help: Skip the image build step before running container-based levels.
       allowed: ["yes", "no"]
       default: "no"
+    - long: --model
+      arg: model
+      help: Model loaded by the live-server profile.
+      default: "tiny-random/gemma-4-dense"
+    - long: --live-target
+      arg: live-target
+      help: Hardware target for the live-server profile.
+      allowed: ["cpu", "nvidia", "amd", "spark"]
+      default: "cpu"
+    - long: --live-timeout
+      arg: live-timeout
+      help: Seconds to wait for API and vLLM readiness in the live profile.
+      default: "600"
   examples:
     - ./scalarlm test                                      # default: --level cpu
     - ./scalarlm test --level unit                          # only Layer 3
@@ -103,6 +117,7 @@ commands:
     - ./scalarlm test --level component -k work_queue       # Layer 2 tests matching "work_queue"
     - ./scalarlm test --level ui                            # npm-side tests only
     - ./scalarlm test --level e2e --workers 1               # serialized E2E
+    - ./scalarlm test --level live --live-target spark --model Qwen/Qwen3-0.6B --tag cray:latest --no-build yes
     - ./scalarlm test test/unit/test_config_override.py     # explicit path (runs in container)
 
 - name: llm
@@ -153,4 +168,3 @@ commands:
     - name: visible-gpus
       help: Comma separated list of the IDs of visible gpus
       default: "0"
-

--- a/cmd/test_command.sh
+++ b/cmd/test_command.sh
@@ -271,7 +271,7 @@ live_stage() {
       echo "$(red_bold "A custom --tag requires --no-build yes; build-image produces cray:latest")"
       return 1
     fi
-    "$REPO_ROOT/scalarlm" build-image "$live_target"
+    "$REPO_ROOT/scalarlm" build-image "$live_target" || return 1
   fi
 
   "$REPO_ROOT/test/live/run_live_server_tests.sh" \

--- a/cmd/test_command.sh
+++ b/cmd/test_command.sh
@@ -11,6 +11,9 @@ coverage_path=${args[--coverage-path]}
 verbose=${args[--verbose]}
 workers=${args[--workers]}
 no_build=${args[--no-build]}
+model=${args[--model]}
+live_target=${args[--live-target]}
+live_timeout=${args[--live-timeout]}
 
 if [ -z "$tag" ]; then
   tag="cray:latest"
@@ -42,6 +45,7 @@ run_ui="no"
 # in-process tests; starting slurmctld for them is wasted boot time and
 # noisy failures in logs when /app/cray state is stale.
 needs_slurm="no"
+run_live="no"
 
 if [ -n "$test_path" ]; then
   container_pytest_paths=("$test_path")
@@ -75,6 +79,9 @@ else
       container_pytest_paths=("test/unit" "test/component" "test/e2e" "test/collectives")
       run_ui="yes"
       needs_slurm="yes"
+      ;;
+    live)
+      run_live="yes"
       ;;
     all)
       container_pytest_paths=("test/unit" "test/component" "test/e2e" "test/collectives")
@@ -249,6 +256,33 @@ pytest_stage() {
 if [ ${#container_pytest_paths[@]} -gt 0 ]; then
   run_stage "Container pytest (${container_pytest_paths[*]})" \
     pytest_stage "${container_pytest_paths[@]}"
+fi
+
+# ---- Live-server stage ------------------------------------------------------
+
+live_stage() {
+  if ! [[ "$live_timeout" =~ ^[1-9][0-9]*$ ]]; then
+    echo "$(red_bold "--live-timeout must be a positive integer")"
+    return 1
+  fi
+
+  if [ "yes" != "$no_build" ]; then
+    if [ "cray:latest" != "$tag" ]; then
+      echo "$(red_bold "A custom --tag requires --no-build yes; build-image produces cray:latest")"
+      return 1
+    fi
+    "$REPO_ROOT/scalarlm" build-image "$live_target"
+  fi
+
+  "$REPO_ROOT/test/live/run_live_server_tests.sh" \
+    --tag "$tag" \
+    --model "$model" \
+    --target "$live_target" \
+    --timeout "$live_timeout"
+}
+
+if [ "yes" = "$run_live" ]; then
+  run_stage "Live server ($live_target, $model)" live_stage
 fi
 
 # ---- Summary ---------------------------------------------------------------

--- a/cmd/test_command.sh
+++ b/cmd/test_command.sh
@@ -261,6 +261,8 @@ fi
 # ---- Live-server stage ------------------------------------------------------
 
 live_stage() {
+  local -a live_pytest_filters=()
+
   if ! [[ "$live_timeout" =~ ^[1-9][0-9]*$ ]]; then
     echo "$(red_bold "--live-timeout must be a positive integer")"
     return 1
@@ -274,11 +276,19 @@ live_stage() {
     "$REPO_ROOT/scalarlm" build-image "$live_target" || return 1
   fi
 
+  if [ -n "$keyword" ]; then
+    live_pytest_filters+=(--keyword "$keyword")
+  fi
+  if [ -n "$mark" ]; then
+    live_pytest_filters+=(--mark "$mark")
+  fi
+
   "$REPO_ROOT/test/live/run_live_server_tests.sh" \
     --tag "$tag" \
     --model "$model" \
     --target "$live_target" \
-    --timeout "$live_timeout"
+    --timeout "$live_timeout" \
+    "${live_pytest_filters[@]}"
 }
 
 if [ "yes" = "$run_live" ]; then

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -708,7 +708,7 @@ Level semantics — every row runs in a container:
 | `collectives` | scalarlm CPU image | `test/collectives/test_shm_channel.py` via pytest |
 | `fast` | both | `unit` + `collectives` + `ui` |
 | `cpu` | both | `fast` + `component` + `e2e` *(default)* |
-| `live` | selected ScalarLM image | Provisions a real server, then checks health, model listing, direct, queued, and streaming inference |
+| `live` | selected ScalarLM image | Provisions a real server, then checks health, model listing, synchronous ScalarLM API, queued SDK, and streaming inference |
 | `all` | both | every non-live level; `live` remains opt-in because it downloads and loads a model |
 
 Pytest stages run inside `$tag` (default `cray:latest`, overridable with
@@ -724,11 +724,14 @@ inside the image, the node toolchain lives inside `node:24.2.0`, and the
 `./scalarlm` wrapper regenerates the bashly CLI inside its own container via
 `cmd/bashly.sh`.
 
-The live profile creates a uniquely named container and Docker network, waits
-until both the API and vLLM report healthy, runs its pytest smoke checks from a
-second container on that network, and removes both resources on exit. Set
-`SCALARLM_MODEL_CACHE` to override the default persistent cache at `./models`.
-On failure, the harness prints the final 400 server-log lines before cleanup.
+The live profile creates uniquely named server and test containers plus a
+Docker network, waits until both the API and vLLM report healthy, and runs its
+pytest smoke checks on that network. `--keyword` / `--mark` are forwarded to
+the live pytest process. The harness manages the test process explicitly and
+removes both containers and the network on success, failure, SIGINT, or
+SIGTERM. Set `SCALARLM_MODEL_CACHE` to override the default persistent cache
+at `./models`. On failure, the harness prints the final 400 server-log lines
+before cleanup.
 
 ### 8.3 Fail-fast and parallelism
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -676,7 +676,14 @@ Every stage runs inside Docker. There is no host-side Python or npm step.
 ./scalarlm test --level ui                           # npm lint + typecheck + test
 ./scalarlm test --level collectives                  # SHM channel tests
 ./scalarlm test --level fast                         # unit + ui + collectives (CI fast)
-./scalarlm test --level all                          # everything
+./scalarlm test --level all                          # every non-live level
+
+# Opt-in live inference smoke against an already-built hardware image:
+./scalarlm test --level live \
+  --live-target spark \
+  --model Qwen/Qwen3-0.6B \
+  --tag cray:latest \
+  --no-build yes
 
 # Filter within a level:
 ./scalarlm test --level component -k work_queue      # pytest -k pattern
@@ -701,7 +708,8 @@ Level semantics — every row runs in a container:
 | `collectives` | scalarlm CPU image | `test/collectives/test_shm_channel.py` via pytest |
 | `fast` | both | `unit` + `collectives` + `ui` |
 | `cpu` | both | `fast` + `component` + `e2e` *(default)* |
-| `all` | both | every level |
+| `live` | selected ScalarLM image | Provisions a real server, then checks health, model listing, direct, queued, and streaming inference |
+| `all` | both | every non-live level; `live` remains opt-in because it downloads and loads a model |
 
 Pytest stages run inside `$tag` (default `cray:latest`, overridable with
 `--tag`). The UI stage runs inside `node:24.2.0` with `ui/` bind-mounted, so
@@ -715,6 +723,12 @@ Minimum host toolchain: **Docker**. That's it — the Python interpreter lives
 inside the image, the node toolchain lives inside `node:24.2.0`, and the
 `./scalarlm` wrapper regenerates the bashly CLI inside its own container via
 `cmd/bashly.sh`.
+
+The live profile creates a uniquely named container and Docker network, waits
+until both the API and vLLM report healthy, runs its pytest smoke checks from a
+second container on that network, and removes both resources on exit. Set
+`SCALARLM_MODEL_CACHE` to override the default persistent cache at `./models`.
+On failure, the harness prints the final 400 server-log lines before cleanup.
 
 ### 8.3 Fail-fast and parallelism
 

--- a/test/live/run_live_server_tests.sh
+++ b/test/live/run_live_server_tests.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: run_live_server_tests.sh --tag IMAGE --model MODEL --target TARGET --timeout SECONDS
+
+Starts a temporary ScalarLM server, waits for API and vLLM readiness, runs the
+live inference smoke tests from a second container, and always tears down the
+temporary Docker resources.
+EOF
+}
+
+tag=""
+model=""
+target=""
+readiness_timeout=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --tag)
+            tag=$2
+            shift 2
+            ;;
+        --model)
+            model=$2
+            shift 2
+            ;;
+        --target)
+            target=$2
+            shift 2
+            ;;
+        --timeout)
+            readiness_timeout=$2
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ -z "$tag" ] || [ -z "$model" ] || [ -z "$target" ] || [ -z "$readiness_timeout" ]; then
+    usage >&2
+    exit 2
+fi
+
+if ! [[ "$readiness_timeout" =~ ^[1-9][0-9]*$ ]]; then
+    echo "--timeout must be a positive integer" >&2
+    exit 2
+fi
+
+case "$target" in
+    cpu|nvidia|amd|spark) ;;
+    *)
+        echo "Unsupported target: $target" >&2
+        exit 2
+        ;;
+esac
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required for the live-server profile" >&2
+    exit 1
+fi
+
+if ! docker image inspect "$tag" >/dev/null 2>&1; then
+    echo "Docker image not found: $tag" >&2
+    echo "Build it first or omit --no-build when invoking ./scalarlm test." >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+run_id="${BASHPID:-$$}-$(date +%s)"
+server_name="scalarlm-live-server-$run_id"
+network_name="scalarlm-live-network-$run_id"
+model_cache="${SCALARLM_MODEL_CACHE:-$REPO_ROOT/models}"
+
+mkdir -p "$model_cache"
+
+cleanup() {
+    docker rm -f "$server_name" >/dev/null 2>&1 || true
+    docker network rm "$network_name" >/dev/null 2>&1 || true
+}
+
+dump_server_logs() {
+    echo "---- ScalarLM live-server logs (last 400 lines) ----" >&2
+    docker logs --tail 400 "$server_name" >&2 || true
+    echo "---- end ScalarLM live-server logs ----" >&2
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+docker network create "$network_name" >/dev/null
+
+declare -a device_args=()
+case "$target" in
+    nvidia|spark)
+        device_args=("--gpus" "all")
+        ;;
+    amd)
+        device_args=(
+            "--device=/dev/kfd"
+            "--device=/dev/dri"
+            "--security-opt" "seccomp=unconfined"
+        )
+        ;;
+esac
+
+echo "Starting $server_name from $tag with model $model ($target)"
+docker run --detach \
+    --name "$server_name" \
+    --network "$network_name" \
+    --init \
+    --shm-size=8g \
+    "${device_args[@]}" \
+    -e "PYTHONDONTWRITEBYTECODE=1" \
+    -e "SCALARLM_ENABLE_LORA=false" \
+    -e "SCALARLM_ENABLE_TOKENFORMER=true" \
+    -e "SCALARLM_MODEL=$model" \
+    -v "$model_cache:/root/.cache/huggingface" \
+    -v "$REPO_ROOT/infra/cray_infra:/app/cray/infra/cray_infra:ro" \
+    -v "$REPO_ROOT/scripts:/app/cray/scripts:ro" \
+    -v "$REPO_ROOT/ml:/app/cray/ml:ro" \
+    -v "$REPO_ROOT/test:/app/cray/test:ro" \
+    "$tag" \
+    /app/cray/scripts/start_one_server.sh >/dev/null
+
+echo "Waiting up to ${readiness_timeout}s for API and vLLM readiness"
+started_at=$(date +%s)
+last_progress=0
+while true; do
+    now=$(date +%s)
+    elapsed=$((now - started_at))
+
+    if [ "$elapsed" -ge "$readiness_timeout" ]; then
+        echo "Timed out waiting for the live server after ${elapsed}s" >&2
+        dump_server_logs
+        exit 1
+    fi
+
+    running=$(docker inspect --format '{{.State.Running}}' "$server_name" 2>/dev/null || true)
+    if [ "true" != "$running" ]; then
+        echo "Live-server container exited before becoming ready" >&2
+        dump_server_logs
+        exit 1
+    fi
+
+    health=$(
+        docker exec "$server_name" \
+            curl --fail --silent --show-error --max-time 5 \
+            http://127.0.0.1:8000/v1/health 2>/dev/null || true
+    )
+    if printf '%s' "$health" | grep -Eq '"api"[[:space:]]*:[[:space:]]*"up"' && \
+       printf '%s' "$health" | grep -Eq '"vllm"[[:space:]]*:[[:space:]]*"up"'; then
+        echo "Live server ready after ${elapsed}s: $health"
+        break
+    fi
+
+    if [ $((elapsed - last_progress)) -ge 15 ]; then
+        echo "Still waiting (${elapsed}s); latest health: ${health:-unavailable}"
+        last_progress=$elapsed
+    fi
+    sleep 2
+done
+
+if ! docker run --rm --init \
+    --network "$network_name" \
+    -e "PYTHONDONTWRITEBYTECODE=1" \
+    -e "SCALARLM_LIVE_URL=http://$server_name:8000" \
+    -e "SCALARLM_LIVE_MODEL=$model" \
+    -v "$REPO_ROOT/infra/cray_infra:/app/cray/infra/cray_infra:ro" \
+    -v "$REPO_ROOT/sdk:/app/cray/sdk:ro" \
+    -v "$REPO_ROOT/test:/app/cray/test:ro" \
+    -v "$REPO_ROOT/pytest.ini:/app/cray/pytest.ini:ro" \
+    --entrypoint sh \
+    "$tag" -c \
+    'pip install --quiet --disable-pip-version-check -r test/requirements-pytest.txt && python -m pytest -p no:cacheprovider test/live/test_server_smoke.py -vv -rA'; then
+    dump_server_logs
+    exit 1
+fi
+
+echo "Live-server smoke tests passed."

--- a/test/live/run_live_server_tests.sh
+++ b/test/live/run_live_server_tests.sh
@@ -4,7 +4,7 @@ set -Eeuo pipefail
 
 usage() {
     cat <<'EOF'
-Usage: run_live_server_tests.sh --tag IMAGE --model MODEL --target TARGET --timeout SECONDS
+Usage: run_live_server_tests.sh --tag IMAGE --model MODEL --target TARGET --timeout SECONDS [--keyword EXPR] [--mark EXPR]
 
 Starts a temporary ScalarLM server, waits for API and vLLM readiness, runs the
 live inference smoke tests from a second container, and always tears down the
@@ -16,6 +16,8 @@ tag=""
 model=""
 target=""
 readiness_timeout=""
+keyword=""
+mark=""
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -33,6 +35,14 @@ while [ "$#" -gt 0 ]; do
             ;;
         --timeout)
             readiness_timeout=$2
+            shift 2
+            ;;
+        --keyword)
+            keyword=$2
+            shift 2
+            ;;
+        --mark)
+            mark=$2
             shift 2
             ;;
         -h|--help)
@@ -80,14 +90,37 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 run_id="${BASHPID:-$$}-$(date +%s)"
 server_name="scalarlm-live-server-$run_id"
+test_name="scalarlm-live-tests-$run_id"
 network_name="scalarlm-live-network-$run_id"
 model_cache="${SCALARLM_MODEL_CACHE:-$REPO_ROOT/models}"
+test_runner_pid=""
+forwarded_signal=""
 
 mkdir -p "$model_cache"
 
 cleanup() {
+    if [ -n "$test_runner_pid" ] && [ -z "$forwarded_signal" ]; then
+        kill "$test_runner_pid" >/dev/null 2>&1 || true
+    fi
+    docker rm -f "$test_name" >/dev/null 2>&1 || true
+    if [ -n "$test_runner_pid" ]; then
+        kill -KILL "$test_runner_pid" >/dev/null 2>&1 || true
+        wait "$test_runner_pid" 2>/dev/null || true
+    fi
     docker rm -f "$server_name" >/dev/null 2>&1 || true
     docker network rm "$network_name" >/dev/null 2>&1 || true
+}
+
+forward_signal() {
+    local signal=$1
+    local exit_code=$2
+
+    trap - INT TERM
+    forwarded_signal=$signal
+    if [ -n "$test_runner_pid" ]; then
+        kill -s "$signal" "$test_runner_pid" >/dev/null 2>&1 || true
+    fi
+    exit "$exit_code"
 }
 
 dump_server_logs() {
@@ -97,7 +130,8 @@ dump_server_logs() {
 }
 
 trap cleanup EXIT
-trap 'exit 130' INT TERM
+trap 'forward_signal INT 130' INT
+trap 'forward_signal TERM 143' TERM
 
 docker network create "$network_name" >/dev/null
 
@@ -172,18 +206,38 @@ while true; do
     sleep 2
 done
 
-if ! docker run --rm --init \
-    --network "$network_name" \
-    -e "PYTHONDONTWRITEBYTECODE=1" \
-    -e "SCALARLM_LIVE_URL=http://$server_name:8000" \
-    -e "SCALARLM_LIVE_MODEL=$model" \
-    -v "$REPO_ROOT/infra/cray_infra:/app/cray/infra/cray_infra:ro" \
-    -v "$REPO_ROOT/sdk:/app/cray/sdk:ro" \
-    -v "$REPO_ROOT/test:/app/cray/test:ro" \
-    -v "$REPO_ROOT/pytest.ini:/app/cray/pytest.ini:ro" \
-    --entrypoint sh \
-    "$tag" -c \
-    'pip install --quiet --disable-pip-version-check -r test/requirements-pytest.txt && python -m pytest -p no:cacheprovider test/live/test_server_smoke.py -vv -rA'; then
+declare -a pytest_filter_args=()
+if [ -n "$keyword" ]; then
+    pytest_filter_args+=("-k" "$keyword")
+fi
+if [ -n "$mark" ]; then
+    pytest_filter_args+=("-m" "$mark")
+fi
+
+run_test_container() {
+    local status=0
+
+    docker run --rm --init \
+        --name "$test_name" \
+        --network "$network_name" \
+        -e "PYTHONDONTWRITEBYTECODE=1" \
+        -e "SCALARLM_LIVE_URL=http://$server_name:8000" \
+        -e "SCALARLM_LIVE_MODEL=$model" \
+        -v "$REPO_ROOT/infra/cray_infra:/app/cray/infra/cray_infra:ro" \
+        -v "$REPO_ROOT/sdk:/app/cray/sdk:ro" \
+        -v "$REPO_ROOT/test:/app/cray/test:ro" \
+        -v "$REPO_ROOT/pytest.ini:/app/cray/pytest.ini:ro" \
+        --entrypoint sh \
+        "$tag" -c \
+        'pip install --quiet --disable-pip-version-check -r test/requirements-pytest.txt && exec python -m pytest -p no:cacheprovider test/live/test_server_smoke.py -vv -rA "$@"' \
+        scalarlm-live-pytest "${pytest_filter_args[@]}" &
+    test_runner_pid=$!
+    wait "$test_runner_pid" || status=$?
+    test_runner_pid=""
+    return "$status"
+}
+
+if ! run_test_container; then
     dump_server_logs
     exit 1
 fi

--- a/test/live/stream_assertions.py
+++ b/test/live/stream_assertions.py
@@ -1,0 +1,21 @@
+"""Assertions shared by the live completion-stream smoke test."""
+
+
+def assert_valid_completion_stream(events: list[dict]) -> None:
+    choices = [
+        choice
+        for event in events
+        for choice in event.get("choices", [])
+        if isinstance(choice, dict)
+    ]
+    completion_text = "".join(
+        choice["text"] for choice in choices if isinstance(choice.get("text"), str)
+    )
+    finish_reasons = [
+        choice["finish_reason"]
+        for choice in choices
+        if isinstance(choice.get("finish_reason"), str) and choice["finish_reason"]
+    ]
+
+    assert completion_text.strip(), events
+    assert finish_reasons, events

--- a/test/live/test_server_smoke.py
+++ b/test/live/test_server_smoke.py
@@ -1,0 +1,107 @@
+"""Live inference smoke tests.
+
+These tests intentionally assume the harness in ``run_live_server_tests.sh``
+has provisioned a real ScalarLM server. They skip during ordinary pytest runs;
+invoke them through ``./scalarlm test --level live`` so setup, readiness
+checks, diagnostics, and teardown are all handled consistently.
+"""
+
+import json
+import os
+
+import pytest
+import requests
+
+from masint import SupermassiveIntelligence
+
+
+BASE_URL = os.environ.get("SCALARLM_LIVE_URL", "").rstrip("/")
+MODEL = os.environ.get("SCALARLM_LIVE_MODEL", "")
+REQUEST_TIMEOUT = 120
+pytestmark = pytest.mark.skipif(
+    not BASE_URL or not MODEL,
+    reason="live-server harness is not active",
+)
+
+
+def _assert_success(response: requests.Response) -> None:
+    assert response.ok, (
+        f"{response.request.method} {response.url} returned "
+        f"{response.status_code}: {response.text[:2000]}"
+    )
+
+
+def test_health_reports_api_and_vllm_up():
+    response = requests.get(f"{BASE_URL}/v1/health", timeout=REQUEST_TIMEOUT)
+    _assert_success(response)
+
+    health = response.json()
+    assert health["api"] == "up"
+    assert health["vllm"] == "up"
+
+
+def test_models_lists_configured_model():
+    response = requests.get(f"{BASE_URL}/v1/models", timeout=REQUEST_TIMEOUT)
+    _assert_success(response)
+
+    model_ids = {entry["id"] for entry in response.json()["data"]}
+    assert MODEL in model_ids
+
+
+def test_direct_completion_returns_openai_shape():
+    response = requests.post(
+        f"{BASE_URL}/v1/completions",
+        json={
+            "model": MODEL,
+            "prompt": "ScalarLM live test:",
+            "max_tokens": 8,
+            "temperature": 0,
+        },
+        timeout=REQUEST_TIMEOUT,
+    )
+    _assert_success(response)
+
+    result = response.json()
+    assert isinstance(result["choices"][0]["text"], str)
+    assert result["usage"]["total_tokens"] > 0
+
+
+@pytest.mark.timeout(REQUEST_TIMEOUT)
+def test_queued_sdk_generation_returns_all_results():
+    client = SupermassiveIntelligence(api_url=BASE_URL)
+    prompts = ["Count to two:", "Name one color:"]
+
+    results = client.generate(prompts=prompts, model_name=MODEL, max_tokens=8)
+
+    assert len(results) == len(prompts)
+    assert all(isinstance(result, str) for result in results)
+
+
+def test_streaming_completion_emits_json_and_done():
+    with requests.post(
+        f"{BASE_URL}/v1/completions",
+        json={
+            "model": MODEL,
+            "prompt": "Stream one short sentence:",
+            "max_tokens": 8,
+            "temperature": 0,
+            "stream": True,
+        },
+        stream=True,
+        timeout=REQUEST_TIMEOUT,
+    ) as response:
+        _assert_success(response)
+        events = []
+        saw_done = False
+        for raw_line in response.iter_lines(decode_unicode=True):
+            if not raw_line or not raw_line.startswith("data: "):
+                continue
+            payload = raw_line.removeprefix("data: ")
+            if payload == "[DONE]":
+                saw_done = True
+                break
+            events.append(json.loads(payload))
+
+    assert events
+    assert any(event.get("choices") for event in events)
+    assert saw_done

--- a/test/live/test_server_smoke.py
+++ b/test/live/test_server_smoke.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 
 from masint import SupermassiveIntelligence
+from stream_assertions import assert_valid_completion_stream
 
 
 BASE_URL = os.environ.get("SCALARLM_LIVE_URL", "").rstrip("/")
@@ -48,7 +49,7 @@ def test_models_lists_configured_model():
     assert MODEL in model_ids
 
 
-def test_direct_completion_returns_openai_shape():
+def test_synchronous_scalarlm_completion_returns_openai_shape():
     response = requests.post(
         f"{BASE_URL}/v1/completions",
         json={
@@ -77,7 +78,10 @@ def test_queued_sdk_generation_returns_all_results():
     assert all(isinstance(result, str) for result in results)
 
 
-def test_streaming_completion_emits_json_and_done():
+# ``requests`` resets its read timeout whenever a chunk arrives. The pytest
+# timeout is the independent wall-clock deadline for a stream that never ends.
+@pytest.mark.timeout(REQUEST_TIMEOUT)
+def test_streaming_completion_emits_content_finish_reason_and_done():
     with requests.post(
         f"{BASE_URL}/v1/completions",
         json={
@@ -102,6 +106,5 @@ def test_streaming_completion_emits_json_and_done():
                 break
             events.append(json.loads(payload))
 
-    assert events
-    assert any(event.get("choices") for event in events)
+    assert_valid_completion_stream(events)
     assert saw_done

--- a/test/requirements-pytest.txt
+++ b/test/requirements-pytest.txt
@@ -7,4 +7,5 @@ pytest-dotenv
 pytest-mock
 pytest-rerunfailures
 pytest-timeout
+requests
 codecov

--- a/test/unit/test_live_stream_assertions.py
+++ b/test/unit/test_live_stream_assertions.py
@@ -1,0 +1,39 @@
+"""Regression tests for completion-stream false-positive prevention."""
+
+import runpy
+from pathlib import Path
+
+import pytest
+
+STREAM_ASSERTIONS = (
+    Path(__file__).resolve().parents[1] / "live" / "stream_assertions.py"
+)
+ASSERT_VALID_STREAM = runpy.run_path(str(STREAM_ASSERTIONS))[
+    "assert_valid_completion_stream"
+]
+
+
+def test_completion_stream_requires_text_and_terminal_finish_reason():
+    ASSERT_VALID_STREAM(
+        [
+            {"choices": [{"text": "hello", "finish_reason": None}]},
+            {"choices": [{"text": "", "finish_reason": "stop"}]},
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "events",
+    [
+        [{"choices": [{}]}],
+        [{"choices": [{"text": "", "finish_reason": "stop"}]}],
+    ],
+)
+def test_completion_stream_rejects_missing_text(events):
+    with pytest.raises(AssertionError):
+        ASSERT_VALID_STREAM(events)
+
+
+def test_completion_stream_rejects_missing_finish_reason():
+    with pytest.raises(AssertionError):
+        ASSERT_VALID_STREAM([{"choices": [{"text": "hello"}]}])

--- a/test/unit/test_live_test_command.py
+++ b/test/unit/test_live_test_command.py
@@ -1,10 +1,16 @@
 """Regression tests for the live profile's shell orchestration."""
 
+import json
 import os
+import signal
 import subprocess
+import time
 from pathlib import Path
 
+import pytest
+
 TEST_COMMAND = Path(__file__).resolve().parents[2] / "cmd" / "test_command.sh"
+LIVE_HARNESS = Path(__file__).resolve().parents[1] / "live" / "run_live_server_tests.sh"
 
 
 def _write_executable(path: Path, contents: str) -> None:
@@ -62,3 +68,198 @@ source "$1"
     assert result.returncode == 1, result.stdout + result.stderr
     assert not harness_marker.exists()
     assert "Live server (cpu, tiny-random/gemma-4-dense) FAILED" in result.stdout
+
+
+def test_live_profile_forwards_pytest_filters(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "cmd").mkdir(parents=True)
+    (repo / "test" / "live").mkdir(parents=True)
+    (repo / "cmd" / "test_command.sh").write_text(TEST_COMMAND.read_text())
+
+    _write_executable(repo / "scalarlm", "#!/bin/bash\nexit 91\n")
+    _write_executable(
+        repo / "test" / "live" / "run_live_server_tests.sh",
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+Path(os.environ["HARNESS_ARGS"]).write_text(json.dumps(sys.argv[1:]))
+""",
+    )
+
+    runner = tmp_path / "run-test-command.sh"
+    _write_executable(
+        runner,
+        """#!/bin/bash
+inspect_args() { :; }
+red_bold() { printf '%s\\n' "$*"; }
+green_bold() { printf '%s\\n' "$*"; }
+blue_bold() { printf '%s\\n' "$*"; }
+declare -A args=(
+  [test-path]=""
+  [--level]="live"
+  [--keyword]="streaming or queued"
+  [--mark]="not slow"
+  [--tag]="image:test"
+  [--coverage-path]="/tmp/coverage"
+  [--verbose]="no"
+  [--workers]="1"
+  [--no-build]="yes"
+  [--model]="org/model name"
+  [--live-target]="spark"
+  [--live-timeout]="37"
+)
+source "$1"
+""",
+    )
+
+    harness_args = tmp_path / "harness-args.json"
+    env = os.environ.copy()
+    env["HARNESS_ARGS"] = str(harness_args)
+    result = subprocess.run(
+        ["bash", str(runner), str(repo / "cmd" / "test_command.sh")],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(harness_args.read_text()) == [
+        "--tag",
+        "image:test",
+        "--model",
+        "org/model name",
+        "--target",
+        "spark",
+        "--timeout",
+        "37",
+        "--keyword",
+        "streaming or queued",
+        "--mark",
+        "not slow",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("signal_number", "exit_code"),
+    [(signal.SIGINT, 130), (signal.SIGTERM, 143)],
+)
+def test_live_harness_pid_only_signal_stops_named_test_container(
+    tmp_path, signal_number, exit_code
+):
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    docker_log = tmp_path / "docker.jsonl"
+    test_runner_ready = tmp_path / "test-runner-ready"
+    _write_executable(
+        fake_bin / "docker",
+        """#!/usr/bin/env python3
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+args = sys.argv[1:]
+log_path = Path(os.environ["FAKE_DOCKER_LOG"])
+
+
+def log(entry):
+    with log_path.open("a") as stream:
+        stream.write(json.dumps(entry) + "\\n")
+
+
+log(args)
+if args[:2] == ["image", "inspect"]:
+    raise SystemExit(0)
+if args[:2] == ["network", "create"]:
+    print("network-id")
+    raise SystemExit(0)
+if args[:2] == ["network", "rm"] or args[:2] == ["rm", "-f"]:
+    raise SystemExit(0)
+if args and args[0] == "inspect":
+    print("true")
+    raise SystemExit(0)
+if args and args[0] == "exec":
+    print('{"api":"up","vllm":"up"}')
+    raise SystemExit(0)
+if args and args[0] == "logs":
+    raise SystemExit(0)
+if args and args[0] == "run" and "--detach" in args:
+    print("server-id")
+    raise SystemExit(0)
+if args and args[0] == "run":
+    def stop(signum, _frame):
+        log(["SIGNAL", signum])
+        raise SystemExit(128 + signum)
+
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+    Path(os.environ["FAKE_TEST_RUNNER_READY"]).write_text(str(os.getpid()))
+    while True:
+        time.sleep(0.05)
+raise SystemExit(9)
+""",
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["FAKE_DOCKER_LOG"] = str(docker_log)
+    env["FAKE_TEST_RUNNER_READY"] = str(test_runner_ready)
+    env["SCALARLM_MODEL_CACHE"] = str(tmp_path / "model-cache")
+    process = subprocess.Popen(
+        [
+            str(LIVE_HARNESS),
+            "--tag",
+            "image:test",
+            "--model",
+            "org/model name",
+            "--target",
+            "cpu",
+            "--timeout",
+            "10",
+            "--keyword",
+            "streaming or queued",
+            "--mark",
+            "not slow",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+
+    deadline = time.monotonic() + 5
+    while not test_runner_ready.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    if not test_runner_ready.exists():
+        process.terminate()
+        stdout, stderr = process.communicate(timeout=5)
+        raise AssertionError(stdout + stderr)
+
+    process.send_signal(signal_number)  # Deliberately signal only the harness PID.
+    stdout, stderr = process.communicate(timeout=5)
+
+    assert process.returncode == exit_code, stdout + stderr
+    calls = [json.loads(line) for line in docker_log.read_text().splitlines()]
+    test_run = next(
+        call for call in calls if call and call[0] == "run" and "--detach" not in call
+    )
+    test_name = test_run[test_run.index("--name") + 1]
+    server_run = next(
+        call for call in calls if call and call[0] == "run" and "--detach" in call
+    )
+    server_name = server_run[server_run.index("--name") + 1]
+    network_name = server_run[server_run.index("--network") + 1]
+
+    assert test_name.startswith("scalarlm-live-tests-")
+    assert ["-k", "streaming or queued"] == test_run[-4:-2]
+    assert ["-m", "not slow"] == test_run[-2:]
+    assert ["SIGNAL", signal_number] in calls
+    assert ["rm", "-f", test_name] in calls
+    assert ["rm", "-f", server_name] in calls
+    assert ["network", "rm", network_name] in calls

--- a/test/unit/test_live_test_command.py
+++ b/test/unit/test_live_test_command.py
@@ -1,0 +1,64 @@
+"""Regression tests for the live profile's shell orchestration."""
+
+import os
+import subprocess
+from pathlib import Path
+
+TEST_COMMAND = Path(__file__).resolve().parents[2] / "cmd" / "test_command.sh"
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents)
+    path.chmod(0o755)
+
+
+def test_live_profile_stops_when_image_build_fails(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "cmd").mkdir(parents=True)
+    (repo / "test" / "live").mkdir(parents=True)
+    (repo / "cmd" / "test_command.sh").write_text(TEST_COMMAND.read_text())
+
+    _write_executable(repo / "scalarlm", "#!/bin/bash\nexit 23\n")
+    _write_executable(
+        repo / "test" / "live" / "run_live_server_tests.sh",
+        '#!/bin/bash\ntouch "$HARNESS_MARKER"\n',
+    )
+
+    runner = tmp_path / "run-test-command.sh"
+    _write_executable(
+        runner,
+        """#!/bin/bash
+inspect_args() { :; }
+red_bold() { printf '%s\\n' "$*"; }
+green_bold() { printf '%s\\n' "$*"; }
+blue_bold() { printf '%s\\n' "$*"; }
+declare -A args=(
+  [test-path]=""
+  [--level]="live"
+  [--tag]="cray:latest"
+  [--coverage-path]="/tmp/coverage"
+  [--verbose]="no"
+  [--workers]="1"
+  [--no-build]="no"
+  [--model]="tiny-random/gemma-4-dense"
+  [--live-target]="cpu"
+  [--live-timeout]="30"
+)
+source "$1"
+""",
+    )
+
+    harness_marker = tmp_path / "harness-ran"
+    env = os.environ.copy()
+    env["HARNESS_MARKER"] = str(harness_marker)
+    result = subprocess.run(
+        ["bash", str(runner), str(repo / "cmd" / "test_command.sh")],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert not harness_marker.exists()
+    assert "Live server (cpu, tiny-random/gemma-4-dense) FAILED" in result.stdout


### PR DESCRIPTION
Closes #224.

## Why

ScalarLM's pytest tree contains live API tests, but `./scalarlm test` did not
provision a server for them. Broad runs therefore produced connection-refused
failures rather than model/runtime compatibility evidence, while the legacy
deployment runner required manual startup and host-environment cleanup.

## What changed

- add opt-in `./scalarlm test --level live` orchestration;
- configure image tag, model, hardware target, readiness timeout, and pytest
  keyword/mark filters;
- create uniquely named server and test containers plus an isolated network;
- wait for both ScalarLM and vLLM health with a bounded timeout;
- test health, model discovery, synchronous ScalarLM OpenAI compatibility,
  queued SDK generation, and streaming completion;
- enforce a true wall-clock streaming deadline and require generated text plus
  a terminal finish reason;
- mount the current checkout read-only, print bounded server diagnostics on
  failure, and clean up on success, failure, SIGINT, or SIGTERM; and
- keep model-backed tests out of the default `--level all` suite.

Here, “synchronous ScalarLM” is the public port-8000 OpenAI-compatible path;
the private vLLM port is intentionally outside issue #224's scope.

## Validation

- DGX Spark/v0.27.1 baseline: all **5 live tests passed twice**, with cold and
  warm caches (230 and 132 seconds to readiness).
- Final hardened PR head: all **5 live tests passed** against the exact final
  CPU image filesystem; readiness took 47 seconds and tests took 4.48 seconds.
  GPU-memory utilization was reduced from 0.4 to 0.2 because the Muse service
  was running concurrently on the same DGX Spark.
- An intentionally overcommitted run failed with bounded engine diagnostics,
  removed its resources, and left the existing Muse service healthy.
- Eight focused lifecycle/filter/stream regressions pass, including PID-only
  SIGINT/SIGTERM cleanup and rejection of empty or unterminated streams.
- Exact-image unit suite: **531 passed**, with the independent stale assertion
  fixed by #227; with #227 overlaid: **532 passed**.
- `shellcheck`, `bash -n`, Python compilation, Black, and `git diff --check`
  pass.
- Initial Codex review findings were fixed; a fresh exact-head Codex re-review
  found no actionable regression and returned `MERGE`.

## Dependencies

None. The harness is runtime-version independent; the v0.27.1 image above is
validation evidence, not a merge prerequisite.
