### PR TITLE
fix(config): align max_model_length=0 docs and tests

### DIFF
--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -260,7 +260,7 @@ The ScalarLM convention is: the vLLM-internal attribute is still called `lora_ma
 
 ### 4.5 New KV-cache introspection APIs
 
-`vllm/v1/engine/async_llm.py:1013` adds `AsyncLLM.get_current_kv_cache_size()` and `get_total_kv_cache_tokens()`. These are what the Generate Worker calls to size its batch pulls (see `docs/inference-queue.md` §4.3 — `get_batch_size` divides `current` by `max_model_length`).
+`vllm/v1/engine/async_llm.py:1013` adds `AsyncLLM.get_current_kv_cache_size()` and `get_total_kv_cache_tokens()`. These are what the Generate Worker calls to size its batch pulls (see `docs/inference-queue.md` §4.3 — `get_batch_size` divides `current` by the runtime engine's `model_config.max_model_len`).
 
 The plumbing: `AsyncLLM.get_current_kv_cache_size()` → `engine_core.get_free_kv_cache_tokens_async()` → RPC → `EngineCore.get_free_kv_cache_tokens()` (`vllm/v1/engine/core.py:290`), which does:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -254,7 +254,7 @@ Key fields (from `default_config.py`):
 | `max_train_time` | 86400 (24 h) | SLURM walltime |
 | `extra_training_seconds` | 300 | Graceful-exit buffer before SLURM kills |
 | `gpu_memory_utilization` | 0.40 | vLLM KV cache fraction |
-| `max_model_length` | 256 | vLLM max context (override per model) |
+| `max_model_length` | 0 (auto) | Fallback admission cap; the live vLLM context limit is selected and queried at runtime |
 | `generate_batch_size` | 1024 | Worker-side batch size |
 | `response_timeout` | 60 | Per-request cap on synchronous SDK calls |
 | `tokenformer_r`, `tokenformer_num_heads` | 32, 4 | Tokenformer adapter shape |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,7 +96,7 @@ From `infra/cray_infra/util/default_config.py:5`. Every field is a Pydantic mode
 | Field | Default | Purpose |
 |---|---|---|
 | `model` | `tiny-random/gemma-4-dense` | HF Hub ID of the base model loaded at startup. vLLM serves this; training jobs default to it for `llm_name`. |
-| `max_model_length` | 256 | Max context window. vLLM uses it to size KV cache; the Generate Worker divides free KV cache by this to compute pull batch size. Override per model. |
+| `max_model_length` | 0 (auto) | Fallback admission cap when vLLM runtime introspection is unavailable; `0` means no configured fallback cap. vLLM selects its model limit automatically, and the Generate Worker uses that runtime value for KV-cache batching. |
 | `dtype` | `auto` | vLLM dtype. `auto` → bf16 on GPUs with SM ≥ 8, float32 on CPU. Forced to `float32` on sm<8 (flashmla backend). |
 | `gpu_memory_utilization` | 0.40 | Fraction of GPU memory vLLM reserves for KV cache + activations. Raise for dedicated inference pods; lower when training and inference share GPUs. |
 | `tensor_parallel_size` | 1 | vLLM `--tensor-parallel-size`. Number of GPUs to shard the model across. |

--- a/docs/inference-queue.md
+++ b/docs/inference-queue.md
@@ -347,7 +347,7 @@ Queue-relevant fields from `infra/cray_infra/util/default_config.py`:
 | `inference_work_queue_idle_time` | 5 (s) | Minimum idle-worker time before stuck-request recycling is allowed. |
 | `inference_work_queue_ack_timeout` | 300 (s) | Max age of an `unack` row before it's eligible for recycling. |
 | `generate_batch_size` | 1024 | Ceiling on per-pull batch size (worker side). |
-| `max_model_length` | 256 (per-model override) | Divisor in `batch_size = kv_free / max_model_length`. |
+| `max_model_length` | 0 (auto) | Fallback admission cap when vLLM runtime introspection is unavailable; `0` disables the fallback cap. Worker batching uses the runtime engine's `max_model_len`. |
 | `response_timeout` | 60 (s) | Max time `poll_for_responses` blocks in `/v1/generate` and `/v1/generate/get_results`. Timed-out prompts return `response=None`. |
 | `max_upload_file_size` | 10 GB | Upper bound on upload batch file size. |
 

--- a/docs/inference-queue.md
+++ b/docs/inference-queue.md
@@ -173,11 +173,12 @@ loop forever:
 
 ```python
 current = await engine_client.get_current_kv_cache_size()
