### PR TITLE
fix: build-context bloat, phantom build/ artifacts, and two plot.py bugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+**/.git
 .github
 *.md
 .gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ scripts/scalarlm
 # Python
 **/__pycache__/
 *.egg-info/
+build/
+dist/
 
 # OS
 .DS_Store

--- a/sdk/masint/cli/plot.py
+++ b/sdk/masint/cli/plot.py
@@ -24,7 +24,9 @@ def plot(models, smooth, y_limit=None):
     try:
         asyncio.run(plot_async(models=models, smooth=smooth, y_limit=y_limit))
     except Exception as e:
-        logger.error(f"Failed to plot model {model_name}")
+        # `model_name` is scoped to plot_async's loop, not this frame; naming it
+        # here raised NameError and masked the underlying failure.
+        logger.error(f"Failed to plot models {models}")
         logger.error(e)
         logger.error(traceback.format_exc())
 
@@ -59,7 +61,9 @@ def plot_loss(histories, model_names, smooth, y_limit):
 
     model_name = model_names[0]
 
-    plt.plot(steps, losses)
+    # The loop above already plotted every history with a label; re-plotting the
+    # last one here drew a duplicate, unlabeled line over it.
+    plt.legend()
     plt.xlabel("Step")
     plt.ylabel("Loss")
     plt.title("Training loss for model " + model_name)


### PR DESCRIPTION
Four small independent fixes. None touch runtime behaviour, and none depend on each other — happy to split if preferred.

## 1. `.dockerignore`: exclude nested `.git`

`.dockerignore` lists `.git`, but that pattern matches only the **context root**. A nested vLLM checkout at `./vllm` therefore ships its entire history into the build context.

Worse, the vLLM stage bind-mounts `./vllm`, so that subtree is part of the layer's cache key — **any git operation in the checkout invalidates the ~45 minute CUDA compile layer.**

Measured, with a control. A throwaway Dockerfile that `COPY`s `vllm/` was built against the real context so `.dockerignore` applied identically, then rebuilt after git activity in `./vllm`:

| | `.git` in context | context size | after git activity |
| --- | --- | --- | --- |
| without `**/.git` | present | 346.8 MB | **not cached** after `git branch` |
| with `**/.git` | absent | **113.6 MB** | **CACHED** after branch + fetch + gc |

So the exclusion cuts 233 MB from every context transfer *and* makes the expensive layer survive routine git work in the checkout.

**This cannot change build output.** `scripts/build-copy-vllm.sh` already does `rm -rf $DEST_DIR/.git` and re-inits a fresh repo purely so `setuptools_scm` can derive a version — the shipped history is never read.

One caveat: the first build after this lands still misses the cache once, because removing `.git` changes the mounted content and therefore the layer key. Stability applies from the following build onward.

## 2. `.gitignore`: ignore `build/` and `dist/`

The Python section ignores `*.egg-info/` but not `build/`, though a single `pip install -e sdk/` produces both. Every developer sees a 27-file phantom `sdk/build/` in `git status`. `dist/` added alongside for the same reason.

## 3–4. `sdk/masint/cli/plot.py`: two bugs

- The `except` handler references `model_name`, which is scoped to `plot_async`'s loop rather than that frame. Any plotting failure raised `NameError` and **masked the real error**. Now reports `models`.
- `plot_loss` re-plots the last history after the loop, drawing a duplicate unlabeled line over the labeled one. Replaced with the `plt.legend()` call that was missing, so the per-model labels actually render.

## Testing

Cache behaviour measured as above. `plot.py` changes are a scope fix and a plotting-call fix, both local to that module.

Found while bringing ScalarLM up on a DGX Spark (GB10).