### PR TITLE
fix(slurm): avoid over-reporting container memory

### DIFF
--- a/infra/cray_infra/slurm/discovery/discover_clusters.py
+++ b/infra/cray_infra/slurm/discovery/discover_clusters.py
@@ -130,9 +130,11 @@ def get_memory_mb() -> int | None:
     ``/proc/meminfo`` commonly reports host-wide memory in containers. Bound
     it by the active cgroup v2 or v1 memory limit so each ScalarLM replica
     does not register capacity that its container cannot use. Missing memory
-    controllers and explicit unlimited sentinels leave ``MemTotal`` as the
-    finite bound. Unreadable or malformed controller state is indeterminate,
-    so omit ``RealMemory`` rather than risk over-advertising it.
+    controllers leave ``MemTotal`` as the finite bound for a bare-host process.
+    An explicit unlimited container value is not a per-replica allocation:
+    colocated replicas would each advertise the same host total, so omit
+    ``RealMemory``. Unreadable or malformed controller state is likewise
+    indeterminate and omitted.
     """
     total_bytes = _read_memtotal_bytes()
     if total_bytes is None:
@@ -171,10 +173,10 @@ def _read_memtotal_bytes() -> int | None:
 def _read_cgroup_memory_limit_bytes() -> tuple[bool, int | None]:
     """Return ``(is_known, finite_limit)`` for the active memory controller.
 
-    ``finite_limit=None`` means that no controller is mounted at the standard
-    container paths or that the active controller explicitly reports an
-    unlimited value. ``is_known=False`` means a controller was present but its
-    value could not be trusted.
+    ``finite_limit=None`` with ``is_known=True`` means no controller is mounted
+    at the standard paths, as for a bare-host process. ``is_known=False`` means
+    a controller was present but did not provide a safe per-node allocation,
+    whether because it was unreadable/malformed or explicitly unlimited.
     """
     try:
         with open(cgroup_v2_memory_limit_path) as f:
@@ -186,7 +188,10 @@ def _read_cgroup_memory_limit_bytes() -> tuple[bool, int | None]:
         return False, None
     else:
         if value == "max":
-            return True, None
+            # This is host-wide availability, not an allocation unique to a
+            # container/SLURM node. Multiple unlimited replicas can coexist,
+            # so advertising MemTotal from each would multiply capacity.
+            return False, None
         return _parse_cgroup_limit(value, "v2")
 
     try:
@@ -203,7 +208,7 @@ def _read_cgroup_memory_limit_bytes() -> tuple[bool, int | None]:
         # Linux cgroup v1 represents "unlimited" as a page-aligned value near
         # LONG_MAX (usually 9223372036854771712 on 64-bit hosts).
         if limit_bytes >= _cgroup_v1_unlimited_threshold:
-            return True, None
+            return False, None
     return parsed, limit_bytes
 
 

--- a/infra/cray_infra/slurm/discovery/discover_clusters.py
+++ b/infra/cray_infra/slurm/discovery/discover_clusters.py
@@ -9,6 +9,7 @@ import time
 import socket
 import os
 import json
+import re
 
 import logging
 
@@ -22,6 +23,16 @@ shared_slurm_config_path = "/app/cray/nfs/slurm.conf"
 shared_gres_config_path = "/app/cray/nfs/gres.conf"
 shared_cgroup_config_path = "/app/cray/nfs/cgroup.conf"
 shared_node_config_directory = "/app/cray/nfs/nodes"
+
+meminfo_path = "/proc/meminfo"
+cgroup_v2_memory_limit_path = "/sys/fs/cgroup/memory.max"
+cgroup_v1_memory_limit_path = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+_bytes_per_kib = 1024
+_bytes_per_mib = 1024 * 1024
+_max_memory_bytes = (1 << 63) - 1
+_cgroup_v1_unlimited_threshold = 1 << 60
+_memtotal_pattern = re.compile(r"MemTotal:[ \t]+([1-9][0-9]*)[ \t]+kB")
 
 
 def main():
@@ -114,23 +125,98 @@ def get_cpu_count() -> int | None:
 
 
 def get_memory_mb() -> int | None:
-    """Read total host memory from ``/proc/meminfo``, in MB.
+    """Return the effective memory capacity visible to this container, in MiB.
 
-    Mirrors ``get_cpu_count()``'s style: a thin wrapper with no new
-    dependency, best-effort rather than fatal. Returns ``None`` (rather
-    than raising) if ``/proc/meminfo`` is missing, unreadable (e.g.
-    ``PermissionError`` in a restricted container), or unparseable —
-    callers then omit ``RealMemory`` from the generated node config
-    instead of writing a bogus value.
+    ``/proc/meminfo`` commonly reports host-wide memory in containers. Bound
+    it by the active cgroup v2 or v1 memory limit so each ScalarLM replica
+    does not register capacity that its container cannot use. Missing memory
+    controllers and explicit unlimited sentinels leave ``MemTotal`` as the
+    finite bound. Unreadable or malformed controller state is indeterminate,
+    so omit ``RealMemory`` rather than risk over-advertising it.
     """