-batch  = current // config["max_model_length"]          # conservative
+max_model_length = engine_client.model_config.max_model_len
+batch  = current // max_model_length                     # conservative
 return min(batch, config["generate_batch_size"])        # cap at 1024
 ```
 
-The division by `max_model_length` assumes every request could consume a full context window. That's intentionally pessimistic — it prevents OOM on worst-case long-output batches at the cost of occasionally underfilling when outputs are short. `generate_batch_size` (default 1024) is the hard ceiling.
+The division uses the runtime engine's `max_model_len` and assumes every request could consume a full context window. That's intentionally pessimistic — it prevents OOM on worst-case long-output batches at the cost of occasionally underfilling when outputs are short. `generate_batch_size` (default 1024) is the hard ceiling.
 
 ### 4.4 `/v1/generate/get_work` — the dequeue endpoint
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -306,7 +306,7 @@ Covers inference-queue.md §2–§5.
 
 ### 5.2 Work-queue worker loop — `one_server/create_generate_worker.py`
 
-- `test_worker_batch_size_from_kv_cache` — mock `engine_client.get_current_kv_cache_size` → 2048, `max_model_length=256` → `get_batch_size` returns `min(2048/256, generate_batch_size) == 8`.
+- `test_worker_batch_size_from_kv_cache` — mock `engine_client.get_current_kv_cache_size` → 2048 and `engine_client.model_config.max_model_len` → 256; `get_batch_size` returns `min(2048/256, generate_batch_size) == 8`.
 - `test_worker_loads_new_adapter_via_get_adaptors_response` — `get_work` response carries `new_adaptors=["hash1"]`; worker calls `load_lora_adapter` exactly once; `loaded_adaptor_count` increments.
 - `test_worker_retries_failed_adapter_load` — `load_lora_adapter` raises first call, worker does not increment `loaded_adaptor_count`; second `get_work` re-delivers and succeeds (adapters.md §6.5).
 - `test_worker_sleeps_when_no_work` — empty queue, worker sleeps roughly `inference_work_queue_timeout` + idle 1 s; not spin-looping.

--- a/infra/cray_infra/api/fastapi/chat_completions/handler.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/handler.py
@@ -115,11 +115,11 @@ async def chat_completions_via_queue(request: Any) -> StreamingResponse:
     # cached one render_chat_template already loaded, so this is a
     # microsecond-scale check on the hot path. The cap comes from
     # vLLM's runtime config (per-model, cached) rather than the
-    # cray-config knob — that knob default is 256 and tends to drift
-    # stale after operator-side model changes. resolve_max_model_length
-    # falls back to the config value when vLLM is unreachable, and
-    # treats <= 0 as "no cap" so we don't block requests on transient
-    # vLLM unavailability.
+    # cray-config knob. That knob defaults to 0 (no fallback cap), and
+    # any operator-set nonzero value can drift stale after model changes.
+    # resolve_max_model_length falls back to the config value when vLLM
+    # is unreachable and treats <= 0 as "no cap" so we don't block
+    # requests on transient vLLM unavailability.
     max_model_length = await resolve_max_model_length(model)
     if max_model_length > 0:
         try:
@@ -293,5 +293,4 @@ def get_queue_depth() -> int:
     from cray_infra.generate.metrics import get_metrics
 
     return get_metrics().queue_depth
-
 

--- a/infra/cray_infra/api/fastapi/chat_completions/resolve_max_model_length.py
+++ b/infra/cray_infra/api/fastapi/chat_completions/resolve_max_model_length.py
@@ -2,10 +2,10 @@
 Resolve `max_model_length` from vLLM's runtime config rather than from
 a stale operator-configured value.
 
-The cray-config.yaml's `max_model_length` is easy to misconfigure
-(default is 256 in default_config.py — way smaller than any real
-deployment), and an operator-set value also drifts the moment vLLM
-is restarted with a different `--max-model-len`. vLLM itself knows
+The cray-config.yaml's `max_model_length` is easy to misconfigure. Its
+default of 0 intentionally disables the fallback admission cap, while
+any operator-set nonzero value can drift the moment vLLM is restarted
+with a different `--max-model-len`. vLLM itself knows
 the right number for each loaded model (it's in the `/v1/models`
 response shape: `{data: [{id: "...", max_model_len: 65536, ...}]}`),
 so we ask it directly.

--- a/test/unit/test_config_override.py
+++ b/test/unit/test_config_override.py
@@ -25,7 +25,7 @@ def test_config_defaults_when_no_yaml_and_no_env(tmp_path, monkeypatch):
 
     assert cfg["model"] == "tiny-random/gemma-4-dense"
     assert cfg["api_url"] == "http://localhost:8000"
-    assert cfg["max_model_length"] == 256
+    assert cfg["max_model_length"] == 0
     assert cfg["gpu_memory_utilization"] == pytest.approx(0.40)
     assert cfg["tokenformer_r"] == 32
     assert cfg["tokenformer_num_heads"] == 4

--- a/test/unit/test_resolve_max_model_length.py
+++ b/test/unit/test_resolve_max_model_length.py
@@ -1,14 +1,14 @@
 """
 Pin the contract for `resolve_max_model_length`.
 
-Production motivation: cray-config.yaml's `max_model_length` defaults
-to 256 (default_config.py) and tends to drift stale relative to the
-actual `--max-model-len` vLLM was started with. Operators saw the
-pre-admission length check reject every long-prompt request with
-"max_model_length=256" while the real model was Gemma-4 with a 64k
-context. The resolver fixes the source of truth: ask vLLM directly,
-cache per-model, fall back to the config knob when vLLM is
-unreachable.
+Production motivation: an operator-set cray-config.yaml
+`max_model_length` can drift stale relative to the actual
+`--max-model-len` vLLM was started with. Operators saw a deployed value
+of 256 make the pre-admission check reject every long-prompt request
+while the real model was Gemma-4 with a 64k context. The resolver fixes
+the source of truth: ask vLLM directly, cache per-model, and fall back to
+the config knob when vLLM is unreachable. The shipped fallback is 0,
+which means no configured fallback cap.
 """
 
 from contextlib import asynccontextmanager


### PR DESCRIPTION
## Why

Commit `b4a2fe7` intentionally changed the production `max_model_length`
default to `0`, meaning “no configured fallback cap; use vLLM's live model
limit.” One unit assertion and several documentation references retained the
old value of 256, creating the only failure in the otherwise passing v0.27.1
unit-suite validation and describing stale batching behavior.

## What changed

- update the stale config-default assertion from 256 to 0; and
- align configuration, architecture, adapter, inference-queue, source-comment,
  and test-plan references with the live vLLM model limit and runtime batching
  behavior.

This is strictly a consistency correction for existing production behavior;
it does not change the runtime default.

## Validation

- Exact ScalarLM/vllm-fork v0.27.1 image: **524 unit tests passed**.
- Combined with #218's finalized regressions: **532 unit tests passed**.
- Complete config-override test file: **12 passed**.
- Independent Codex and Gemini 3.6 Flash reviews returned `MERGE`; Sonnet 4.6
  supported the code fix and identified the remaining stale documentation,
  which is corrected at the final head.
- Targeted stale-reference search, Python compilation, and `git diff --check`
  pass.

## Dependencies

None. Merge this before #209 because both touch
`chat_completions/handler.py`; #209 can then be refreshed onto the result.
