### PR TITLE
build(cpu): prevent CUDA-linked wheels in CPU images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -229,7 +229,7 @@ RUN \
     fi && \
     uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt && \
     if [ "$VLLM_TARGET_DEVICE" = "cpu" ]; then \
-        python -c "import peft, sentence_transformers, torch, torchaudio, torchcodec, torchvision; assert torch.version.cuda is None; assert '+cpu' in torch.__version__, torch.__version__; assert '+cpu' in torchvision.__version__, torchvision.__version__; assert '+cpu' in torchaudio.__version__, torchaudio.__version__; assert '+cpu' in torchcodec.__version__, torchcodec.__version__"; \
+        python -c "import peft, sentence_transformers, torch, torchaudio, torchao, torchcodec, torchvision, vllm._C; assert torch.version.cuda is None; assert '+cpu' in torch.__version__, torch.__version__; assert '+cpu' in torchvision.__version__, torchvision.__version__; assert '+cpu' in torchaudio.__version__, torchaudio.__version__; assert '+cpu' in torchcodec.__version__, torchcodec.__version__"; \
     fi
 
 RUN mkdir -p ${INSTALL_ROOT}/jobs ${INSTALL_ROOT}/nfs
@@ -253,4 +253,3 @@ RUN /app/cray/infra/slurm_src/compile.sh
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${PYTHONPATH:-}:/usr/local/lib/slurm
 ENV SLURM_CONF=${INSTALL_ROOT}/nfs/slurm.conf
 ENV VLLM_CPU_MOE_PREPACK=0
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,18 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN python3 -m venv $VIRTUAL_ENV && \
     . $VIRTUAL_ENV/bin/activate
 
-ARG TORCH_VERSION="2.10.0"
+ARG TORCH_VERSION="2.11.0"
+ARG TORCHVISION_VERSION="0.26.0"
+ARG TORCHAUDIO_VERSION="2.11.0"
+ARG TORCHCODEC_VERSION="0.14.0"
 
 RUN pip install uv && \
-    uv pip install torch==${TORCH_VERSION}+cpu --index-url https://download.pytorch.org/whl/cpu && \
+    uv pip install \
+        torch==${TORCH_VERSION}+cpu \
+        torchvision==${TORCHVISION_VERSION}+cpu \
+        torchaudio==${TORCHAUDIO_VERSION}+cpu \
+        torchcodec==${TORCHCODEC_VERSION}+cpu \
+        --index-url https://download.pytorch.org/whl/cpu && \
     uv pip install ninja
 
 # Put torch on the LD_LIBRARY_PATH
@@ -219,7 +227,10 @@ RUN \
     if [ "$VLLM_TARGET_DEVICE" != "cuda" ]; then \
         uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements-megatron-cpu.txt; \
     fi && \
-    uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt
+    uv pip install --no-compile --no-cache-dir -r ${INSTALL_ROOT}/requirements.txt && \
+    if [ "$VLLM_TARGET_DEVICE" = "cpu" ]; then \
+        python -c "import peft, sentence_transformers, torch, torchaudio, torchcodec, torchvision; assert torch.version.cuda is None; assert '+cpu' in torch.__version__, torch.__version__; assert '+cpu' in torchvision.__version__, torchvision.__version__; assert '+cpu' in torchaudio.__version__, torchaudio.__version__; assert '+cpu' in torchcodec.__version__, torchcodec.__version__"; \
+    fi
 
 RUN mkdir -p ${INSTALL_ROOT}/jobs ${INSTALL_ROOT}/nfs
 
@@ -242,5 +253,4 @@ RUN /app/cray/infra/slurm_src/compile.sh
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:${PYTHONPATH:-}:/usr/local/lib/slurm
 ENV SLURM_CONF=${INSTALL_ROOT}/nfs/slurm.conf
 ENV VLLM_CPU_MOE_PREPACK=0
-
 

--- a/infra/requirements-megatron-cpu.txt
+++ b/infra/requirements-megatron-cpu.txt
@@ -4,4 +4,6 @@ torchao>=0.16.1
 transformers>=5.5.0
 huggingface_hub>=0.37
 peft
-torchvision==0.25.0
+# Torch-family binary wheels are installed together from PyTorch's CPU wheel
+# index in the CPU base stage. Keeping any of them here would let PyPI replace
+# the CPU build with a CUDA-linked aarch64 wheel.


### PR DESCRIPTION
## Why

Bare torchvision, torchaudio, and torchcodec requirements can resolve to
CUDA-linked PyPI wheels even when PyTorch itself is CPU-only. On ARM64 this
produced images that built successfully but failed at import time because the
companion extensions referenced unavailable CUDA libraries.

The CPU image also strips vLLM's Torch pins before its editable install, so the
complete binary family must be aligned explicitly and verified after every
resolver transaction.

## What changed

- align the CPU defaults with vllm-fork v0.26: PyTorch 2.11.0, torchvision
  0.26.0, torchaudio 2.11.0, and torchcodec 0.14.0;
- install all four packages together from PyTorch's official CPU index;
- remove the later generic PyPI torchvision pin that could replace the CPU
  wheel and that also risked overwriting ROCm's own torchvision; and
- fail the final image build unless PEFT, Sentence Transformers, TorchAO,
  native `vllm._C`, and the Torch family import successfully, PyTorch has no
  CUDA runtime, and all four binary wheels report `+cpu` builds.

## Validation

- Built the final Linux ARM64 CPU image from vllm-fork v0.26 revision
  `e01dda4f7814d50275dca507759815e205c079f5` with `VLLM_SOURCE=local`
  (image ID
  `sha256:d3419c73d87acb2b724f37f8298ee179e525ff54757b8329f4ac6081b57c9be6`).
- The post-transaction gate imported PEFT, Sentence Transformers, TorchAO,
  native `vllm._C`, and the exact CPU quartet:
  `torch==2.11.0+cpu`, `torchvision==0.26.0+cpu`,
  `torchaudio==2.11.0+cpu`, and `torchcodec==0.14.0+cpu`; PyTorch reported no
  CUDA runtime.
- Tokenformer integration files against the exact v0.26 source: **11 passed,
  1 intentional skip**.
- Verified the same installation pattern with the planned v0.27 defaults,
  `torch==2.13.0+cpu` and `torchvision==0.28.0+cpu`.
- Independent Codex review found no actionable defect. Post-hardening Gemini
  3.6 Flash and Sonnet 4.6 re-reviews closed all findings and returned `MERGE`.

## Dependencies

None; this CPU-image integrity fix can merge at any time. #223 depends on it.