+    total_bytes = _read_memtotal_bytes()
+    if total_bytes is None:
+        return None
+
+    limit_is_known, limit_bytes = _read_cgroup_memory_limit_bytes()
+    if not limit_is_known:
+        return None
+
+    effective_bytes = (
+        min(total_bytes, limit_bytes) if limit_bytes is not None else total_bytes
+    )
+    memory_mb = effective_bytes // _bytes_per_mib
+    return memory_mb if memory_mb > 0 else None
+
+
+def _read_memtotal_bytes() -> int | None:
     try:
-        with open("/proc/meminfo") as f:
+        with open(meminfo_path) as f:
             for line in f:
                 if line.startswith("MemTotal:"):
-                    return int(line.split()[1]) // 1024
-    except (OSError, ValueError, IndexError) as e:
+                    match = _memtotal_pattern.fullmatch(line.rstrip("\r\n"))
+                    if match is None:
+                        logger.debug("Malformed MemTotal line in %s", meminfo_path)
+                        return None
+                    total_kib = int(match.group(1))
+                    if total_kib > _max_memory_bytes // _bytes_per_kib:
+                        logger.debug("MemTotal in %s is out of range", meminfo_path)
+                        return None
+                    return total_kib * _bytes_per_kib
+    except OSError as e:
         logger.debug(f"Error reading total memory: {e}")
     return None
+
+
+def _read_cgroup_memory_limit_bytes() -> tuple[bool, int | None]:
+    """Return ``(is_known, finite_limit)`` for the active memory controller.
+
+    ``finite_limit=None`` means that no controller is mounted at the standard
+    container paths or that the active controller explicitly reports an
+    unlimited value. ``is_known=False`` means a controller was present but its
+    value could not be trusted.
+    """
+    try:
+        with open(cgroup_v2_memory_limit_path) as f:
+            value = f.read().strip()
+    except FileNotFoundError:
+        pass
+    except OSError as e:
+        logger.debug(f"Error reading cgroup v2 memory limit: {e}")
+        return False, None
+    else:
+        if value == "max":
+            return True, None
+        return _parse_cgroup_limit(value, "v2")
+
+    try:
+        with open(cgroup_v1_memory_limit_path) as f:
+            value = f.read().strip()
+    except FileNotFoundError:
+        return True, None
+    except OSError as e:
+        logger.debug(f"Error reading cgroup v1 memory limit: {e}")
+        return False, None
+
+    parsed, limit_bytes = _parse_cgroup_limit(value, "v1")
+    if parsed and limit_bytes is not None:
+        # Linux cgroup v1 represents "unlimited" as a page-aligned value near
+        # LONG_MAX (usually 9223372036854771712 on 64-bit hosts).
+        if limit_bytes >= _cgroup_v1_unlimited_threshold:
+            return True, None
+    return parsed, limit_bytes
+
+
+def _parse_cgroup_limit(value: str, version: str) -> tuple[bool, int | None]:
+    if not value.isascii() or not value.isdecimal():
+        logger.debug("Malformed cgroup %s memory limit", version)
+        return False, None
+
+    limit_bytes = int(value)
+    if not 0 < limit_bytes <= _max_memory_bytes:
+        logger.debug("Cgroup %s memory limit is out of range", version)
+        return False, None
+    return True, limit_bytes
 
 
 def get_gpu_count():
