### PR TITLE
chore(slurm): remove redundant no-accounting settings

### DIFF
--- a/infra/slurm_configs/slurm.conf
+++ b/infra/slurm_configs/slurm.conf
@@ -23,12 +23,16 @@ Waittime=0
 SchedulerType=sched/backfill
 SelectType=select/cons_tres
 SelectTypeParameters=CR_Core
-AccountingStorageType=accounting_storage/none
-AccountingStoreFlags=job_comment
+# No accounting/completion/gather backend is configured (single-node,
+# no slurmdbd). The legacy */none compatibility aliases resolve to the
+# documented unset defaults on Slurm 23.11, so leave them out explicitly.
+#
+# Slurm 23.11 can still transiently report InvalidAccount without an
+# accounting backend; the upstream ticket remains open:
+# https://support.schedmd.com/show_bug.cgi?id=19894
+# AccountingStorageEnforce is unset here, and jobs continue to schedule.
 ClusterName=supermas
-JobCompType=jobcomp/none
 JobAcctGatherFrequency=30
-JobAcctGatherType=jobacct_gather/none
 SlurmctldDebug=debug
 AuthType=auth/none
 CredType=cred/none


### PR DESCRIPTION
## Why

ScalarLM's single-node Slurm configuration has no `slurmdbd`, but it explicitly
spelled legacy `*/none` compatibility aliases and a database-only
`AccountingStoreFlags=job_comment` setting. Current Slurm uses equivalent
unset defaults, so the explicit lines make the configuration look more active
than it is without enabling an accounting backend.

Slurm 23.11 may still transiently report `InvalidAccount` without a backend;
this PR does not claim to fix that upstream behavior.

## What changed

- leave `AccountingStorageType`, `JobCompType`, and `JobAcctGatherType` unset;
  and
- remove the ineffective database-only `AccountingStoreFlags` value.

This cleanup is split from #226 so the no-accounting defaults and functional
node-memory correction can be reviewed independently.

## Validation

- A disposable ScalarLM container with the proposed configuration started
  Slurm 23.11.4 normally.
- `scontrol show config` reported all three plugin types as `(null)`.
- A real `srun --ntasks=1 --cpus-per-task=1 true` completed successfully.
- Independent Codex, Gemini 3.6 Flash, and Sonnet 4.6 reviews found no
  actionable defect and returned `MERGE`.
- `git diff --check` passes.

References: [Slurm configuration documentation](https://slurm.schedmd.com/slurm.conf.html),
[upstream `InvalidAccount` report](https://support.schedmd.com/show_bug.cgi?id=19894),
and [SchedMD ticket 21398](https://support.schedmd.com/show_bug.cgi?id=21398).

## Dependencies

None; this configuration cleanup can merge independently of #226 and in any
order.