@@ -304,10 +390,9 @@ def write_node_config(node: dict) -> str:
 
         NodeName=hostname CPUs=64 RealMemory=257723 Gres=gpu:6 State=UNKNOWN
 
-    ``RealMemory`` is omitted when ``node["memory_mb"]`` is missing or
-    falsy (e.g. ``get_memory_mb()`` couldn't read ``/proc/meminfo``),
-    matching how ``Gres`` is already omitted for GPU-less nodes rather
-    than writing a misleading value.
+    ``RealMemory`` is omitted when ``node["memory_mb"]`` is missing or is
+    not a positive, in-range integer, matching how ``Gres`` is already
+    omitted for GPU-less nodes rather than writing a misleading value.
     """
     max_gpus_per_node = get_config()["max_gpus_per_node"]
     gres_string = (
@@ -316,7 +401,12 @@ def write_node_config(node: dict) -> str:
         else ""
     )
     memory_mb = node.get("memory_mb")
-    memory_string = f"RealMemory={memory_mb}" if memory_mb else ""
+    memory_is_valid = (
+        isinstance(memory_mb, int)
+        and not isinstance(memory_mb, bool)
+        and 0 < memory_mb <= _max_memory_bytes // _bytes_per_mib
+    )
+    memory_string = f"RealMemory={memory_mb}" if memory_is_valid else ""
     fields = [
         f"NodeName={node['hostname']}",
         f"CPUs={node['cpu_count']}",

--- a/infra/cray_infra/slurm/discovery/discover_clusters.py
+++ b/infra/cray_infra/slurm/discovery/discover_clusters.py
@@ -69,7 +69,7 @@ def clean_old_node_info():
                 os.remove(file_path)
 
 
-def get_node_info():
+def get_node_info() -> dict:
     hostname = get_hostname()
     cpu_count = get_cpu_count()
     gpu_count = get_gpu_count()
@@ -79,6 +79,7 @@ def get_node_info():
         "machine_id": machine_id,
         "hostname": hostname,
         "cpu_count": cpu_count,
+        "memory_mb": get_memory_mb(),
         "gpu_count": gpu_count,
         "gpu_type": get_gpu_type(),
         "gpu_indexes": get_gpu_indexes(),
@@ -108,8 +109,28 @@ def get_hostname():
     return socket.gethostname()
 
 
-def get_cpu_count():
+def get_cpu_count() -> int | None:
     return os.cpu_count()
+
+
+def get_memory_mb() -> int | None:
+    """Read total host memory from ``/proc/meminfo``, in MB.
+
+    Mirrors ``get_cpu_count()``'s style: a thin wrapper with no new
+    dependency, best-effort rather than fatal. Returns ``None`` (rather
+    than raising) if ``/proc/meminfo`` is missing, unreadable (e.g.
+    ``PermissionError`` in a restricted container), or unparseable —
+    callers then omit ``RealMemory`` from the generated node config
+    instead of writing a bogus value.
+    """
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemTotal:"):
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError) as e:
+        logger.debug(f"Error reading total memory: {e}")
+    return None
 
 
 def get_gpu_count():
@@ -276,9 +297,17 @@ def save_slurm_conf_values(slurm_conf_values):
     return config
 
 
-def write_node_config(node):
-    """
-    NodeName=hostname CPUs=64 Gres=gpu:6 State=UNKNOWN
+def write_node_config(node: dict) -> str:
+    """Render one ``NodeName=...`` line for ``slurm.conf``.
+
+    Example output::
+
+        NodeName=hostname CPUs=64 RealMemory=257723 Gres=gpu:6 State=UNKNOWN
+
+    ``RealMemory`` is omitted when ``node["memory_mb"]`` is missing or
+    falsy (e.g. ``get_memory_mb()`` couldn't read ``/proc/meminfo``),
+    matching how ``Gres`` is already omitted for GPU-less nodes rather
+    than writing a misleading value.
     """
     max_gpus_per_node = get_config()["max_gpus_per_node"]
     gres_string = (
@@ -286,7 +315,16 @@ def write_node_config(node):
         if node["gpu_count"] > 0
         else ""
     )
-    node_config = f"NodeName={node['hostname']} CPUs={node['cpu_count']} {gres_string} State=UNKNOWN"
+    memory_mb = node.get("memory_mb")
+    memory_string = f"RealMemory={memory_mb}" if memory_mb else ""
+    fields = [
+        f"NodeName={node['hostname']}",
+        f"CPUs={node['cpu_count']}",
+        memory_string,
+        gres_string,
+        "State=UNKNOWN",
+    ]
+    node_config = " ".join(field for field in fields if field)
     return node_config + "\n"
 
 

--- a/test/unit/test_discover_clusters.py
+++ b/test/unit/test_discover_clusters.py
@@ -63,26 +63,24 @@ def test_get_memory_mb_uses_smaller_cgroup_v1_limit(monkeypatch, tmp_path):
     assert dc.get_memory_mb() == 512
 
 
-def test_get_memory_mb_keeps_host_bound_when_v2_is_unlimited(monkeypatch, tmp_path):
+def test_get_memory_mb_omits_capacity_when_v2_is_unlimited(monkeypatch, tmp_path):
     _configure_memory_files(
         monkeypatch,
         tmp_path,
         "MemTotal: 1048576 kB\n",
         cgroup_v2="max\n",
     )
-    assert dc.get_memory_mb() == 1024
+    assert dc.get_memory_mb() is None
 
 
-def test_get_memory_mb_keeps_host_bound_for_v1_unlimited_sentinel(
-    monkeypatch, tmp_path
-):
+def test_get_memory_mb_omits_capacity_for_v1_unlimited_sentinel(monkeypatch, tmp_path):
     _configure_memory_files(
         monkeypatch,
         tmp_path,
         "MemTotal: 1048576 kB\n",
         cgroup_v1="9223372036854771712\n",
     )
-    assert dc.get_memory_mb() == 1024
+    assert dc.get_memory_mb() is None
 
 
 def test_get_memory_mb_never_exceeds_mem_total(monkeypatch, tmp_path):

--- a/test/unit/test_discover_clusters.py
+++ b/test/unit/test_discover_clusters.py
@@ -1,0 +1,89 @@
+"""
+Unit tests for the node-memory-reporting bits of discover_clusters.py:
+``get_memory_mb`` and ``write_node_config``.
+"""
+
+from unittest.mock import patch
+
+from cray_infra.slurm.discovery import discover_clusters as dc
+
+
+def _fake_meminfo(tmp_path, contents):
+    path = tmp_path / "meminfo"
+    path.write_text(contents)
+    return str(path)
+
+
+def test_get_memory_mb_parses_mem_total(tmp_path):
+    path = _fake_meminfo(
+        tmp_path,
+        "MemTotal:       131072000 kB\nMemFree:        1000 kB\n",
+    )
+    real_open = open
+    with patch("builtins.open", side_effect=lambda *_a, **_kw: real_open(path)):
+        assert dc.get_memory_mb() == 131072000 // 1024
+
+
+def test_get_memory_mb_returns_none_when_file_missing():
+    with patch("builtins.open", side_effect=FileNotFoundError):
+        assert dc.get_memory_mb() is None
+
+
+def test_get_memory_mb_returns_none_on_permission_error():
+    """A restricted container/sandbox can deny reading /proc/meminfo
+    with PermissionError rather than FileNotFoundError -- both must be
+    treated as "can't determine memory", not propagate as a crash."""
+    with patch("builtins.open", side_effect=PermissionError):
+        assert dc.get_memory_mb() is None
+
+
+def test_get_memory_mb_returns_none_on_unparseable_content(tmp_path):
+    path = _fake_meminfo(tmp_path, "MemTotal:       not-a-number kB\n")
+    real_open = open
+    with patch("builtins.open", side_effect=lambda *_a, **_kw: real_open(path)):
+        assert dc.get_memory_mb() is None
+
+
+def _node(**overrides):
+    node = {
+        "hostname": "node1",
+        "cpu_count": 64,
+        "gpu_count": 0,
+    }
+    node.update(overrides)
+    return node
+
+
+def _fake_get_config(**overrides):
+    config = {"max_gpus_per_node": 8}
+    config.update(overrides)
+    return config
+
+
+def test_write_node_config_includes_real_memory_when_present():
+    with patch.object(dc, "get_config", return_value=_fake_get_config()):
+        line = dc.write_node_config(_node(memory_mb=257723))
+    assert "RealMemory=257723" in line
+    assert line.startswith("NodeName=node1 CPUs=64 RealMemory=257723")
+
+
+def test_write_node_config_omits_real_memory_when_missing():
+    with patch.object(dc, "get_config", return_value=_fake_get_config()):
+        line = dc.write_node_config(_node(memory_mb=None))
+    assert "RealMemory=" not in line
+
+
+def test_write_node_config_no_double_spaces_when_fields_missing():
+    """Both RealMemory (no memory_mb) and Gres (no GPUs) can be absent
+    at once; the rendered line must not have doubled-up whitespace from
+    joining empty fields."""
+    with patch.object(dc, "get_config", return_value=_fake_get_config()):
+        line = dc.write_node_config(_node(memory_mb=None, gpu_count=0))
+    assert "  " not in line
+    assert line == "NodeName=node1 CPUs=64 State=UNKNOWN\n"
+
+
+def test_write_node_config_includes_gres_when_gpus_present():
+    with patch.object(dc, "get_config", return_value=_fake_get_config()):
+        line = dc.write_node_config(_node(memory_mb=257723, gpu_count=6))
+    assert line == "NodeName=node1 CPUs=64 RealMemory=257723 Gres=gpu:6 State=UNKNOWN\n"

--- a/test/unit/test_discover_clusters.py
+++ b/test/unit/test_discover_clusters.py
@@ -5,28 +5,99 @@ Unit tests for the node-memory-reporting bits of discover_clusters.py:
 
 from unittest.mock import patch
 
+import pytest
+
 from cray_infra.slurm.discovery import discover_clusters as dc
 
 
-def _fake_meminfo(tmp_path, contents):
-    path = tmp_path / "meminfo"
-    path.write_text(contents)
-    return str(path)
+_missing = object()
+_mib = 1024 * 1024
 
 
-def test_get_memory_mb_parses_mem_total(tmp_path):
-    path = _fake_meminfo(
+def _configure_memory_files(
+    monkeypatch, tmp_path, meminfo, *, cgroup_v2=_missing, cgroup_v1=_missing
+):
+    paths = {
+        "meminfo_path": tmp_path / "meminfo",
+        "cgroup_v2_memory_limit_path": tmp_path / "memory.max",
+        "cgroup_v1_memory_limit_path": tmp_path / "memory.limit_in_bytes",
+    }
+    paths["meminfo_path"].write_text(meminfo)
+    if cgroup_v2 is not _missing:
+        paths["cgroup_v2_memory_limit_path"].write_text(cgroup_v2)
+    if cgroup_v1 is not _missing:
+        paths["cgroup_v1_memory_limit_path"].write_text(cgroup_v1)
+    for name, path in paths.items():
+        monkeypatch.setattr(dc, name, str(path))
+    return paths
+
+
+def test_get_memory_mb_parses_mem_total_without_a_cgroup_controller(
+    monkeypatch, tmp_path
+):
+    _configure_memory_files(
+        monkeypatch,
         tmp_path,
         "MemTotal:       131072000 kB\nMemFree:        1000 kB\n",
     )
-    real_open = open
-    with patch("builtins.open", side_effect=lambda *_a, **_kw: real_open(path)):
-        assert dc.get_memory_mb() == 131072000 // 1024
+    assert dc.get_memory_mb() == 131072000 // 1024
 
 
-def test_get_memory_mb_returns_none_when_file_missing():
-    with patch("builtins.open", side_effect=FileNotFoundError):
-        assert dc.get_memory_mb() is None
+def test_get_memory_mb_uses_smaller_cgroup_v2_limit(monkeypatch, tmp_path):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v2=str(384 * _mib),
+    )
+    assert dc.get_memory_mb() == 384
+
+
+def test_get_memory_mb_uses_smaller_cgroup_v1_limit(monkeypatch, tmp_path):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v1=str(512 * _mib),
+    )
+    assert dc.get_memory_mb() == 512
+
+
+def test_get_memory_mb_keeps_host_bound_when_v2_is_unlimited(monkeypatch, tmp_path):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v2="max\n",
+    )
+    assert dc.get_memory_mb() == 1024
+
+
+def test_get_memory_mb_keeps_host_bound_for_v1_unlimited_sentinel(
+    monkeypatch, tmp_path
+):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v1="9223372036854771712\n",
+    )
+    assert dc.get_memory_mb() == 1024
+
+
+def test_get_memory_mb_never_exceeds_mem_total(monkeypatch, tmp_path):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 524288 kB\n",
+        cgroup_v2=str(1024 * _mib),
+    )
+    assert dc.get_memory_mb() == 512
+
+
+def test_get_memory_mb_returns_none_when_meminfo_is_missing(monkeypatch, tmp_path):
+    monkeypatch.setattr(dc, "meminfo_path", str(tmp_path / "missing-meminfo"))
+    assert dc.get_memory_mb() is None
 
 
 def test_get_memory_mb_returns_none_on_permission_error():
@@ -37,10 +108,85 @@ def test_get_memory_mb_returns_none_on_permission_error():
         assert dc.get_memory_mb() is None
 
 
-def test_get_memory_mb_returns_none_on_unparseable_content(tmp_path):
-    path = _fake_meminfo(tmp_path, "MemTotal:       not-a-number kB\n")
+@pytest.mark.parametrize(
+    "meminfo",
+    [
+        "MemTotal: not-a-number kB\n",
+        "MemTotal: 0 kB\n",
+        "MemTotal: -1024 kB\n",
+        "MemTotal: 1024\n",
+        "MemTotal: 1024 KB\n",
+        "MemTotal: 1024 kB extra\n",
+        "MemTotal: 9007199254740992 kB\n",
+    ],
+)
+def test_get_memory_mb_rejects_malformed_or_out_of_range_memtotal(
+    monkeypatch, tmp_path, meminfo
+):
+    _configure_memory_files(monkeypatch, tmp_path, meminfo)
+    assert dc.get_memory_mb() is None
+
+
+def test_get_memory_mb_rejects_positive_capacity_below_one_mib(monkeypatch, tmp_path):
+    _configure_memory_files(monkeypatch, tmp_path, "MemTotal: 1023 kB\n")
+    assert dc.get_memory_mb() is None
+
+
+@pytest.mark.parametrize(
+    "limit",
+    ["", "not-a-number", "-1", "0", "max extra", "9223372036854775808"],
+)
+def test_get_memory_mb_rejects_invalid_cgroup_v2_limits(monkeypatch, tmp_path, limit):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v2=limit,
+    )
+    assert dc.get_memory_mb() is None
+
+
+@pytest.mark.parametrize("limit", ["max", "-1", "0", "not-a-number"])
+def test_get_memory_mb_rejects_invalid_cgroup_v1_limits(monkeypatch, tmp_path, limit):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v1=limit,
+    )
+    assert dc.get_memory_mb() is None
+
+
+def test_get_memory_mb_does_not_fall_back_when_v2_limit_is_malformed(
+    monkeypatch, tmp_path
+):
+    _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v2="malformed",
+        cgroup_v1=str(256 * _mib),
+    )
+    assert dc.get_memory_mb() is None
+
+
+def test_get_memory_mb_returns_none_when_cgroup_limit_is_unreadable(
+    monkeypatch, tmp_path
+):
+    paths = _configure_memory_files(
+        monkeypatch,
+        tmp_path,
+        "MemTotal: 1048576 kB\n",
+        cgroup_v2=str(512 * _mib),
+    )
     real_open = open
-    with patch("builtins.open", side_effect=lambda *_a, **_kw: real_open(path)):
+
+    def guarded_open(path, *args, **kwargs):
+        if str(path) == str(paths["cgroup_v2_memory_limit_path"]):
+            raise PermissionError("restricted cgroup")
+        return real_open(path, *args, **kwargs)
+
+    with patch("builtins.open", side_effect=guarded_open):
         assert dc.get_memory_mb() is None
 
 
@@ -70,6 +216,16 @@ def test_write_node_config_includes_real_memory_when_present():
 def test_write_node_config_omits_real_memory_when_missing():
     with patch.object(dc, "get_config", return_value=_fake_get_config()):
         line = dc.write_node_config(_node(memory_mb=None))
+    assert "RealMemory=" not in line
+
+
+@pytest.mark.parametrize(
+    "memory_mb",
+    [0, -1, True, "257723", (1 << 63) // _mib],
+)
+def test_write_node_config_omits_invalid_real_memory(memory_mb):
+    with patch.object(dc, "get_config", return_value=_fake_get_config()):
+        line = dc.write_node_config(_node(memory_mb=memory_mb))
     assert "RealMemory=" not in line
 
 


### PR DESCRIPTION
## Why

Without `RealMemory`, Slurm assigns its documented 1 MiB default, leaving an
incorrect node record that would break memory-aware scheduling. But
`/proc/meminfo` can expose host-wide memory inside a container, so advertising
it for every constrained or colocated replica would multiply capacity Slurm
cannot actually use.

## What changed

- strictly parse a positive, bounded `MemTotal` with the exact `kB` unit;
- cap host memory by a finite cgroup v2 `memory.max` or cgroup v1
  `memory.limit_in_bytes`;
- omit `RealMemory` for explicit unlimited sentinels, malformed or unreadable
  controller values, and otherwise indeterminate container allocations;
- retain `MemTotal` as the finite ceiling when no controller path exists, as
  for a bare-host process; and
- render Slurm node lines only from validated, present fields.

With ScalarLM's current Helm defaults, which set GPU but not memory limits,
this deliberately omits a synthetic per-replica RAM value. Operators enabling
memory-aware scheduling for multiple replicas should set finite container
memory limits.

The unrelated no-accounting configuration cleanup is split into #228.

## Validation

- Focused discovery tests in exact vllm-fork v0.26 and v0.27.1 CPU images:
  **37 passed on each**.
- Coverage includes finite v1/v2 limits, both unlimited forms, absent
  controllers, malformed/negative/zero/wrong-unit/out-of-range/unreadable
  inputs, and node rendering.
- Full unit suite in each exact image: **560 passed**, with the same one known
  assertion fixed independently by #227.
- Disposable cgroup-v2 probe: Docker `--memory 384m` exposed
  `memory.max=402653184`, and discovery reported exactly 384 MiB rather than
  the host's 124610 MiB.
- Initial Codex findings about cgroup limits and malformed values were fixed;
  the exact-head re-review found no new issue and returned `MERGE`.
- Black 24.10.0 and `git diff --check` pass.

Reference: [Slurm `RealMemory` documentation](https://slurm.schedmd.com/slurm.conf.html).

## Dependencies

None; this Slurm discovery fix can merge independently of #228 and in any
order.
